### PR TITLE
Don't crash reports when there are untested TestCaseRuns. Fix #88

### DIFF
--- a/tcms/report/data.py
+++ b/tcms/report/data.py
@@ -677,6 +677,8 @@ class TestingReportByCaseRunTesterData(TestingReportBaseData):
 
         for row in query:
             tested_by_id = row['tested_by']
+            if tested_by_id is None:
+                tested_by_id = 0
             name = row['case_run_status__name']
             total_count = row['total_count']
 

--- a/tcms/report/tests.py
+++ b/tcms/report/tests.py
@@ -1,1 +1,52 @@
 # -*- coding: utf-8 -*-
+
+import http.client
+
+from django import test
+from django.urls import reverse
+
+from tcms.testruns.models import TestCaseRunStatus
+
+from tcms.tests.factories import ProductFactory
+from tcms.tests.factories import TestBuildFactory
+from tcms.tests.factories import TestRunFactory
+from tcms.tests.factories import TestCaseRunFactory
+
+
+class TestingReportTestCase(test.TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.product = ProductFactory()
+
+    def test_report_view_loads(self):
+        url = reverse('testing-report')
+        response = self.client.get(url)
+
+        self.assertEqual(http.client.OK, response.status_code)
+
+    def test_report_by_caserun_tester_loads(self):
+        # test for https://github.com/kiwitcms/Kiwi/issues/88
+        #
+        run = TestRunFactory()
+        product_build = TestBuildFactory(product=run.plan.product)
+
+        for status in TestCaseRunStatus.objects.all():
+            TestCaseRunFactory(
+                case_run_status=status,
+                run=run,
+                build=product_build)
+
+        self.untested_tcr = TestCaseRunFactory(
+            tested_by=None,
+            case_run_status=TestCaseRunStatus.objects.get(name='IDLE'),
+            run=run,
+            build=product_build,
+        )
+
+        url = reverse('testing-report')
+        response = self.client.get(url, {
+            'r_product': run.plan.product.pk,
+            'report_type': 'per_build_report'
+        })
+
+        self.assertEqual(http.client.OK, response.status_code)


### PR DESCRIPTION
The report will simply display 'None' for the tester name which
means this case has not been executed yet (iow its tested_by
attribute has not been set).