### PR TITLE
Update how we render the XMLRPC info page. Fixes #80

### DIFF
--- a/tcms/templates/xmlrpc.html
+++ b/tcms/templates/xmlrpc.html
@@ -70,7 +70,7 @@
 		<ul>
 			{% for method in method_list %}
 			{% if method.name != 'system.multicall' %}
-			<li><a href="#{{ method.name|lower }}">{{ method.name|escape }}</a></li>
+			<li class="xmlrpc_method"><a href="#{{ method.name|lower }}">{{ method.name|escape }}</a></li>
 			{% endif %}
 			{% endfor %}
 		</ul>

--- a/tcms/xmlrpc/tests/test_views.py
+++ b/tcms/xmlrpc/tests/test_views.py
@@ -1,0 +1,12 @@
+import http.client
+from django.test import TestCase
+
+
+class XMLRPCViewTest(TestCase):
+    def test_xmlrpc_info_page_loads(self):
+        # test for https://github.com/kiwitcms/Kiwi/issues/80
+        response = self.client.get('/xmlrpc/')
+
+        self.assertEqual(http.client.OK, response.status_code)
+        self.assertContains(response, 'Kiwi TCMS XML-RPC Service')
+        self.assertContains(response, '<li class="xmlrpc_method">')

--- a/tcms/xmlrpc/views.py
+++ b/tcms/xmlrpc/views.py
@@ -36,7 +36,7 @@ import django.db
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.http import HttpResponse
-from django.template import Template, RequestContext, loader
+from django.template import Template, loader
 
 from .dispatcher import DjangoXMLRPCDispatcher
 
@@ -149,20 +149,20 @@ class XMLRPCHandlerFactory(object):
                     "help": self.xmlrpc_dispatcher.system_methodHelp(method).split("\n"),
                 })
 
-            c = RequestContext(request, {
-                "title": "XML-RPC interface (%s)" % self.name,
-                "method_list": method_list,
-            })
-
             template = getattr(settings, "XMLRPC_TEMPLATE", None)
             if template is not None:
                 t = loader.get_template(template)
             else:
                 t = Template(XMLRPC_TEMPLATE, name="XML-RPC template")
 
-            context_instance = RequestContext(request)
-            context_instance.update(c)
-            return HttpResponse(t.render(context_instance))
+            return HttpResponse(
+                t.render(
+                    context={
+                        "method_list": method_list,
+                    },
+                    request=request
+                )
+            )
 
 
 for var in ("XMLRPC_METHODS", ):


### PR DESCRIPTION
also removed unused variables in context, updated the template
to make it easier to assert if something has been rendered and
added a sanity test for that