### PR TITLE
Update to Python 3.6. Fixes #91

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM centos/httpd
 
 RUN rpm -Uhv https://dl.fedoraproject.org/pub/epel/7/x86_64/Packages/e/epel-release-7-11.noarch.rpm && \
     yum -y --setopt=tsflags=nodocs install centos-release-scl && \
-    yum -y --setopt=tsflags=nodocs install rh-python35 gcc mariadb-devel \
+    yum -y --setopt=tsflags=nodocs install rh-python36 gcc mariadb-devel \
     libxml2-devel libxslt-devel httpd-devel mod_wsgi mod_ssl npm && \
     yum -y update --setopt=tsflags=nodocs
 
@@ -12,11 +12,11 @@ COPY ./etc/kiwi-httpd.conf /etc/httpd/conf.d/
 # configure uploads directory
 RUN mkdir -p /var/kiwi/uploads && chown apache:apache /var/kiwi/uploads
 
-# make sure Python 3.5 is enabled by default
-ENV PATH /opt/rh/rh-python35/root/usr/bin${PATH:+:${PATH}}
-ENV LD_LIBRARY_PATH /opt/rh/rh-python35/root/usr/lib64${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
-ENV PKG_CONFIG_PATH /opt/rh/rh-python35/root/usr/lib64/pkgconfig${PKG_CONFIG_PATH:+:${PKG_CONFIG_PATH}}
-ENV XDG_DATA_DIRS "/opt/rh/rh-python35/root/usr/share:${XDG_DATA_DIRS:-/usr/local/share:/usr/share}"
+# make sure Python 3.6 is enabled by default
+ENV PATH /opt/rh/rh-python36/root/usr/bin${PATH:+:${PATH}}
+ENV LD_LIBRARY_PATH /opt/rh/rh-python36/root/usr/lib64${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+ENV PKG_CONFIG_PATH /opt/rh/rh-python36/root/usr/lib64/pkgconfig${PKG_CONFIG_PATH:+:${PKG_CONFIG_PATH}}
+ENV XDG_DATA_DIRS "/opt/rh/rh-python36/root/usr/share:${XDG_DATA_DIRS:-/usr/local/share:/usr/share}"
 
 # Create a virtualenv for the application dependencies
 RUN virtualenv /venv
@@ -31,7 +31,7 @@ ENV PATH /venv/bin:$PATH
 # Install Kiwi TCMS dependencies and replace
 # standard mod_wsgi with one compiled for Python 3
 RUN pip install --upgrade pip mod_wsgi && \
-    ln -fs /venv/lib64/python3.5/site-packages/mod_wsgi/server/mod_wsgi-py35.cpython-35m-x86_64-linux-gnu.so \
+    ln -fs /venv/lib64/python3.6/site-packages/mod_wsgi/server/mod_wsgi-py36.cpython-36m-x86_64-linux-gnu.so \
            /usr/lib64/httpd/modules/mod_wsgi.so
 
 COPY ./requirements/ /Kiwi/requirements/
@@ -48,7 +48,7 @@ RUN cd /Kiwi/ && npm install && \
     find ./node_modules -type d -empty -delete
 
 # Copy the application code to the virtual environment
-COPY ./tcms/ /venv/lib64/python3.5/site-packages/tcms/
+COPY ./tcms/ /venv/lib64/python3.6/site-packages/tcms/
 
 # collect static files
 RUN /Kiwi/manage.py collectstatic --noinput

--- a/docs/source/installing_docker.rst
+++ b/docs/source/installing_docker.rst
@@ -98,7 +98,7 @@ You can edit ``docker-compose.yml`` to mount the local file
 
         volumes:
             - uploads:/var/kiwi/uploads
-            - ./local_settings.py:/venv/lib64/python3.5/site-packages/tcms/settings/product.py
+            - ./local_settings.py:/venv/lib64/python3.6/site-packages/tcms/settings/product.py
 
 You can override any default settings in this way!
 

--- a/docs/source/set_dev_env.rst
+++ b/docs/source/set_dev_env.rst
@@ -16,14 +16,14 @@ Kiwi TCMS is a Python 3 project! On CentOS 7 this is available via
 All further instructions assume that you have Python 3 enabled. If you are using software
 collections then execute::
 
-    scl enable rh-python35 /bin/bash
+    scl enable rh-python36 /bin/bash
 
 If you are using a different Linux distribution then consult its documentation
 for more details on how to install and enable Python 3!
 
 .. note::
 
-    At the time of writing Kiwi TCMS has been tested with Python 3.5. You can always consult
+    At the time of writing Kiwi TCMS has been tested with Python 3.6. You can always consult
     ``Dockerfile`` to find out the latest version which we use!
 
 Setup virtualenv

--- a/etc/kiwi-httpd.conf
+++ b/etc/kiwi-httpd.conf
@@ -20,9 +20,9 @@ MaxClients 256
 MaxRequestsPerChild 0
 
 # Configurations for mod_wsgi
-WSGIDaemonProcess kiwitcms python-path=/venv/lib64/python3.5/site-packages:/opt/rh/rh-python35/root/usr/lib64/python3.5/site-packages
+WSGIDaemonProcess kiwitcms python-path=/venv/lib64/python3.6/site-packages:/opt/rh/rh-python36/root/usr/lib64/python3.6/site-packages
 WSGIProcessGroup kiwitcms
-WSGIScriptAlias / /venv/lib64/python3.5/site-packages/tcms/wsgi.py
+WSGIScriptAlias / /venv/lib64/python3.6/site-packages/tcms/wsgi.py
 WSGIPassAuthorization On
 
 


### PR DESCRIPTION
this is also necessary because we make use of the 'secrets'
module in the authentication backend and this module is available
only for Python 3.6!