### PR TITLE
Rename EMAIL_FROM to DEFAULT_FROM_EMAIL. Fixes #128

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -25,17 +25,18 @@ Using Amazon SES instead of SMTP email
 Kiwi TCMS supports email notifications which by default are sent over SMTP and
 need to be configured via the following settings::
 
-    EMAIL_HOST = ''
+    # standard Django settings
+    EMAIL_HOST = 'smtp.example.com'
     EMAIL_PORT = 25
-    EMAIL_FROM = 'kiwi@example.com'
+    DEFAULT_FROM_EMAIL = 'kiwi@example.com'
+    
+    # additional Kiwi TCMS setting
     EMAIL_SUBJECT_PREFIX = '[Kiwi-TCMS] '
 
-If you'd like to use an external email service, like Amazon SES you have to
-configure the following settings instead::
+If you'd like to use an external email service, like Amazon SES you also need to
+configure the following settings::
 
-    EMAIL_HOST = 'example.com'
-    EMAIL_FROM = 'kiwi@example.com'
-    DEFAULT_FROM_EMAIL = EMAIL_FROM
+
     EMAIL_BACKEND = 'django_ses.SESBackend'
     AWS_SES_ACCESS_KEY_ID = 'xxxxxxxxxxxxxxxxxxxx'
     AWS_SES_SECRET_ACCESS_KEY = 'YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY'

--- a/tcms/core/contrib/auth/tests.py
+++ b/tcms/core/contrib/auth/tests.py
@@ -132,7 +132,7 @@ class TestRegistration(TestCase):
         return response
 
     @patch('tcms.core.utils.mailto.send_mail')
-    @patch('tcms.core.contrib.auth.views.settings.EMAIL_HOST', new='smtp.example.com')
+    @patch('tcms.core.contrib.auth.views.settings.DEFAULT_FROM_EMAIL', new='kiwi@example.com')
     def test_register_user_by_email_confirmation(self, send_mail):
         response = self.assert_user_registration('new-tester')
 
@@ -151,9 +151,9 @@ class TestRegistration(TestCase):
 
 %s
 """ % confirm_url,
-            settings.EMAIL_FROM, ['new-tester@example.com'], fail_silently=False)
+            settings.DEFAULT_FROM_EMAIL, ['new-tester@example.com'], fail_silently=False)
 
-    @patch('tcms.core.contrib.auth.views.settings.EMAIL_HOST', new='')
+    @patch('tcms.core.contrib.auth.views.settings.DEFAULT_FROM_EMAIL', new='')
     @patch('tcms.core.contrib.auth.views.settings.ADMINS',
            new=[('admin1', 'admin1@example.com'),
                 ('admin2', 'admin2@example.com')])

--- a/tcms/core/contrib/auth/views.py
+++ b/tcms/core/contrib/auth/views.py
@@ -37,8 +37,8 @@ def register(request, template_name='registration/registration_form.html'):
             form.save()
             ak = form.set_active_key()
 
-            # Send email to user if mail server is available.
-            if form.cleaned_data['email'] and settings.EMAIL_HOST:
+            # Send email to user if email is configured.
+            if form.cleaned_data['email'] and settings.DEFAULT_FROM_EMAIL:
                 form.send_confirm_mail(request=request, active_key=ak)
 
                 msg = 'Your account has been created, please check your ' \

--- a/tcms/core/utils/mailto.py
+++ b/tcms/core/utils/mailto.py
@@ -7,7 +7,7 @@ from django.template.loader import render_to_string
 
 
 def mailto(template_name, subject, recipients=None,
-           context=None, sender=settings.EMAIL_FROM,
+           context=None, sender=settings.DEFAULT_FROM_EMAIL,
            cc=None):
     # make a list with recipients and filter out duplicates
     if isinstance(recipients, list):

--- a/tcms/settings/common.py
+++ b/tcms/settings/common.py
@@ -39,10 +39,10 @@ ADMINS = [
 
 
 # Email settings
-# EMAIL_HOST must be defined if you want Kiwi TCMS to send emails
-EMAIL_HOST = ''
-EMAIL_PORT = 25
-EMAIL_FROM = 'kiwi@example.com'
+# DEFAULT_FROM_EMAIL must be defined if you want Kiwi TCMS to send emails.
+# You also need to configure the email backend. For more information see:
+# https://docs.djangoproject.com/en/1.11/topics/email/#quick-example
+DEFAULT_FROM_EMAIL = 'kiwi@example.com'
 EMAIL_SUBJECT_PREFIX = '[Kiwi-TCMS] '
 
 


### PR DESCRIPTION
`DEFAULT_FROM_EMAIL` is the standard name for this setting and is used by other Django apps/email backends.  There's no point for us keeping a setting with a different name!