### PR TITLE
Refactor SQL queries in ajax.py to Django queries

### DIFF
--- a/tcms/core/tests/test_ajax.py
+++ b/tcms/core/tests/test_ajax.py
@@ -5,8 +5,12 @@ import http.client
 from django import test
 from django.urls import reverse
 from django.conf import settings
+from django.db.models import Count
 
-from tcms.testcases.models import TestCase
+from tcms.core.ajax import _TagCounter
+from tcms.testplans.models import TestPlanTag
+from tcms.testruns.models import TestRunTag
+from tcms.testcases.models import TestCase, TestCaseTag
 from tcms.tests import BasePlanCase
 
 from tcms.tests.factories import TagFactory
@@ -229,3 +233,89 @@ class Test_Tag_Render(Test_Tag_Test):
         self.assertContains(response, '>4</a>')
         self.assertContains(response, '>5</a>')
         self.assertContains(response, '>6</a>')
+
+
+class Test_Tag_Counter(test.TestCase):
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.tag_one = TagFactory()
+        cls.tag_two = TagFactory()
+        cls.tag_three = TagFactory()
+        cls.tags = [cls.tag_one, cls.tag_two, cls.tag_three]
+
+    def test_with_empty_query(self):
+        """Given an empty TestCaseTag QuerySet we expect the result of all the counting to be 0"""
+
+        test_case_tags = TestCaseTag.objects.filter(tag=-1).values('tag').annotate(
+            num_cases=Count('tag')).order_by('tag')
+
+        case_tag_counter = _TagCounter('num_cases', test_case_tags)
+        count_for_tag_one = case_tag_counter.calculate_tag_count(self.tag_one)
+        count_for_tag_two = case_tag_counter.calculate_tag_count(self.tag_two)
+
+        self.assertEqual(count_for_tag_one, 0)
+        self.assertEqual(count_for_tag_two, 0)
+
+    def test_with_tag_not_in_query(self):
+        """Given a QuerySet that does not contain a given tag,the count for this tag should be 0"""
+
+        test_case = TestCaseFactory()
+        test_case.add_tag(self.tag_one)
+
+        test_case_tags = TestCaseTag.objects.filter(
+            tag=self.tag_one).values('tag').annotate(
+            num_cases=Count('tag')).order_by('tag')
+
+        case_tag_counter = _TagCounter('num_cases', test_case_tags)
+        count_for_tag_one = case_tag_counter.calculate_tag_count(self.tag_one)
+        count_for_tag_two = case_tag_counter.calculate_tag_count(self.tag_two)
+
+        self.assertEqual(count_for_tag_one, 1)
+        self.assertEqual(count_for_tag_two, 0)
+
+    def test_in_loop(self):
+
+        test_plan = TestPlanFactory()
+        test_run = TestRunFactory()
+        test_case_one = TestCaseFactory()
+        test_case_two = TestCaseFactory()
+
+        test_plan.add_tag(self.tag_one)
+        test_plan.add_tag(self.tag_two)
+        test_plan.add_tag(self.tag_three)
+
+        test_case_one.add_tag(self.tag_one)
+        test_case_one.add_tag(self.tag_three)
+
+        test_run.add_tag(self.tag_two)
+
+        test_case_two.add_tag(self.tag_three)
+
+        test_plan_tags = TestPlanTag.objects.filter(tag__in=self.tags).values('tag').annotate(
+            num_plans=Count('tag')).order_by('tag')
+        test_case_tags = TestCaseTag.objects.filter(tag__in=self.tags).values('tag').annotate(
+            num_cases=Count('tag')).order_by('tag')
+        test_run_tags = TestRunTag.objects.filter(tag__in=self.tags).values('tag').annotate(
+            num_runs=Count('tag')).order_by('tag')
+
+        plan_counter = _TagCounter('num_plans', test_plan_tags)
+        case_counter = _TagCounter('num_cases', test_case_tags)
+        run_counter = _TagCounter('num_runs', test_run_tags)
+
+        for tag in self.tags:
+            tag.num_plans = plan_counter.calculate_tag_count(tag)
+            tag.num_cases = case_counter.calculate_tag_count(tag)
+            tag.num_runs = run_counter.calculate_tag_count(tag)
+
+        self.assertEqual(self.tag_one.num_plans, 1)
+        self.assertEqual(self.tag_two.num_plans, 1)
+        self.assertEqual(self.tag_three.num_plans, 1)
+
+        self.assertEqual(self.tag_one.num_cases, 1)
+        self.assertEqual(self.tag_two.num_cases, 0)
+        self.assertEqual(self.tag_three.num_cases, 2)
+
+        self.assertEqual(self.tag_one.num_runs, 0)
+        self.assertEqual(self.tag_two.num_runs, 1)
+        self.assertEqual(self.tag_three.num_runs, 0)


### PR DESCRIPTION
As discussed in #222 the SQL queries in `ajax.py` needed to be refactored into Django queries. 