### PR TITLE
Refactor ajax.info

### DIFF
--- a/tcms/core/ajax.py
+++ b/tcms/core/ajax.py
@@ -89,14 +89,9 @@ class _InfoObjects(object):
         try:
             is_active = strtobool(self.request.GET.get('is_active', default='False'))
         except (ValueError, TypeError):
-            _is_active = False
+            is_active = False
 
-        query = {
-            'product_id': self.product_id,
-            'is_active': _is_active
-        }
-
-        return Build.list(query)
+        return Build.objects.filter(product_id=self.product_id, is_active=is_active)
 
     def categories(self):
         return Category.objects.filter(product__id=self.product_id)

--- a/tcms/core/tests/test_ajax.py
+++ b/tcms/core/tests/test_ajax.py
@@ -63,16 +63,16 @@ class TestInfo(test.TestCase):
         self.assertContains(response, '<ul>')
         self.assertContains(response, '</ul>')
 
-    def test_with_unrecognisable_infotype(self):
+    def test_with_unrecognisable_info_type(self):
         """ When a request comes with invalid info_type,
-            we expect to receive response containing the 'Unrecognizable infotype' error message
+            we expect to receive response containing the 'Unrecognizable info-type' error message
         """
 
         url = "%s?info_type=INVALID" % reverse('ajax-info')
 
         response = self.client.get(url)
 
-        self.assertContains(response, 'Unrecognizable infotype')
+        self.assertContains(response, 'Unrecognizable info-type')
 
     def test_with_json_format(self):
         """ When a request comes with info_type=categories for given product_id,

--- a/tcms/management/models.py
+++ b/tcms/management/models.py
@@ -210,27 +210,10 @@ class Build(TCMSActionModel):
         return s.serialize_queryset()
 
     @classmethod
-    def list(cls, query):
-        q = cls.objects
-
-        if query.get('build_id'):
-            q = q.filter(build_id=query['build_id'])
-        if query.get('name'):
-            q = q.filter(name=query['name'])
-        if query.get('product'):
-            q = q.filter(product=query['product'])
-        if query.get('product_id'):
-            q = q.filter(product__id=query['product_id'])
-        if query.get('is_active'):
-            q = q.filter(is_active=query['is_active'])
-
-        return q.all()
-
-    @classmethod
     def list_active(cls, query={}):
         if isinstance(query, dict):
             query['is_active'] = True
-        return cls.list(query)
+        return cls.objects.filter(**query)
 
     def __str__(self):
         return self.name


### PR DESCRIPTION
After adding tests for `ajax.info` in #268 we now have the freedom to refactor the method. This includes pulling the inner class `Objects` into outer `_InfoObjects` class (adding separate tests in the process) and refactoring the nested if logic in the`info` method itself