### PR TITLE
Fixed pylint issues in tcms.settings and tcms.core.db

### DIFF
--- a/tcms/core/db.py
+++ b/tcms/core/db.py
@@ -101,7 +101,7 @@ class GroupByResult(object):
             total = self[self._total_name]
         else:
             total = 0
-            for name, subtotal in self._data.items():
+            for _, subtotal in self._data.items():
                 # NOTE: is it possible do such judgement in advance when adding
                 # element
                 if isinstance(subtotal, int):
@@ -125,12 +125,11 @@ class GroupByResult(object):
         subtotal = self[key]
         if total == 0:
             return .0
-        else:
-            return subtotal * 100.0 / total
+        return subtotal * 100.0 / total
 
     def __getattr__(self, name):
         if name.endswith('_percent'):
-            key, identifier = name.split('_')
+            key, _ = name.split('_')
             if key in self._data:
                 return self._get_percent(key)
         return 0
@@ -160,7 +159,7 @@ class GroupByResult(object):
             return self._meta['value_leaf_count']
 
         count = 0
-        for key, value in self.items():
+        for _, value in self.items():
             if isinstance(value, GroupByResult):
                 count += value.leaf_values_count(value_in_row)
             else:

--- a/tcms/settings/devel.py
+++ b/tcms/settings/devel.py
@@ -1,4 +1,7 @@
-# Django settings for devel env.
+# pylint: disable=wildcard-import, unused-wildcard-import
+"""
+    Django settings for devel env.
+"""
 
 import os
 from .product import *  # noqa: F403

--- a/tcms/settings/test/__init__.py
+++ b/tcms/settings/test/__init__.py
@@ -1,9 +1,14 @@
+# pylint: disable=wildcard-import, unused-wildcard-import
+
 import warnings
+
+from tcms.settings.devel import *  # noqa: F401,F403
+
+
 # silence resource warnings while testing, see
 # https://emptysqua.re/blog/against-resourcewarnings-in-python-3/
 warnings.simplefilter("ignore", ResourceWarning)
 
-from tcms.settings.devel import *  # noqa: F401,F403
 
 DATABASES = {
     'default': {

--- a/tcms/settings/test/mysql.py
+++ b/tcms/settings/test/mysql.py
@@ -1,3 +1,5 @@
+# pylint: disable=wildcard-import, unused-wildcard-import
+
 from tcms.settings.test import *  # noqa: F403
 
 DATABASES['default'].update({     # noqa: F405

--- a/tcms/settings/test/postgresql.py
+++ b/tcms/settings/test/postgresql.py
@@ -1,5 +1,6 @@
-from tcms.settings.test import *  # noqa: F403
+# pylint: disable=wildcard-import, unused-wildcard-import
 
+from tcms.settings.test import *  # noqa: F403
 
 DATABASES['default'].update({     # noqa: F405
     'ENGINE': 'django.db.backends.postgresql_psycopg2',


### PR DESCRIPTION
Small fixes in `tcms.settings` and its inner modules plus `tcms.core.db`. 

1. Added flag for `pylint` to ignore the wild-card imports, used by Django
2. Replaced some unused variables with `_`


