### PR TITLE
[bug-fix] Properly urlencode emails in personal menu

### DIFF
--- a/tcms/templates/navigation.html
+++ b/tcms/templates/navigation.html
@@ -30,11 +30,11 @@
                     <ul class="dropdown-menu">
                     {% if user.is_authenticated %}
                         <li>
-                            <a href="{% url "testruns-all" %}?people={{ user.email }}" target="_parent">My Test Runs</a>
+                            <a href="{% url "testruns-all" %}?people={{ user.email|urlencode }}" target="_parent">My Test Runs</a>
                         </li>
 
                         <li>
-                            <a href="{% url "plans-all" %}?author__email__startswith={{ user.email }}" target="_parent">My Test Plans</a>
+                            <a href="{% url "plans-all" %}?author__email__startswith={{ user.email|urlencode }}" target="_parent">My Test Plans</a>
                         </li>
 
                         <li>


### PR DESCRIPTION
when email contains + sign, e.g. user+qa@example.com this was causing
the search views to not find any Test Plans or Test Runs. The reason
is because the email address needs to be properly urlencoded before
passing it as query string argument to the search views!

Without urlencoding the + sign is then decoded as a space within
the search view!

Originally spotted by @Akulavenkatesh