### PR TITLE
New setting AUTO_APPROVE_NEW_USERS. Fixes #203

### DIFF
--- a/tcms/core/contrib/auth/tests.py
+++ b/tcms/core/contrib/auth/tests.py
@@ -157,7 +157,6 @@ class TestRegistration(TestCase):
             signals.user_registered.disconnect(signals.notify_admins)
 
     @patch('tcms.core.utils.mailto.send_mail')
-    @patch('tcms.core.contrib.auth.views.settings.DEFAULT_FROM_EMAIL', new='kiwi@example.com')
     def test_register_user_by_email_confirmation(self, send_mail):
         response = self.assert_user_registration('new-tester', follow=True)
         self.assertContains(
@@ -179,10 +178,9 @@ class TestRegistration(TestCase):
 """ % confirm_url,
             settings.DEFAULT_FROM_EMAIL, ['new-tester@example.com'], fail_silently=False)
 
-    @patch('tcms.core.contrib.auth.views.settings.DEFAULT_FROM_EMAIL', new='')
-    @patch('tcms.core.contrib.auth.views.settings.ADMINS',
-           new=[('admin1', 'admin1@example.com'),
-                ('admin2', 'admin2@example.com')])
+    @override_settings(AUTO_APPROVE_NEW_USERS=False,
+                       ADMINS=[('admin1', 'admin1@example.com'),
+                               ('admin2', 'admin2@example.com')])
     def test_register_user_and_activate_by_admin(self):
         response = self.assert_user_registration('plan-tester', follow=True)
 

--- a/tcms/core/contrib/auth/views.py
+++ b/tcms/core/contrib/auth/views.py
@@ -43,8 +43,8 @@ def register(request, template_name='registration/registration_form.html'):
                                  user=new_user,
                                  backend=backend)
 
-            # Send email to user if email is configured.
-            if form.cleaned_data['email'] and settings.DEFAULT_FROM_EMAIL:
+            # Send confirmation email to new user
+            if settings.DEFAULT_FROM_EMAIL and settings.AUTO_APPROVE_NEW_USERS:
                 form.send_confirm_mail(request=request, active_key=ak)
 
                 messages.add_message(

--- a/tcms/settings/common.py
+++ b/tcms/settings/common.py
@@ -42,7 +42,7 @@ ADMINS = [
 # Email settings
 # DEFAULT_FROM_EMAIL must be defined if you want Kiwi TCMS to send emails.
 # You also need to configure the email backend. For more information see:
-# https://docs.djangoproject.com/en/1.11/topics/email/#quick-example
+# https://docs.djangoproject.com/en/2.0/topics/email/#quick-example
 DEFAULT_FROM_EMAIL = 'kiwi@example.com'
 EMAIL_SUBJECT_PREFIX = '[Kiwi-TCMS] '
 
@@ -58,6 +58,12 @@ ALLOWED_HOSTS = ['*']
 
 # default group in which new users will be created
 DEFAULT_GROUPS = ['Tester']
+
+
+# When set to False site administrators will have to manually approve
+# new users. You can combine this with tcms.signals.notify_admins() signal
+# handler!
+AUTO_APPROVE_NEW_USERS = True
 
 
 # Maximum upload file size, default set to 5MB.


### PR DESCRIPTION
setting this to False will force manual user approval by site administrators.