### PR TITLE
Fixed typo in pylint disable comments

### DIFF
--- a/tcms/issuetracker/bugzilla_integration.py
+++ b/tcms/issuetracker/bugzilla_integration.py
@@ -39,6 +39,6 @@ Summary: %s""" % (self.testcase.get_full_url(), self.testcase.summary)
 
             self.rpc.update_bugs(self.bug.bug_id, {'comment': {'comment': text,
                                                                'is_private': False}})
-        except Exception as err:  # pylint: disable=broad-expect
+        except Exception as err:  # pylint: disable=broad-except
             message = '%s: %s' % (err.__class__.__name__, err)
             warnings.warn(message)

--- a/tcms/issuetracker/github_integration.py
+++ b/tcms/issuetracker/github_integration.py
@@ -43,6 +43,6 @@ URL: %s
 Summary: %s""" % (self.testcase.get_full_url(), self.testcase.summary)
 
             self.repo.get_issue(int(self.bug.bug_id)).create_comment(text)
-        except Exception as err:  # pylint: disable=broad-expect
+        except Exception as err:  # pylint: disable=broad-except
             message = '%s: %s' % (err.__class__.__name__, err)
             warnings.warn(message)

--- a/tcms/issuetracker/jira_integration.py
+++ b/tcms/issuetracker/jira_integration.py
@@ -37,6 +37,6 @@ URL: %s
 Summary: %s""" % (self.testcase.get_full_url(), self.testcase.summary)
 
             self.rpc.add_comment(self.bug.bug_id, text)
-        except Exception as err:  # pylint: disable=broad-expect
+        except Exception as err:  # pylint: disable=broad-except
             message = '%s: %s' % (err.__class__.__name__, err)
             warnings.warn(message)


### PR DESCRIPTION
It seems that three typos went unnoticed in #496 

This has got me thinking. Why don't we commit our pylint log? Or introduce some kind of hook that runs pylint and compares it to the previous version. This way, we may keep track of all the pylint errors in a centralized manner, and will easily see this kind of errors, when opening a PR. Also, currently we have no guarantee that more pylint issues won't be commited. Using some kind of checks will give us that guarantee.