### PR TITLE
[docs] Add API .rst sources and test for autogenerated docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,11 +10,6 @@
 TAGS
 build/
 dist/
-docs/source/modules.rst
-docs/source/manage.rst
-docs/source/setup.rst
-docs/source/tcms.*rst
-docs/source/tcms_api.*rst
 docs/source/*.dot
 docs/guide/target
 docs/target/

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,15 @@ services:
   - mysql
   - postgresql
 addons:
-  - postgresql: 9.5
+  postgresql: 9.5
 matrix:
   include:
+    - python: 3.6
+      env: DOCS_TEST=1 TEST_DB=SQLite
+      addons:
+        apt:
+          packages:
+            - graphviz
     - python: 3.5
       env: TEST_DB=MariaDB
       addons:
@@ -50,7 +56,7 @@ install:
   - if [ -n "$DJANGO" ]; then pip install --upgrade Django==$DJANGO; fi
   - pip install coveralls
   - npm install
-script: make check
+script: if [ -n "$DOCS_TEST" ]; then make check-docs-source-in-git; else make check; fi
 after_success:
   - coveralls
 notifications:

--- a/Makefile
+++ b/Makefile
@@ -90,6 +90,28 @@ docker-image:
 run:
 	docker-compose up
 
+.PHONY: docs
+docs:
+	make -C docs/ html
+
+.PHONY: doctest
+doctest: docs
+	make -C docs/ doctest
+
+# checks if all of our documentation/source files are under git!
+# this is necessary because ReadTheDocs doesn't call `make' but uses
+# conf.py and builds the documentation itself! Since we have some
+# auto-generated API docs we want to make sure that we didn't forget
+# to regenerate them after code changes!
+.PHONY: check-docs-source-in-git
+check-docs-source-in-git: doctest
+	git status
+	if [ -n "$$(git status --short)" ]; then \
+	    echo "FAIL: unmerged docs changes. Pobably auto-generated!"; \
+	    echo "HELP: execute make docs && git add && git commit to fix this"; \
+	    exit 1; \
+	fi
+
 
 .PHONY: help
 help:

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -50,7 +50,6 @@ help:
 
 clean:
 	rm -rf $(BUILDDIR)/*
-	rm -rf source/tcms.*rst source/tcms_api.*rst source/modules.rst
 
 apidoc:
 	$(SPHINXAPIDOC) -o source/ ../ ../manage.py ../setup.py

--- a/docs/source/modules.rst
+++ b/docs/source/modules.rst
@@ -1,0 +1,8 @@
+Kiwi
+====
+
+.. toctree::
+   :maxdepth: 4
+
+   tcms
+   tcms_api

--- a/docs/source/tcms.core.contrib.auth.migrations.rst
+++ b/docs/source/tcms.core.contrib.auth.migrations.rst
@@ -1,0 +1,22 @@
+tcms\.core\.contrib\.auth\.migrations package
+=============================================
+
+Submodules
+----------
+
+tcms\.core\.contrib\.auth\.migrations\.0001\_initial module
+-----------------------------------------------------------
+
+.. automodule:: tcms.core.contrib.auth.migrations.0001_initial
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: tcms.core.contrib.auth.migrations
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/tcms.core.contrib.auth.rst
+++ b/docs/source/tcms.core.contrib.auth.rst
@@ -1,0 +1,69 @@
+tcms\.core\.contrib\.auth package
+=================================
+
+Subpackages
+-----------
+
+.. toctree::
+
+    tcms.core.contrib.auth.migrations
+
+Submodules
+----------
+
+tcms\.core\.contrib\.auth\.apps module
+--------------------------------------
+
+.. automodule:: tcms.core.contrib.auth.apps
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.core\.contrib\.auth\.backends module
+------------------------------------------
+
+.. automodule:: tcms.core.contrib.auth.backends
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.core\.contrib\.auth\.forms module
+---------------------------------------
+
+.. automodule:: tcms.core.contrib.auth.forms
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.core\.contrib\.auth\.models module
+----------------------------------------
+
+.. automodule:: tcms.core.contrib.auth.models
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.core\.contrib\.auth\.tests module
+---------------------------------------
+
+.. automodule:: tcms.core.contrib.auth.tests
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.core\.contrib\.auth\.views module
+---------------------------------------
+
+.. automodule:: tcms.core.contrib.auth.views
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: tcms.core.contrib.auth
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/tcms.core.contrib.comments.rst
+++ b/docs/source/tcms.core.contrib.comments.rst
@@ -1,0 +1,62 @@
+tcms\.core\.contrib\.comments package
+=====================================
+
+Submodules
+----------
+
+tcms\.core\.contrib\.comments\.admin module
+-------------------------------------------
+
+.. automodule:: tcms.core.contrib.comments.admin
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.core\.contrib\.comments\.apps module
+------------------------------------------
+
+.. automodule:: tcms.core.contrib.comments.apps
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.core\.contrib\.comments\.forms module
+-------------------------------------------
+
+.. automodule:: tcms.core.contrib.comments.forms
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.core\.contrib\.comments\.models module
+--------------------------------------------
+
+.. automodule:: tcms.core.contrib.comments.models
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.core\.contrib\.comments\.tests module
+-------------------------------------------
+
+.. automodule:: tcms.core.contrib.comments.tests
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.core\.contrib\.comments\.views module
+-------------------------------------------
+
+.. automodule:: tcms.core.contrib.comments.views
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: tcms.core.contrib.comments
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/tcms.core.contrib.linkreference.migrations.rst
+++ b/docs/source/tcms.core.contrib.linkreference.migrations.rst
@@ -1,0 +1,22 @@
+tcms\.core\.contrib\.linkreference\.migrations package
+======================================================
+
+Submodules
+----------
+
+tcms\.core\.contrib\.linkreference\.migrations\.0001\_initial module
+--------------------------------------------------------------------
+
+.. automodule:: tcms.core.contrib.linkreference.migrations.0001_initial
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: tcms.core.contrib.linkreference.migrations
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/tcms.core.contrib.linkreference.rst
+++ b/docs/source/tcms.core.contrib.linkreference.rst
@@ -1,0 +1,53 @@
+tcms\.core\.contrib\.linkreference package
+==========================================
+
+Subpackages
+-----------
+
+.. toctree::
+
+    tcms.core.contrib.linkreference.migrations
+
+Submodules
+----------
+
+tcms\.core\.contrib\.linkreference\.forms module
+------------------------------------------------
+
+.. automodule:: tcms.core.contrib.linkreference.forms
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.core\.contrib\.linkreference\.models module
+-------------------------------------------------
+
+.. automodule:: tcms.core.contrib.linkreference.models
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.core\.contrib\.linkreference\.tests module
+------------------------------------------------
+
+.. automodule:: tcms.core.contrib.linkreference.tests
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.core\.contrib\.linkreference\.views module
+------------------------------------------------
+
+.. automodule:: tcms.core.contrib.linkreference.views
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: tcms.core.contrib.linkreference
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/tcms.core.contrib.rst
+++ b/docs/source/tcms.core.contrib.rst
@@ -1,0 +1,19 @@
+tcms\.core\.contrib package
+===========================
+
+Subpackages
+-----------
+
+.. toctree::
+
+    tcms.core.contrib.auth
+    tcms.core.contrib.comments
+    tcms.core.contrib.linkreference
+
+Module contents
+---------------
+
+.. automodule:: tcms.core.contrib
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/tcms.core.forms.rst
+++ b/docs/source/tcms.core.forms.rst
@@ -1,0 +1,38 @@
+tcms\.core\.forms package
+=========================
+
+Submodules
+----------
+
+tcms\.core\.forms\.fields module
+--------------------------------
+
+.. automodule:: tcms.core.forms.fields
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.core\.forms\.forms module
+-------------------------------
+
+.. automodule:: tcms.core.forms.forms
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.core\.forms\.widgets module
+---------------------------------
+
+.. automodule:: tcms.core.forms.widgets
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: tcms.core.forms
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/tcms.core.helpers.rst
+++ b/docs/source/tcms.core.helpers.rst
@@ -1,0 +1,30 @@
+tcms\.core\.helpers package
+===========================
+
+Submodules
+----------
+
+tcms\.core\.helpers\.cache module
+---------------------------------
+
+.. automodule:: tcms.core.helpers.cache
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.core\.helpers\.comments module
+------------------------------------
+
+.. automodule:: tcms.core.helpers.comments
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: tcms.core.helpers
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/tcms.core.logs.migrations.rst
+++ b/docs/source/tcms.core.logs.migrations.rst
@@ -1,0 +1,22 @@
+tcms\.core\.logs\.migrations package
+====================================
+
+Submodules
+----------
+
+tcms\.core\.logs\.migrations\.0001\_initial module
+--------------------------------------------------
+
+.. automodule:: tcms.core.logs.migrations.0001_initial
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: tcms.core.logs.migrations
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/tcms.core.logs.rst
+++ b/docs/source/tcms.core.logs.rst
@@ -1,0 +1,53 @@
+tcms\.core\.logs package
+========================
+
+Subpackages
+-----------
+
+.. toctree::
+
+    tcms.core.logs.migrations
+
+Submodules
+----------
+
+tcms\.core\.logs\.managers module
+---------------------------------
+
+.. automodule:: tcms.core.logs.managers
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.core\.logs\.models module
+-------------------------------
+
+.. automodule:: tcms.core.logs.models
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.core\.logs\.tests module
+------------------------------
+
+.. automodule:: tcms.core.logs.tests
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.core\.logs\.views module
+------------------------------
+
+.. automodule:: tcms.core.logs.views
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: tcms.core.logs
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/tcms.core.migrations.rst
+++ b/docs/source/tcms.core.migrations.rst
@@ -1,0 +1,38 @@
+tcms\.core\.migrations package
+==============================
+
+Submodules
+----------
+
+tcms\.core\.migrations\.0001\_django\_comments\_\_object\_pk module
+-------------------------------------------------------------------
+
+.. automodule:: tcms.core.migrations.0001_django_comments__object_pk
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.core\.migrations\.0002\_add\_initial\_data module
+-------------------------------------------------------
+
+.. automodule:: tcms.core.migrations.0002_add_initial_data
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.core\.migrations\.0003\_add\_default\_permissions\_to\_groups module
+--------------------------------------------------------------------------
+
+.. automodule:: tcms.core.migrations.0003_add_default_permissions_to_groups
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: tcms.core.migrations
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/tcms.core.models.rst
+++ b/docs/source/tcms.core.models.rst
@@ -1,0 +1,38 @@
+tcms\.core\.models package
+==========================
+
+Submodules
+----------
+
+tcms\.core\.models\.base module
+-------------------------------
+
+.. automodule:: tcms.core.models.base
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.core\.models\.fields module
+---------------------------------
+
+.. automodule:: tcms.core.models.fields
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.core\.models\.signals module
+----------------------------------
+
+.. automodule:: tcms.core.models.signals
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: tcms.core.models
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/tcms.core.rst
+++ b/docs/source/tcms.core.rst
@@ -1,0 +1,93 @@
+tcms\.core package
+==================
+
+Subpackages
+-----------
+
+.. toctree::
+
+    tcms.core.contrib
+    tcms.core.forms
+    tcms.core.helpers
+    tcms.core.logs
+    tcms.core.migrations
+    tcms.core.models
+    tcms.core.templatetags
+    tcms.core.utils
+    tcms.core.views
+
+Submodules
+----------
+
+tcms\.core\.ajax module
+-----------------------
+
+.. automodule:: tcms.core.ajax
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.core\.context\_processors module
+--------------------------------------
+
+.. automodule:: tcms.core.context_processors
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.core\.db module
+---------------------
+
+.. automodule:: tcms.core.db
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.core\.exceptions module
+-----------------------------
+
+.. automodule:: tcms.core.exceptions
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.core\.files module
+------------------------
+
+.. automodule:: tcms.core.files
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.core\.managers module
+---------------------------
+
+.. automodule:: tcms.core.managers
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.core\.middleware module
+-----------------------------
+
+.. automodule:: tcms.core.middleware
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.core\.responses module
+----------------------------
+
+.. automodule:: tcms.core.responses
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: tcms.core
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/tcms.core.templatetags.rst
+++ b/docs/source/tcms.core.templatetags.rst
@@ -1,0 +1,54 @@
+tcms\.core\.templatetags package
+================================
+
+Submodules
+----------
+
+tcms\.core\.templatetags\.extra\_filters module
+-----------------------------------------------
+
+.. automodule:: tcms.core.templatetags.extra_filters
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.core\.templatetags\.ifin module
+-------------------------------------
+
+.. automodule:: tcms.core.templatetags.ifin
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.core\.templatetags\.report\_tags module
+---------------------------------------------
+
+.. automodule:: tcms.core.templatetags.report_tags
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.core\.templatetags\.split\_as\_option module
+--------------------------------------------------
+
+.. automodule:: tcms.core.templatetags.split_as_option
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.core\.templatetags\.testcase\_tags module
+-----------------------------------------------
+
+.. automodule:: tcms.core.templatetags.testcase_tags
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: tcms.core.templatetags
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/tcms.core.utils.rst
+++ b/docs/source/tcms.core.utils.rst
@@ -1,0 +1,62 @@
+tcms\.core\.utils package
+=========================
+
+Submodules
+----------
+
+tcms\.core\.utils\.checksum module
+----------------------------------
+
+.. automodule:: tcms.core.utils.checksum
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.core\.utils\.mailto module
+--------------------------------
+
+.. automodule:: tcms.core.utils.mailto
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.core\.utils\.raw\_sql module
+----------------------------------
+
+.. automodule:: tcms.core.utils.raw_sql
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.core\.utils\.timedelta2int module
+---------------------------------------
+
+.. automodule:: tcms.core.utils.timedelta2int
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.core\.utils\.timedeltaformat module
+-----------------------------------------
+
+.. automodule:: tcms.core.utils.timedeltaformat
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.core\.utils\.validations module
+-------------------------------------
+
+.. automodule:: tcms.core.utils.validations
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: tcms.core.utils
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/tcms.core.views.rst
+++ b/docs/source/tcms.core.views.rst
@@ -1,0 +1,46 @@
+tcms\.core\.views package
+=========================
+
+Submodules
+----------
+
+tcms\.core\.views\.error module
+-------------------------------
+
+.. automodule:: tcms.core.views.error
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.core\.views\.index module
+-------------------------------
+
+.. automodule:: tcms.core.views.index
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.core\.views\.prompt module
+--------------------------------
+
+.. automodule:: tcms.core.views.prompt
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.core\.views\.search module
+--------------------------------
+
+.. automodule:: tcms.core.views.search
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: tcms.core.views
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/tcms.issuetracker.rst
+++ b/docs/source/tcms.issuetracker.rst
@@ -1,0 +1,46 @@
+tcms\.issuetracker package
+==========================
+
+Submodules
+----------
+
+tcms\.issuetracker\.bugzilla\_integration module
+------------------------------------------------
+
+.. automodule:: tcms.issuetracker.bugzilla_integration
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.issuetracker\.github\_integration module
+----------------------------------------------
+
+.. automodule:: tcms.issuetracker.github_integration
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.issuetracker\.jira\_integration module
+--------------------------------------------
+
+.. automodule:: tcms.issuetracker.jira_integration
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.issuetracker\.types module
+--------------------------------
+
+.. automodule:: tcms.issuetracker.types
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: tcms.issuetracker
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/tcms.management.migrations.rst
+++ b/docs/source/tcms.management.migrations.rst
@@ -1,0 +1,30 @@
+tcms\.management\.migrations package
+====================================
+
+Submodules
+----------
+
+tcms\.management\.migrations\.0001\_initial module
+--------------------------------------------------
+
+.. automodule:: tcms.management.migrations.0001_initial
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.management\.migrations\.0002\_add\_initial\_data module
+-------------------------------------------------------------
+
+.. automodule:: tcms.management.migrations.0002_add_initial_data
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: tcms.management.migrations
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/tcms.management.rst
+++ b/docs/source/tcms.management.rst
@@ -1,0 +1,61 @@
+tcms\.management package
+========================
+
+Subpackages
+-----------
+
+.. toctree::
+
+    tcms.management.migrations
+
+Submodules
+----------
+
+tcms\.management\.admin module
+------------------------------
+
+.. automodule:: tcms.management.admin
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.management\.forms module
+------------------------------
+
+.. automodule:: tcms.management.forms
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.management\.models module
+-------------------------------
+
+.. automodule:: tcms.management.models
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.management\.tests module
+------------------------------
+
+.. automodule:: tcms.management.tests
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.management\.views module
+------------------------------
+
+.. automodule:: tcms.management.views
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: tcms.management
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/tcms.profiles.migrations.rst
+++ b/docs/source/tcms.profiles.migrations.rst
@@ -1,0 +1,30 @@
+tcms\.profiles\.migrations package
+==================================
+
+Submodules
+----------
+
+tcms\.profiles\.migrations\.0001\_initial module
+------------------------------------------------
+
+.. automodule:: tcms.profiles.migrations.0001_initial
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.profiles\.migrations\.0002\_remove\_unused\_models module
+---------------------------------------------------------------
+
+.. automodule:: tcms.profiles.migrations.0002_remove_unused_models
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: tcms.profiles.migrations
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/tcms.profiles.rst
+++ b/docs/source/tcms.profiles.rst
@@ -1,0 +1,61 @@
+tcms\.profiles package
+======================
+
+Subpackages
+-----------
+
+.. toctree::
+
+    tcms.profiles.migrations
+
+Submodules
+----------
+
+tcms\.profiles\.forms module
+----------------------------
+
+.. automodule:: tcms.profiles.forms
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.profiles\.models module
+-----------------------------
+
+.. automodule:: tcms.profiles.models
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.profiles\.tests module
+----------------------------
+
+.. automodule:: tcms.profiles.tests
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.profiles\.urls module
+---------------------------
+
+.. automodule:: tcms.profiles.urls
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.profiles\.views module
+----------------------------
+
+.. automodule:: tcms.profiles.views
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: tcms.profiles
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/tcms.report.rst
+++ b/docs/source/tcms.report.rst
@@ -1,0 +1,62 @@
+tcms\.report package
+====================
+
+Submodules
+----------
+
+tcms\.report\.data module
+-------------------------
+
+.. automodule:: tcms.report.data
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.report\.forms module
+--------------------------
+
+.. automodule:: tcms.report.forms
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.report\.models module
+---------------------------
+
+.. automodule:: tcms.report.models
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.report\.tests module
+--------------------------
+
+.. automodule:: tcms.report.tests
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.report\.urls module
+-------------------------
+
+.. automodule:: tcms.report.urls
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.report\.views module
+--------------------------
+
+.. automodule:: tcms.report.views
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: tcms.report
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/tcms.rst
+++ b/docs/source/tcms.rst
@@ -1,0 +1,49 @@
+tcms package
+============
+
+Subpackages
+-----------
+
+.. toctree::
+
+    tcms.core
+    tcms.issuetracker
+    tcms.management
+    tcms.profiles
+    tcms.report
+    tcms.search
+    tcms.settings
+    tcms.testcases
+    tcms.testplans
+    tcms.testruns
+    tcms.tests
+    tcms.utils
+    tcms.xmlrpc
+
+Submodules
+----------
+
+tcms\.urls module
+-----------------
+
+.. automodule:: tcms.urls
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.wsgi module
+-----------------
+
+.. automodule:: tcms.wsgi
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: tcms
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/tcms.search.rst
+++ b/docs/source/tcms.search.rst
@@ -1,0 +1,54 @@
+tcms\.search package
+====================
+
+Submodules
+----------
+
+tcms\.search\.forms module
+--------------------------
+
+.. automodule:: tcms.search.forms
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.search\.order module
+--------------------------
+
+.. automodule:: tcms.search.order
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.search\.query module
+--------------------------
+
+.. automodule:: tcms.search.query
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.search\.utils module
+--------------------------
+
+.. automodule:: tcms.search.utils
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.search\.views module
+--------------------------
+
+.. automodule:: tcms.search.views
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: tcms.search
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/tcms.settings.rst
+++ b/docs/source/tcms.settings.rst
@@ -1,0 +1,45 @@
+tcms\.settings package
+======================
+
+Subpackages
+-----------
+
+.. toctree::
+
+    tcms.settings.test
+
+Submodules
+----------
+
+tcms\.settings\.common module
+-----------------------------
+
+.. automodule:: tcms.settings.common
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.settings\.devel module
+----------------------------
+
+.. automodule:: tcms.settings.devel
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.settings\.product module
+------------------------------
+
+.. automodule:: tcms.settings.product
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: tcms.settings
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/tcms.settings.test.rst
+++ b/docs/source/tcms.settings.test.rst
@@ -1,0 +1,30 @@
+tcms\.settings\.test package
+============================
+
+Submodules
+----------
+
+tcms\.settings\.test\.mysql module
+----------------------------------
+
+.. automodule:: tcms.settings.test.mysql
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.settings\.test\.postgresql module
+---------------------------------------
+
+.. automodule:: tcms.settings.test.postgresql
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: tcms.settings.test
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/tcms.testcases.helpers.rst
+++ b/docs/source/tcms.testcases.helpers.rst
@@ -1,0 +1,22 @@
+tcms\.testcases\.helpers package
+================================
+
+Submodules
+----------
+
+tcms\.testcases\.helpers\.email module
+--------------------------------------
+
+.. automodule:: tcms.testcases.helpers.email
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: tcms.testcases.helpers
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/tcms.testcases.migrations.rst
+++ b/docs/source/tcms.testcases.migrations.rst
@@ -1,0 +1,102 @@
+tcms\.testcases\.migrations package
+===================================
+
+Submodules
+----------
+
+tcms\.testcases\.migrations\.0001\_initial module
+-------------------------------------------------
+
+.. automodule:: tcms.testcases.migrations.0001_initial
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.testcases\.migrations\.0002\_auto\_20160828\_1427 module
+--------------------------------------------------------------
+
+.. automodule:: tcms.testcases.migrations.0002_auto_20160828_1427
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.testcases\.migrations\.0003\_add\_initial\_data module
+------------------------------------------------------------
+
+.. automodule:: tcms.testcases.migrations.0003_add_initial_data
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.testcases\.migrations\.0004\_add\_unique\_to\_testcasebugsystem\_name module
+----------------------------------------------------------------------------------
+
+.. automodule:: tcms.testcases.migrations.0004_add_unique_to_testcasebugsystem_name
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.testcases\.migrations\.0005\_allow\_null\_to\_testcaseattachment\_case\_run module
+----------------------------------------------------------------------------------------
+
+.. automodule:: tcms.testcases.migrations.0005_allow_null_to_testcaseattachment_case_run
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.testcases\.migrations\.0005\_change\_meta\_options\_on\_testcasebugsystem module
+--------------------------------------------------------------------------------------
+
+.. automodule:: tcms.testcases.migrations.0005_change_meta_options_on_testcasebugsystem
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.testcases\.migrations\.0006\_add\_bugtracker\_integration\_fields module
+------------------------------------------------------------------------------
+
+.. automodule:: tcms.testcases.migrations.0006_add_bugtracker_integration_fields
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.testcases\.migrations\.0007\_merge module
+-----------------------------------------------
+
+.. automodule:: tcms.testcases.migrations.0007_merge
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.testcases\.migrations\.0008\_testcasebug\_field\_options module
+---------------------------------------------------------------------
+
+.. automodule:: tcms.testcases.migrations.0008_testcasebug_field_options
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.testcases\.migrations\.0009\_testcasebug\_rename\_report\_url\_to\_base\_url module
+-----------------------------------------------------------------------------------------
+
+.. automodule:: tcms.testcases.migrations.0009_testcasebug_rename_report_url_to_base_url
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.testcases\.migrations\.0010\_update\_blank\_and\_null\_constraints module
+-------------------------------------------------------------------------------
+
+.. automodule:: tcms.testcases.migrations.0010_update_blank_and_null_constraints
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: tcms.testcases.migrations
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/tcms.testcases.rst
+++ b/docs/source/tcms.testcases.rst
@@ -1,0 +1,95 @@
+tcms\.testcases package
+=======================
+
+Subpackages
+-----------
+
+.. toctree::
+
+    tcms.testcases.helpers
+    tcms.testcases.migrations
+    tcms.testcases.urls
+
+Submodules
+----------
+
+tcms\.testcases\.actions module
+-------------------------------
+
+.. automodule:: tcms.testcases.actions
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.testcases\.admin module
+-----------------------------
+
+.. automodule:: tcms.testcases.admin
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.testcases\.data module
+----------------------------
+
+.. automodule:: tcms.testcases.data
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.testcases\.fields module
+------------------------------
+
+.. automodule:: tcms.testcases.fields
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.testcases\.forms module
+-----------------------------
+
+.. automodule:: tcms.testcases.forms
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.testcases\.models module
+------------------------------
+
+.. automodule:: tcms.testcases.models
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.testcases\.signals module
+-------------------------------
+
+.. automodule:: tcms.testcases.signals
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.testcases\.tests module
+-----------------------------
+
+.. automodule:: tcms.testcases.tests
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.testcases\.views module
+-----------------------------
+
+.. automodule:: tcms.testcases.views
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: tcms.testcases
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/tcms.testcases.urls.rst
+++ b/docs/source/tcms.testcases.urls.rst
@@ -1,0 +1,30 @@
+tcms\.testcases\.urls package
+=============================
+
+Submodules
+----------
+
+tcms\.testcases\.urls\.case\_urls module
+----------------------------------------
+
+.. automodule:: tcms.testcases.urls.case_urls
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.testcases\.urls\.cases\_urls module
+-----------------------------------------
+
+.. automodule:: tcms.testcases.urls.cases_urls
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: tcms.testcases.urls
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/tcms.testplans.helpers.rst
+++ b/docs/source/tcms.testplans.helpers.rst
@@ -1,0 +1,22 @@
+tcms\.testplans\.helpers package
+================================
+
+Submodules
+----------
+
+tcms\.testplans\.helpers\.email module
+--------------------------------------
+
+.. automodule:: tcms.testplans.helpers.email
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: tcms.testplans.helpers
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/tcms.testplans.migrations.rst
+++ b/docs/source/tcms.testplans.migrations.rst
@@ -1,0 +1,38 @@
+tcms\.testplans\.migrations package
+===================================
+
+Submodules
+----------
+
+tcms\.testplans\.migrations\.0001\_initial module
+-------------------------------------------------
+
+.. automodule:: tcms.testplans.migrations.0001_initial
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.testplans\.migrations\.0002\_add\_initial\_data module
+------------------------------------------------------------
+
+.. automodule:: tcms.testplans.migrations.0002_add_initial_data
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.testplans\.migrations\.0003\_delete\_testplanpermissions\_model module
+----------------------------------------------------------------------------
+
+.. automodule:: tcms.testplans.migrations.0003_delete_testplanpermissions_model
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: tcms.testplans.migrations
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/tcms.testplans.rst
+++ b/docs/source/tcms.testplans.rst
@@ -1,0 +1,79 @@
+tcms\.testplans package
+=======================
+
+Subpackages
+-----------
+
+.. toctree::
+
+    tcms.testplans.helpers
+    tcms.testplans.migrations
+    tcms.testplans.urls
+
+Submodules
+----------
+
+tcms\.testplans\.actions module
+-------------------------------
+
+.. automodule:: tcms.testplans.actions
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.testplans\.admin module
+-----------------------------
+
+.. automodule:: tcms.testplans.admin
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.testplans\.forms module
+-----------------------------
+
+.. automodule:: tcms.testplans.forms
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.testplans\.models module
+------------------------------
+
+.. automodule:: tcms.testplans.models
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.testplans\.signals module
+-------------------------------
+
+.. automodule:: tcms.testplans.signals
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.testplans\.tests module
+-----------------------------
+
+.. automodule:: tcms.testplans.tests
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.testplans\.views module
+-----------------------------
+
+.. automodule:: tcms.testplans.views
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: tcms.testplans
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/tcms.testplans.urls.rst
+++ b/docs/source/tcms.testplans.urls.rst
@@ -1,0 +1,30 @@
+tcms\.testplans\.urls package
+=============================
+
+Submodules
+----------
+
+tcms\.testplans\.urls\.plan\_urls module
+----------------------------------------
+
+.. automodule:: tcms.testplans.urls.plan_urls
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.testplans\.urls\.plans\_urls module
+-----------------------------------------
+
+.. automodule:: tcms.testplans.urls.plans_urls
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: tcms.testplans.urls
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/tcms.testruns.helpers.rst
+++ b/docs/source/tcms.testruns.helpers.rst
@@ -1,0 +1,22 @@
+tcms\.testruns\.helpers package
+===============================
+
+Submodules
+----------
+
+tcms\.testruns\.helpers\.serializer module
+------------------------------------------
+
+.. automodule:: tcms.testruns.helpers.serializer
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: tcms.testruns.helpers
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/tcms.testruns.migrations.rst
+++ b/docs/source/tcms.testruns.migrations.rst
@@ -1,0 +1,54 @@
+tcms\.testruns\.migrations package
+==================================
+
+Submodules
+----------
+
+tcms\.testruns\.migrations\.0001\_initial module
+------------------------------------------------
+
+.. automodule:: tcms.testruns.migrations.0001_initial
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.testruns\.migrations\.0002\_add\_initial\_data module
+-----------------------------------------------------------
+
+.. automodule:: tcms.testruns.migrations.0002_add_initial_data
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.testruns\.migrations\.0003\_testrun\_estimated\_time\_remove\_max\_length module
+--------------------------------------------------------------------------------------
+
+.. automodule:: tcms.testruns.migrations.0003_testrun_estimated_time_remove_max_length
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.testruns\.migrations\.0004\_remove\_testrun\_errata\_id module
+--------------------------------------------------------------------
+
+.. automodule:: tcms.testruns.migrations.0004_remove_testrun_errata_id
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.testruns\.migrations\.0005\_alter\_testrun\_tag module
+------------------------------------------------------------
+
+.. automodule:: tcms.testruns.migrations.0005_alter_testrun_tag
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: tcms.testruns.migrations
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/tcms.testruns.rst
+++ b/docs/source/tcms.testruns.rst
@@ -1,0 +1,72 @@
+tcms\.testruns package
+======================
+
+Subpackages
+-----------
+
+.. toctree::
+
+    tcms.testruns.helpers
+    tcms.testruns.migrations
+    tcms.testruns.tests
+    tcms.testruns.urls
+
+Submodules
+----------
+
+tcms\.testruns\.admin module
+----------------------------
+
+.. automodule:: tcms.testruns.admin
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.testruns\.data module
+---------------------------
+
+.. automodule:: tcms.testruns.data
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.testruns\.forms module
+----------------------------
+
+.. automodule:: tcms.testruns.forms
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.testruns\.models module
+-----------------------------
+
+.. automodule:: tcms.testruns.models
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.testruns\.signals module
+------------------------------
+
+.. automodule:: tcms.testruns.signals
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.testruns\.views module
+----------------------------
+
+.. automodule:: tcms.testruns.views
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: tcms.testruns
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/tcms.testruns.tests.rst
+++ b/docs/source/tcms.testruns.tests.rst
@@ -1,0 +1,38 @@
+tcms\.testruns\.tests package
+=============================
+
+Submodules
+----------
+
+tcms\.testruns\.tests\.test\_data module
+----------------------------------------
+
+.. automodule:: tcms.testruns.tests.test_data
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.testruns\.tests\.test\_models module
+------------------------------------------
+
+.. automodule:: tcms.testruns.tests.test_models
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.testruns\.tests\.test\_views module
+-----------------------------------------
+
+.. automodule:: tcms.testruns.tests.test_views
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: tcms.testruns.tests
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/tcms.testruns.urls.rst
+++ b/docs/source/tcms.testruns.urls.rst
@@ -1,0 +1,30 @@
+tcms\.testruns\.urls package
+============================
+
+Submodules
+----------
+
+tcms\.testruns\.urls\.run\_urls module
+--------------------------------------
+
+.. automodule:: tcms.testruns.urls.run_urls
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.testruns\.urls\.runs\_urls module
+---------------------------------------
+
+.. automodule:: tcms.testruns.urls.runs_urls
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: tcms.testruns.urls
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/tcms.tests.rst
+++ b/docs/source/tcms.tests.rst
@@ -1,0 +1,30 @@
+tcms\.tests package
+===================
+
+Submodules
+----------
+
+tcms\.tests\.factories module
+-----------------------------
+
+.. automodule:: tcms.tests.factories
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.tests\.storage module
+---------------------------
+
+.. automodule:: tcms.tests.storage
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: tcms.tests
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/tcms.utils.rst
+++ b/docs/source/tcms.utils.rst
@@ -1,0 +1,54 @@
+tcms\.utils package
+===================
+
+Submodules
+----------
+
+tcms\.utils\.dict\_utils module
+-------------------------------
+
+.. automodule:: tcms.utils.dict_utils
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.utils\.models module
+--------------------------
+
+.. automodule:: tcms.utils.models
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.utils\.permissions module
+-------------------------------
+
+.. automodule:: tcms.utils.permissions
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.utils\.views module
+-------------------------
+
+.. automodule:: tcms.utils.views
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.utils\.xml module
+-----------------------
+
+.. automodule:: tcms.utils.xml
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: tcms.utils
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/tcms.xmlrpc.api.rst
+++ b/docs/source/tcms.xmlrpc.api.rst
@@ -1,0 +1,118 @@
+tcms\.xmlrpc\.api package
+=========================
+
+Submodules
+----------
+
+tcms\.xmlrpc\.api\.auth module
+------------------------------
+
+.. automodule:: tcms.xmlrpc.api.auth
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.xmlrpc\.api\.build module
+-------------------------------
+
+.. automodule:: tcms.xmlrpc.api.build
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.xmlrpc\.api\.env module
+-----------------------------
+
+.. automodule:: tcms.xmlrpc.api.env
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.xmlrpc\.api\.product module
+---------------------------------
+
+.. automodule:: tcms.xmlrpc.api.product
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.xmlrpc\.api\.tag module
+-----------------------------
+
+.. automodule:: tcms.xmlrpc.api.tag
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.xmlrpc\.api\.testcase module
+----------------------------------
+
+.. automodule:: tcms.xmlrpc.api.testcase
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.xmlrpc\.api\.testcaseplan module
+--------------------------------------
+
+.. automodule:: tcms.xmlrpc.api.testcaseplan
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.xmlrpc\.api\.testcaserun module
+-------------------------------------
+
+.. automodule:: tcms.xmlrpc.api.testcaserun
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.xmlrpc\.api\.testopia module
+----------------------------------
+
+.. automodule:: tcms.xmlrpc.api.testopia
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.xmlrpc\.api\.testplan module
+----------------------------------
+
+.. automodule:: tcms.xmlrpc.api.testplan
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.xmlrpc\.api\.testrun module
+---------------------------------
+
+.. automodule:: tcms.xmlrpc.api.testrun
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.xmlrpc\.api\.user module
+------------------------------
+
+.. automodule:: tcms.xmlrpc.api.user
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.xmlrpc\.api\.version module
+---------------------------------
+
+.. automodule:: tcms.xmlrpc.api.version
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: tcms.xmlrpc.api
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/tcms.xmlrpc.migrations.rst
+++ b/docs/source/tcms.xmlrpc.migrations.rst
@@ -1,0 +1,22 @@
+tcms\.xmlrpc\.migrations package
+================================
+
+Submodules
+----------
+
+tcms\.xmlrpc\.migrations\.0001\_initial module
+----------------------------------------------
+
+.. automodule:: tcms.xmlrpc.migrations.0001_initial
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: tcms.xmlrpc.migrations
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/tcms.xmlrpc.rst
+++ b/docs/source/tcms.xmlrpc.rst
@@ -1,0 +1,103 @@
+tcms\.xmlrpc package
+====================
+
+Subpackages
+-----------
+
+.. toctree::
+
+    tcms.xmlrpc.api
+    tcms.xmlrpc.migrations
+    tcms.xmlrpc.tests
+
+Submodules
+----------
+
+tcms\.xmlrpc\.admin module
+--------------------------
+
+.. automodule:: tcms.xmlrpc.admin
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.xmlrpc\.decorators module
+-------------------------------
+
+.. automodule:: tcms.xmlrpc.decorators
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.xmlrpc\.dispatcher module
+-------------------------------
+
+.. automodule:: tcms.xmlrpc.dispatcher
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.xmlrpc\.filters module
+----------------------------
+
+.. automodule:: tcms.xmlrpc.filters
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.xmlrpc\.forms module
+--------------------------
+
+.. automodule:: tcms.xmlrpc.forms
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.xmlrpc\.models module
+---------------------------
+
+.. automodule:: tcms.xmlrpc.models
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.xmlrpc\.serializer module
+-------------------------------
+
+.. automodule:: tcms.xmlrpc.serializer
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.xmlrpc\.urls module
+-------------------------
+
+.. automodule:: tcms.xmlrpc.urls
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.xmlrpc\.utils module
+--------------------------
+
+.. automodule:: tcms.xmlrpc.utils
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.xmlrpc\.views module
+--------------------------
+
+.. automodule:: tcms.xmlrpc.views
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: tcms.xmlrpc
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/tcms.xmlrpc.tests.rst
+++ b/docs/source/tcms.xmlrpc.tests.rst
@@ -1,0 +1,134 @@
+tcms\.xmlrpc\.tests package
+===========================
+
+Submodules
+----------
+
+tcms\.xmlrpc\.tests\.test\_filters module
+-----------------------------------------
+
+.. automodule:: tcms.xmlrpc.tests.test_filters
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.xmlrpc\.tests\.test\_product module
+-----------------------------------------
+
+.. automodule:: tcms.xmlrpc.tests.test_product
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.xmlrpc\.tests\.test\_serializer module
+--------------------------------------------
+
+.. automodule:: tcms.xmlrpc.tests.test_serializer
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.xmlrpc\.tests\.test\_tag module
+-------------------------------------
+
+.. automodule:: tcms.xmlrpc.tests.test_tag
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.xmlrpc\.tests\.test\_testbuild module
+-------------------------------------------
+
+.. automodule:: tcms.xmlrpc.tests.test_testbuild
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.xmlrpc\.tests\.test\_testcase module
+------------------------------------------
+
+.. automodule:: tcms.xmlrpc.tests.test_testcase
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.xmlrpc\.tests\.test\_testcaseplan module
+----------------------------------------------
+
+.. automodule:: tcms.xmlrpc.tests.test_testcaseplan
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.xmlrpc\.tests\.test\_testcaserun module
+---------------------------------------------
+
+.. automodule:: tcms.xmlrpc.tests.test_testcaserun
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.xmlrpc\.tests\.test\_testplan module
+------------------------------------------
+
+.. automodule:: tcms.xmlrpc.tests.test_testplan
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.xmlrpc\.tests\.test\_testrun module
+-----------------------------------------
+
+.. automodule:: tcms.xmlrpc.tests.test_testrun
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.xmlrpc\.tests\.test\_user module
+--------------------------------------
+
+.. automodule:: tcms.xmlrpc.tests.test_user
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.xmlrpc\.tests\.test\_utils module
+---------------------------------------
+
+.. automodule:: tcms.xmlrpc.tests.test_utils
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.xmlrpc\.tests\.test\_version module
+-----------------------------------------
+
+.. automodule:: tcms.xmlrpc.tests.test_version
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.xmlrpc\.tests\.test\_views module
+---------------------------------------
+
+.. automodule:: tcms.xmlrpc.tests.test_views
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\.xmlrpc\.tests\.utils module
+---------------------------------
+
+.. automodule:: tcms.xmlrpc.tests.utils
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: tcms.xmlrpc.tests
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/tcms_api.rst
+++ b/docs/source/tcms_api.rst
@@ -1,0 +1,85 @@
+tcms\_api package
+=================
+
+Subpackages
+-----------
+
+.. toctree::
+
+    tcms_api.tests
+
+Submodules
+----------
+
+tcms\_api\.base module
+----------------------
+
+.. automodule:: tcms_api.base
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\_api\.config module
+------------------------
+
+.. automodule:: tcms_api.config
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\_api\.containers module
+----------------------------
+
+.. automodule:: tcms_api.containers
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\_api\.immutable module
+---------------------------
+
+.. automodule:: tcms_api.immutable
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\_api\.mutable module
+-------------------------
+
+.. automodule:: tcms_api.mutable
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\_api\.setup module
+-----------------------
+
+.. automodule:: tcms_api.setup
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\_api\.utils module
+-----------------------
+
+.. automodule:: tcms_api.utils
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\_api\.xmlrpc module
+------------------------
+
+.. automodule:: tcms_api.xmlrpc
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: tcms_api
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/tcms_api.tests.rst
+++ b/docs/source/tcms_api.tests.rst
@@ -1,0 +1,30 @@
+tcms\_api\.tests package
+========================
+
+Submodules
+----------
+
+tcms\_api\.tests\.test\_everything module
+-----------------------------------------
+
+.. automodule:: tcms_api.tests.test_everything
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tcms\_api\.tests\.test\_utils module
+------------------------------------
+
+.. automodule:: tcms_api.tests.test_utils
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: tcms_api.tests
+    :members:
+    :undoc-members:
+    :show-inheritance:


### PR DESCRIPTION
module documentation is auto-generated but ReadTheDocs doesn't support this nor does it call `make', see:
https://github.com/rtfd/readthedocs.org/issues/1139

Instead RTD uses its own Sphinx commands and passes in conf.py directly!

I've opted for storing the generated rst sources under git which seems the straight forward solution instead of trying to hack around conf.py. This will also safe us from missing dependencies and other similar issues on the RTD builders!