### PR TITLE
Fix test run email notification content

### DIFF
--- a/tcms/templates/email/post_run_save/email.txt
+++ b/tcms/templates/email/post_run_save/email.txt
@@ -1,5 +1,5 @@
 {% load i18n %}
-{% blocktrans with pk=test_run.pk run_url=test_run.get_full_url plan_url=test_run.plan.get_url summary=test_run.summary manager=test_run.manager default_tester=test_run.default_tester product=test_run.product version=test_run.product_version build=test_run.build notes=test_run.notes %}
+{% blocktrans with pk=test_run.pk run_url=test_run.get_full_url plan_url=test_run.plan.get_full_url summary=test_run.summary manager=test_run.manager default_tester=test_run.default_tester product=test_run.plan.product version=test_run.product_version build=test_run.build notes=test_run.notes %}
 Test run {{ pk }} has been created or updated for you.
 
 ### Links ###


### PR DESCRIPTION
Email notifications for test runs have empty Test Plan url and
Product fields. Correct the blocktrans assignments to fix this.
Fixes #353

Signed-off-by: Matt Porter <mporter@konsulko.com>