### PR TITLE
Configure ReadTheDocs for Python 3.6

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -358,6 +358,3 @@ epub_copyright = u'2013, Red Hat, Inc.; 2017-2018, Kiwi TCMS project and its con
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {'http://docs.python.org/': None}
-
-# this is not available on RTD
-autodoc_mock_imports = ['secrets']

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,0 +1,5 @@
+build:
+    image: latest
+
+python:
+    version: 3.6

--- a/tcms/core/contrib/auth/models.py
+++ b/tcms/core/contrib/auth/models.py
@@ -1,14 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import datetime
-try:
-    import secrets
-except ImportError:
-    # note: this is *only* because RTD still runs Python 3.5
-    # which doesn't have the secrets module. This workaround makes
-    # the doc builds pass! If you try using Kiwi TCMS on Python 3.5
-    # it will still fail below b/c 'secrets' is not defined!
-    pass
+import secrets
 
 from django.db import models
 from django.conf import settings


### PR DESCRIPTION
Remove previous workarounds and add a config file.