### PR TITLE
Refactor get_plain_text

### DIFF
--- a/tcms/management/tests.py
+++ b/tcms/management/tests.py
@@ -734,7 +734,7 @@ class ProductTests(TestCase):
             2) Test Plan is deleted
 
             NOTE: we manually connect signals handlers here
-            b/c in est mode LISTENING_MODEL_SIGNAL = False
+            b/c in test mode LISTENING_MODEL_SIGNAL = False
         """
         # connect signal handlers
         _listen()

--- a/tcms/templates/mail/edit_case.txt
+++ b/tcms/templates/mail/edit_case.txt
@@ -1,9 +1,9 @@
 TestCase [{{ test_case.summary }}] has been updated by {{ test_case.current_user.username|default:"someone" }}
 
-Case - 
+Case -
 {{ test_case.get_url }}?#log
 
--- 
+--
 Configure mail: {{test_case.get_url}}/edit/
 ------- You are receiving this mail because: -------
 You have subscribed to the changes of this TestCase

--- a/tcms/testcases/helpers/email.py
+++ b/tcms/testcases/helpers/email.py
@@ -6,14 +6,13 @@ from tcms.core.utils.mailto import mailto
 
 def email_case_update(case):
     recipients = get_case_notification_recipients(case)
-    cc = case.emailing.get_cc_list()
     if len(recipients) == 0:
         return
+    cc = case.emailing.get_cc_list()
     subject = 'TestCase %s has been updated.' % case.pk
     txt = case.latest_text()
     context = {
         'test_case': case, 'test_case_text': txt,
-        'test_case_plain_text': txt.get_plain_text(),
     }
     template = settings.CASE_EMAIL_TEMPLATE
     mailto(template, subject, recipients, context, cc=cc)
@@ -48,4 +47,4 @@ def get_case_notification_recipients(case):
     if case.emailing.auto_to_case_run_assignee:
         assignees = case.case_run.values_list('assignee__email', flat=True)
         recipients.update(assignees)
-    return filter(lambda e: bool(e), recipients)
+    return list(filter(lambda e: bool(e), recipients))

--- a/tcms/testcases/models.py
+++ b/tcms/testcases/models.py
@@ -45,6 +45,16 @@ class NoneText:
         return {}
 
 
+class PlainText(object):
+    """Contains plain text converted from four text"""
+
+    def __init__(self, action, setup, effect, breakdown):
+        self.action = action
+        self.setup = setup
+        self.effect = effect
+        self.breakdown = breakdown
+
+
 class TestCaseStatus(TCMSActionModel):
     id = models.AutoField(
         db_column='case_status_id', max_length=6, primary_key=True
@@ -564,12 +574,12 @@ class TestCaseText(TCMSActionModel):
         unique_together = ('case', 'case_text_version')
 
     def get_plain_text(self):
-        self.action = html2text(smart_str(self.action))
-        self.effect = html2text(smart_str(self.effect))
-        self.setup = html2text(smart_str(self.setup))
-        self.breakdown = html2text(smart_str(self.breakdown))
-
-        return self
+        action = html2text(smart_str(self.action)).rstrip()
+        effect = html2text(smart_str(self.effect)).rstrip()
+        setup = html2text(smart_str(self.setup)).rstrip()
+        breakdown = html2text(smart_str(self.breakdown)).rstrip()
+        return PlainText(action=action, setup=setup,
+                         effect=effect, breakdown=breakdown)
 
 
 class TestCasePlan(models.Model):
@@ -875,6 +885,13 @@ def _listen():
     post_save.connect(case_watchers.on_case_save, TestCase)
     post_delete.connect(case_watchers.on_case_delete, TestCase)
     pre_save.connect(case_watchers.pre_save_clean, TestCase)
+
+
+def _disconnect_signals():
+    # used in testing
+    post_save.disconnect(case_watchers.on_case_save, TestCase)
+    post_delete.disconnect(case_watchers.on_case_delete, TestCase)
+    pre_save.disconnect(case_watchers.pre_save_clean, TestCase)
 
 
 if settings.LISTENING_MODEL_SIGNAL:

--- a/tcms/testplans/models.py
+++ b/tcms/testplans/models.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 from datetime import datetime
-from html2text import html2text
 
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
@@ -408,10 +407,6 @@ class TestPlanText(TCMSActionModel):
         db_table = u'test_plan_texts'
         ordering = ['plan', '-plan_text_version']
         unique_together = ('plan', 'plan_text_version')
-
-    def get_plain_text(self):
-        self.plan_text = html2text(self.plan_text)
-        return self
 
 
 class TestPlanAttachment(models.Model):


### PR DESCRIPTION
* TestCaseText.get_plain_text is refactored to return an object with
  four plain text converted from HTML.
* Remove TestPlainText.get_plain_text as it is not used in code.

Signed-off-by: Chenxiong Qi <qcxhome@gmail.com>