### PR TITLE
Pin patternfly version to 3.30 and update templates. Fixes #120

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,7 @@ install:
   - pip install -r $REQUIREMENTS_TXT
   - pip install -r requirements/devel.txt
   - pip install coveralls
+  - npm install
 script: make check
 after_success:
   - coveralls

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN sed -i "s/tcms.settings.devel/tcms.settings.product/" /Kiwi/manage.py
 
 # install patternfly
 COPY package.json /Kiwi/
-RUN cd /Kiwi/ && npm install patternfly && \
+RUN cd /Kiwi/ && npm install && \
     find ./node_modules -type f -not -path "*/dist/*" -delete && \
     find ./node_modules -type d -empty -delete
 

--- a/docs/source/set_dev_env.rst
+++ b/docs/source/set_dev_env.rst
@@ -58,7 +58,9 @@ Then install dependencies for development::
 
 The user interface needs the `PatternFly <http://www.patternfly.org/>`_ library so::
 
-    npm install patternfly
+    npm install
+
+inside the project directory.
 
 
 Initialize database

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "patternfly": "^3.23.2"
+    "patternfly": "3.30.0"
   }
 }

--- a/tcms/core/tests/test_views.py
+++ b/tcms/core/tests/test_views.py
@@ -27,6 +27,23 @@ from tcms.tests.factories import TCMSEnvGroupPropertyMapFactory
 from tcms.tests.factories import TCMSEnvPropertyFactory
 
 
+class TestIndex(BaseCaseRun):
+    def test_when_not_logged_in_index_page_redirects_to_login(self):
+        response = self.client.get(reverse('core-views-index'))
+        self.assertRedirects(
+            response,
+            reverse('tcms-login'),
+            target_status_code=http.client.OK)
+
+    def test_when_logged_in_index_page_redirects_to_dashboard(self):
+        self.client.login(username=self.tester.username, password='password')
+        response = self.client.get(reverse('core-views-index'))
+        self.assertRedirects(
+            response,
+            reverse('tcms-recent', args=[self.tester.username]),
+            target_status_code=http.client.OK)
+
+
 class TestQuickSearch(BaseCaseRun):
 
     @classmethod

--- a/tcms/settings/test/__init__.py
+++ b/tcms/settings/test/__init__.py
@@ -13,4 +13,4 @@ DATABASES = {
 
 LISTENING_MODEL_SIGNAL = False
 
-STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.StaticFilesStorage'
+STATICFILES_STORAGE = 'tcms.tests.storage.RaiseWhenFileNotFound'

--- a/tcms/templates/patternfly.html
+++ b/tcms/templates/patternfly.html
@@ -4,6 +4,6 @@
     <link rel="stylesheet" href="{% static 'patternfly/dist/css/patternfly-additions.min.css' %}">
 
     <!-- JS -->
-    <script src="{% static 'patternfly/node_modules/jquery/dist/jquery.min.js' %}"></script>
-    <script src="{% static 'patternfly/node_modules/bootstrap/dist/js/bootstrap.min.js' %}"></script>
+    <script src="{% static 'jquery/dist/jquery.min.js' %}"></script>
+    <script src="{% static 'bootstrap/dist/js/bootstrap.min.js' %}"></script>
     <script src="{% static 'patternfly/dist/js/patternfly.min.js' %}"></script>

--- a/tcms/tests/storage.py
+++ b/tcms/tests/storage.py
@@ -1,0 +1,25 @@
+from collections import OrderedDict
+
+from django.contrib.staticfiles.storage import StaticFilesStorage
+from django.contrib.staticfiles.finders import get_finders
+
+
+def find_files():
+    # copied from django.contrib.staticfiles.management.commands.collectstatic
+    found_files = OrderedDict()
+    for finder in get_finders():
+        for path, storage in finder.list([]):
+            if path not in found_files:
+                found_files[path] = (storage, path)
+
+    return found_files
+
+
+class RaiseWhenFileNotFound(StaticFilesStorage):
+    _files_found = find_files()
+
+    def url(self, name):
+        if name not in self._files_found:
+            raise Exception('Static file "%s" does not exist and will cause 404 errors!' % name)
+
+        return super(RaiseWhenFileNotFound, self).url(name)


### PR DESCRIPTION
In later versions Patternfly has changed the location of dependent
libraries and that broke the template. However we're seeing this
because the Dockerfile was not taking into account the package.json
file in the project but rather installing patternfly directly!


@GodfatherThe sorry for the late reply. Can you please checkout if this fixes the problem for you? 