### PR TITLE
product.py now tries to import local_settings.py

### DIFF
--- a/docs/source/installing_docker.rst
+++ b/docs/source/installing_docker.rst
@@ -65,16 +65,18 @@ You need to create the database schema by executing::
 
     docker exec -it kiwi_web /Kiwi/manage.py migrate
 
-By default the first registered account will become superuser!
-
 .. note::
+
+    By default the first registered account will become superuser!
+
+.. warning::
 
     This requires working email because the account must be activated via
     confirmation link sent to the email address defined during registration.
 
-If email is not configured or you prefer the command line use::
+    If email is not configured or you prefer the command line use::
 
-    docker exec -it kiwi_web /Kiwi/manage.py createsuperuser
+        docker exec -it kiwi_web /Kiwi/manage.py createsuperuser
 
 
 Upgrading
@@ -115,11 +117,11 @@ Customization
 -------------
 
 You can edit ``docker-compose.yml`` to mount the local file
-``local_settings.py`` inside the running Docker container as ``product.py``::
+``local_settings.py`` inside the running Docker container::
 
         volumes:
             - uploads:/var/kiwi/uploads
-            - ./local_settings.py:/venv/lib64/python3.6/site-packages/tcms/settings/product.py
+            - ./local_settings.py:/venv/lib64/python3.6/site-packages/tcms/settings/local_settings.py
 
 You can override any default settings in this way!
 

--- a/tcms/settings/product.py
+++ b/tcms/settings/product.py
@@ -8,3 +8,8 @@ from .common import *  # noqa: F401,F403
 
 # Debug settings
 DEBUG = False
+
+try:
+    from local_settings import *  # noqa: F401,F403
+except ImportError:
+    pass


### PR DESCRIPTION
downstream distributions of Kiwi TCMS (e.g. custom docker images)
only need to provide the settings they wish to override, not
duplicate everything from product.py

Documentation is updated to match.