### PR TITLE
Added tests for TCMSLog

### DIFF
--- a/tcms/core/logs/tests.py
+++ b/tcms/core/logs/tests.py
@@ -1,1 +1,27 @@
 # -*- coding: utf-8 -*-
+
+from django import test
+
+from tcms.core.logs.views import TCMSLog
+from tcms.tests.factories import TestCaseFactory
+from tcms.tests.factories import UserFactory
+
+
+class Test_TCMSLog(test.TestCase):
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.tcms_log = TCMSLog(model=TestCaseFactory())
+        cls.user = UserFactory()
+        cls.actions = [
+            "Test TCMLog with TestCase model",
+            "Test TCMLog with TestCase model 2",
+            "Test TCMLog with TestCase model 3"]
+
+    def test_make_logs(self):
+        for action in self.actions:
+            self.tcms_log.make(self.user, action)
+
+        logged_actions = self.tcms_log.list().values('action')
+        for action in self.actions:
+            self.assertIn({'action': action}, logged_actions)


### PR DESCRIPTION
As said in #292 , `TCMSLog` lacks tests. Though the class has a lot of methods - 7 to be precise, most of them are just helper methods.  I believe that just a single test case is enough to verify 
that the logic is working, as it is a very simple one -  To log (`make` method) and to get the logs (`list` method).

Adding tests is the first step of refactoring these helper methods (making them private and simplifying some of the smelly logic inside).