### PR TITLE
Upon registration assign default group permissions if none set

### DIFF
--- a/tcms/core/contrib/auth/forms.py
+++ b/tcms/core/contrib/auth/forms.py
@@ -4,6 +4,8 @@ from django.contrib.auth.models import User
 from django.contrib.auth.forms import UserCreationForm
 from django.utils.translation import ugettext_lazy as _
 
+from .backends import initiate_user_with_default_setups
+
 
 class RegistrationForm(UserCreationForm):
     email = forms.EmailField(max_length=30)
@@ -28,6 +30,7 @@ class RegistrationForm(UserCreationForm):
         user.set_password(self.cleaned_data["password1"])
         if commit:
             user.save()
+            initiate_user_with_default_setups(user)
         return user
 
     def set_active_key(self):

--- a/tcms/settings/common.py
+++ b/tcms/settings/common.py
@@ -55,6 +55,10 @@ EMAIL_SUBJECT_PREFIX = '[Kiwi-TCMS] '
 ALLOWED_HOSTS = ['*']
 
 
+# default group in which new users will be created
+DEFAULT_GROUPS = ['Tester']
+
+
 # Maximum upload file size, default set to 5MB.
 MAX_UPLOAD_SIZE = 5242880
 
@@ -419,6 +423,3 @@ LOCALE_PATHS = [
 # when importing test cases from XML exported by Testopia
 # this is the version we're looking for
 TESTOPIA_XML_VERSION = '1.1'
-
-# default group in which new users will be created
-DEFAULT_GROUPS = ['default']

--- a/tcms/utils/permissions.py
+++ b/tcms/utils/permissions.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from django.contrib.auth.models import Group, Permission
+
+
+def assign_default_group_permissions():
+    """
+        Adds the default permissions for Administrator and Tester
+        groups!
+    """
+    admin = Group.objects.get(name='Administrator')
+    if admin.permissions.count() == 0:
+        all_perms = Permission.objects.all()
+        admin.permissions.add(*all_perms)
+
+    tester = Group.objects.get(name='Tester')
+    if tester.permissions.count() == 0:
+        # apply all permissions for test case & product management
+        for app_name in ['django_comments', 'management', 'testcases', 'testplans', 'testruns']:
+            app_perms = Permission.objects.filter(content_type__app_label__contains=app_name)
+            tester.permissions.add(*app_perms)


### PR DESCRIPTION
also by default make all users have is_staff permissions so they
can add Products, Builds, Versions, etc. via the ADMIN menu!

If you don't want this to be possible (e.g. products and builds
are synced automatically from a product database) you have to
define another default group and revoke some of its permissions!