### PR TITLE
If JIRA isn't fully configured then don't connect. Fixes #100

### DIFF
--- a/tcms/issuetracker/types.py
+++ b/tcms/issuetracker/types.py
@@ -160,11 +160,14 @@ class JIRA(IssueTrackerType):
         else:
             options = None
 
-        self.rpc = jira.JIRA(
-            tracker.api_url,
-            basic_auth=(self.tracker.api_username, self.tracker.api_password),
-            options=options,
-        )
+        # b/c jira.JIRA tries to connect when object is created
+        # see https://github.com/kiwitcms/Kiwi/issues/100
+        if not self.is_adding_testcase_to_issue_disabled():
+            self.rpc = jira.JIRA(
+                tracker.api_url,
+                basic_auth=(self.tracker.api_username, self.tracker.api_password),
+                options=options,
+            )
 
     def add_testcase_to_issue(self, testcases, issue):
         for case in testcases:

--- a/tcms/testruns/tests/test_views.py
+++ b/tcms/testruns/tests/test_views.py
@@ -1349,3 +1349,94 @@ class TestAddCasesToRun(BaseCaseRun):
             ]
             for html in html_pieces:
                 self.assertContains(response, html, html=True)
+
+
+class Test_TestRunReportUnconfiguredJIRA(BaseCaseRun):
+    """
+        When JIRA isn't fully configured, i.e. missing API URL
+        Username and Password/Token this leads to errors when
+        generating TR reports. See
+        https://github.com/kiwitcms/Kiwi/issues/100
+
+        The problem is the underlying JIRA client assumes default
+        values and tries to connect to the JIRA instance upon
+        object creation!
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        super(Test_TestRunReportUnconfiguredJIRA, cls).setUpTestData()
+
+        # NOTE: base_url, api_url, api_username and api_password
+        # are intentionally left blank!
+        cls.it = TestCaseBugSystem.objects.create(
+            name='Partially configured JIRA',
+            url_reg_exp='https://jira.example.com/browse/%s',
+            validate_reg_exp='^[A-Z0-9]+-\d+$',
+            tracker_type='JIRA'
+        )
+
+        cls.case_run_1.add_bug('KIWI-1234', cls.it.pk)
+
+    def test_reports(self):
+        url = reverse('run-report', args=[self.case_run_1.run_id])
+        response = self.client.get(url)
+
+        self.assertEqual(http.client.OK, response.status_code)
+        self.assertContains(response, self.it.url_reg_exp % 'KIWI-1234')
+
+
+class Test_TestRunReportUnconfiguredBugzilla(BaseCaseRun):
+    """
+        Test for https://github.com/kiwitcms/Kiwi/issues/100
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        super(Test_TestRunReportUnconfiguredBugzilla, cls).setUpTestData()
+
+        # NOTE: base_url, api_url, api_username and api_password
+        # are intentionally left blank!
+        cls.it = TestCaseBugSystem.objects.create(
+            name='Partially configured Bugzilla',
+            url_reg_exp='https://bugzilla.example.com/show_bug.cgi?id=%s',
+            validate_reg_exp='^\d{1,7}$',
+            tracker_type='Bugzilla'
+        )
+
+        cls.case_run_1.add_bug('5678', cls.it.pk)
+
+    def test_reports(self):
+        url = reverse('run-report', args=[self.case_run_1.run_id])
+        response = self.client.get(url)
+
+        self.assertEqual(http.client.OK, response.status_code)
+        self.assertContains(response, self.it.url_reg_exp % '5678')
+
+
+class Test_TestRunReportUnconfiguredGitHub(BaseCaseRun):
+    """
+        Test for https://github.com/kiwitcms/Kiwi/issues/100
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        super(Test_TestRunReportUnconfiguredGitHub, cls).setUpTestData()
+
+        # NOTE: base_url, api_url, api_username and api_password
+        # are intentionally left blank!
+        cls.it = TestCaseBugSystem.objects.create(
+            name='Partially configured GitHub',
+            url_reg_exp='https://github.com/kiwitcms/Kiwi/issues/%s',
+            validate_reg_exp='^\d+$',
+            tracker_type='GitHub'
+        )
+
+        cls.case_run_1.add_bug('100', cls.it.pk)
+
+    def test_reports(self):
+        url = reverse('run-report', args=[self.case_run_1.run_id])
+        response = self.client.get(url)
+
+        self.assertEqual(http.client.OK, response.status_code)
+        self.assertContains(response, self.it.url_reg_exp % '100')


### PR DESCRIPTION
@GotfatherThe turns out the underlying jira library tries to connect
automatically when a jira.JIRA object is created. When the
Issue Tracker is not fully configured (i.e. missing base_url,
api_url, api_username, api_password) then the library will default
to localhost and fail to connect to the JIRA server.

This causes the TestRun report view to timeout and fail.

This commit adds tests for all supported issue trackers and also
fixes the JIRA implementation to not connect if not configured.