### PR TITLE
Removed fmt_queries. Fixes #330

### DIFF
--- a/tcms/report/data.py
+++ b/tcms/report/data.py
@@ -547,11 +547,11 @@ class TestingReportBaseData:
     """Base data of various testing report"""
     # filter criteria is against TestCaseRun
     report_criteria = {
-        'r_product': ('build__product', lambda obj: obj.pk),
-        'r_build': ('build__in', models_to_pks),
-        'r_created_since': ('run__start_date__gte', do_nothing),
-        'r_created_before': ('run__start_date__lte', do_nothing),
-        'r_version': ('run__product_version__in', models_to_pks),
+        'product': ('build__product', lambda obj: obj.pk),
+        'build': ('build__in', models_to_pks),
+        'created_since': ('run__start_date__gte', do_nothing),
+        'created_before': ('run__start_date__lte', do_nothing),
+        'version': ('run__product_version__in', models_to_pks),
     }
 
     def _filter_query(self, form, query):
@@ -595,10 +595,10 @@ class TestingReportBaseData:
     @staticmethod
     def _get_builds(form):
         """Get selected or all product's builds for display"""
-        builds = form.cleaned_data['r_build']
+        builds = form.cleaned_data['build']
         builds_selected = len(builds) > 0
         if not builds:
-            product = form.cleaned_data['r_product']
+            product = form.cleaned_data['product']
             builds = Build.objects.filter(product=product).only('name')
         return builds, builds_selected
 
@@ -1278,11 +1278,11 @@ class TestingReportCaseRunsData:
     """
 
     run_filter_criteria = {
-        'r_product': ('run__build__product', do_nothing),
-        'r_build': ('run__build__in', models_to_pks),
-        'r_created_since': ('run__start_date__gte', do_nothing),
-        'r_created_before': ('run__start_date__lte', do_nothing),
-        'r_version': ('run__product_version__in', models_to_pks),
+        'product': ('run__build__product', do_nothing),
+        'build': ('run__build__in', models_to_pks),
+        'created_since': ('run__start_date__gte', do_nothing),
+        'created_before': ('run__start_date__lte', do_nothing),
+        'version': ('run__product_version__in', models_to_pks),
         'run': ('run__pk', do_nothing),
     }
 

--- a/tcms/report/forms.py
+++ b/tcms/report/forms.py
@@ -77,7 +77,7 @@ REPORT_TYPES = (
 class BasicTestingReportFormFields(forms.Form):
     """Testing report form with basic necessary fields"""
 
-    r_product = forms.ModelChoiceField(
+    product = forms.ModelChoiceField(
         required=True,
         label='Product',
         empty_label=None,
@@ -88,10 +88,10 @@ class BasicTestingReportFormFields(forms.Form):
             'invalid_choice': '%(value)s is not a valid product.',
         },
         widget=forms.Select(attrs={
-            'id': 'r_product',
+            'id': 'product',
         }))
 
-    r_build = forms.ModelMultipleChoiceField(
+    build = forms.ModelMultipleChoiceField(
         required=False,
         label='Build',
         queryset=Build.objects.none(),
@@ -100,11 +100,11 @@ class BasicTestingReportFormFields(forms.Form):
             'invalid_choice': 'Test build ID %s does not exist.',
         },
         widget=forms.SelectMultiple(attrs={
-            'id': 'r_build',
+            'id': 'build',
             'size': '5',
         }))
 
-    r_version = forms.ModelMultipleChoiceField(
+    version = forms.ModelMultipleChoiceField(
         required=False,
         label='Version',
         queryset=Version.objects.none(),
@@ -113,11 +113,11 @@ class BasicTestingReportFormFields(forms.Form):
             'invalid_pk_value': '%s is not a valid version ID.',
         },
         widget=forms.SelectMultiple(attrs={
-            'id': 'r_version',
+            'id': 'version',
             'size': '5',
         }))
 
-    r_created_since = forms.DateField(
+    created_since = forms.DateField(
         required=False,
         input_formats=['%Y-%m-%d'],
         error_messages={
@@ -125,12 +125,12 @@ class BasicTestingReportFormFields(forms.Form):
                        ' is YYYY-MM-DD.',
         },
         widget=forms.TextInput(attrs={
-            'id': 'r_created_since',
+            'id': 'created_since',
             'style': 'width:130px;',
             'class': 'vDateField',
         }))
 
-    r_created_before = forms.DateField(
+    created_before = forms.DateField(
         required=False,
         input_formats=['%Y-%m-%d'],
         error_messages={
@@ -138,20 +138,20 @@ class BasicTestingReportFormFields(forms.Form):
                        'is YYYY-MM-DD.',
         },
         widget=forms.TextInput(attrs={
-            'id': 'r_created_before',
+            'id': 'created_before',
             'style': 'width:130px;',
             'class': 'vDateField',
         }))
 
     def populate(self, product_id):
         if product_id:
-            self.fields['r_build'].queryset = Build.objects.filter(
+            self.fields['build'].queryset = Build.objects.filter(
                 product=product_id).only('name')
-            self.fields['r_version'].queryset = Version.objects.filter(
+            self.fields['version'].queryset = Version.objects.filter(
                 product=product_id).only('value')
         else:
-            self.fields['r_build'].queryset = Build.objects.none()
-            self.fields['r_version'].queryset = Version.objects.none()
+            self.fields['build'].queryset = Build.objects.none()
+            self.fields['version'].queryset = Version.objects.none()
 
 
 class TestingReportCaseRunsListForm(BasicTestingReportFormFields):

--- a/tcms/report/tests.py
+++ b/tcms/report/tests.py
@@ -55,7 +55,7 @@ class TestingReportTestCase(test.TestCase):
 
         url = reverse('testing-report')
         response = self.client.get(url, {
-            'r_product': run.plan.product.pk,
+            'product': run.plan.product.pk,
             'report_type': 'per_build_report'
         })
 

--- a/tcms/report/views.py
+++ b/tcms/report/views.py
@@ -26,7 +26,7 @@ from tcms.report.data import TestingReportByPlanTagsData
 from tcms.report.data import TestingReportByPlanTagsDetailData
 from tcms.report.data import TestingReportCaseRunsData
 from tcms.report.forms import CustomSearchForm
-from tcms.search import fmt_queries, remove_from_request_path
+from tcms.search import remove_from_request_path
 
 from .forms import CustomSearchDetailsForm
 
@@ -468,7 +468,7 @@ class TestingReportBase(TemplateView):
     form_class = TestingReportForm
 
     def _get_form(self, data=None):
-        product_id = self.request.GET.get('r_product')
+        product_id = self.request.GET.get('product')
         if data is not None:
             form = self.form_class(data)
         else:
@@ -491,37 +491,31 @@ class TestingReportBase(TemplateView):
     def _report_context(self):
         errors = None
         report_data = None
-        queries = self.request.GET
 
-        if queries:
+        if self.request.GET:
             form = self._get_form(self.request.GET)
 
             if form.is_valid():
-                queries = form.cleaned_data
                 report_data = self.get_report_data(form)
             else:
                 errors = form.errors
 
-        queries = fmt_queries(queries)
-        del queries['report type']
         request_path = remove_from_request_path(self.request, 'report_type')
 
         data = {
             'errors': errors,
-            'queries': queries,
             'request_path': request_path,
             'run_form': form,
             'report_data': report_data,
         }
 
         if request_path:
-            data['path_without_build'] = remove_from_request_path(request_path,
-                                                                  'r_build')
+            data['path_without_build'] = remove_from_request_path(request_path, 'build')
 
         return data
 
     def get_context_data(self, **kwargs):
-        data = super(TestingReportBase, self).get_context_data(**kwargs)
+        data = super().get_context_data(**kwargs)
 
         if 'report_type' not in self.request.GET:
             context = self._init_context()

--- a/tcms/search/__init__.py
+++ b/tcms/search/__init__.py
@@ -1,4 +1,3 @@
-from django.db.models.query import QuerySet
 from django.http import HttpRequest
 
 
@@ -23,35 +22,3 @@ def remove_from_request_path(request, name):
 
     path = '&'.join(path)
     return '?' + path
-
-
-def fmt_queries(*queries):
-    """
-    Format the queries string.
-    """
-    results = {}
-    for _query in queries:
-        for key, value in _query.items():
-            key = replace_keys(key)
-            if isinstance(value, bool) or value:
-                if isinstance(value, QuerySet):
-                    try:
-                        value = ', '.join(o.name for o in value)
-                    except AttributeError:
-                        try:
-                            value = ', '.join(o.value for o in value)
-                        except AttributeError:
-                            value = ', '.join(value)
-                if isinstance(value, list):
-                    value = ', '.join(map(str, value))
-                results[key] = value
-    return results
-
-
-def replace_keys(key):
-    key = key.replace('p_product', 'product')
-    key = key.replace('p_', 'product ')
-    key = key.replace('cs_', 'case ')
-    key = key.replace('pl_', 'plan ')
-    key = key.replace('r_', 'run ')
-    return key.replace('_', ' ')

--- a/tcms/static/js/advance_search.js
+++ b/tcms/static/js/advance_search.js
@@ -66,10 +66,10 @@ jQ(function() {
 
 jQ(function() {
   // product select on change event binding
-  updateOptionOnProdChange('version', 'pl_product', 'pl_version');
-  updateOptionOnProdChange('version', 'r_product','r_version');
-  updateOptionOnProdChange('build', 'r_product', 'r_build');
-  updateOptionOnProdChange('component', 'pl_product', 'pl_component');
-  updateOptionOnProdChange('component', 'cs_product', 'cs_component');
-  updateOptionOnProdChange('category', 'cs_product', 'cs_category');
+  updateOptionOnProdChange('version', 'product', 'version');
+  updateOptionOnProdChange('version', 'product','version');
+  updateOptionOnProdChange('build', 'product', 'build');
+  updateOptionOnProdChange('component', 'product', 'component');
+  updateOptionOnProdChange('component', 'product', 'component');
+  updateOptionOnProdChange('category', 'product', 'category');
 });

--- a/tcms/templates/report/common/search_run.html
+++ b/tcms/templates/report/common/search_run.html
@@ -17,29 +17,29 @@
 		<div class="leftlistinfo">
 			<div class="listinfo">
 				<div class="title"><label for="id_name">Product&nbsp;:</label></div>
-				<div class="listinfo_input">{{ run_form.r_product }}</div>
+				<div class="listinfo_input">{{ run_form.product }}</div>
 			</div>
 			<div class="listinfo">
-				<div class="title"><label for="r_build">Build&nbsp;:</label></div>
-				<div class="listinfo_input">{{ run_form.r_build }}</div>
+				<div class="title"><label for="build">Build&nbsp;:</label></div>
+				<div class="listinfo_input">{{ run_form.build }}</div>
 			</div>
 			<div class="listinfo">
 				<div class="title"><label for="id_name">Execute Date&nbsp;:</label></div>
 				<div class="listinfo_input">
-					{{ run_form.r_created_since }}
+					{{ run_form.created_since }}
 				</div>
 			</div>
 			<div class="listinfo">
 				<div class="title"></div>
 				<div class="listinfo_input">
-					{{ run_form.r_created_before }}
+					{{ run_form.created_before }}
 				</div>
 			</div>
 		</div>
 		<div class="rightlistinfo">
 			<div class="listinfo">
-				<div class="title"><label for="r_version">Version&nbsp;:</label></div>
-				<div class="listinfo_input">{{ run_form.r_version }}</div>
+				<div class="title"><label for="version">Version&nbsp;:</label></div>
+				<div class="listinfo_input">{{ run_form.version }}</div>
 			</div>
 		</div>
 		<div class="clear"></div>

--- a/tcms/templates/report/testing-report/by_plan_build_with_rates.html
+++ b/tcms/templates/report/testing-report/by_plan_build_with_rates.html
@@ -1,17 +1,6 @@
 {% extends "report/common/search_run.html" %}
 {% block report %}
 {% if report_data %}
-	{% if queries %}
-	<div class="queries">
-		<ul>
-		{% for k, v in queries.items %}
-			<li><label>{{ k|title }}:</label>{{ v|safe }};</li>
-		{% endfor %}
-			<li class="clear"></li>
-		</ul>
-	</div>
-	{% endif %}
-
 	<div class="reportSummary01">
 		<ul>
 			<li class="tagTab">

--- a/tcms/templates/report/testing-report/by_plan_tag_with_rates.html
+++ b/tcms/templates/report/testing-report/by_plan_tag_with_rates.html
@@ -2,17 +2,6 @@
 
 {% block report %}
 {% if report_data %}
-	{% if queries %}
-	<div class="queries">
-		<ul>
-		{% for k, v in queries.items %}
-			<li><label>{{ k|title }}:</label>{{ v|safe }};</li>
-		{% endfor %}
-			<li class="clear"></li>
-		</ul>
-	</div>
-	{% endif %}
-
 	<div class="reportSummary01">
 		<ul>
 			<li class="tagTab">

--- a/tcms/templates/report/testing-report/per_build_report.html
+++ b/tcms/templates/report/testing-report/per_build_report.html
@@ -2,23 +2,6 @@
 
 {% block report %}
 {% if report_data %}
-	{% if queries %}
-	<div class="queries">
-		<ul>
-			{% for k, v in queries.items %}
-			<li><label>{{ k|title }}:</label>{{ v|safe }};</li>
-			{% endfor %}
-			{% if not report_data.builds_selected %}
-			<li>
-				<label>Builds:</label>
-				{% for b in report_data.builds %}{{ b }}, {% endfor %}
-			</li>
-			{% endif %}
-			<li class="clear"></li>
-		</ul>
-	</div>
-	{% endif %}
-
 	<div class="reportSummary01">
 		<ul><li class="tagTab">Tester:<span>All Testers</span></li></ul>
 		<ul>

--- a/tcms/templates/report/testing-report/per_plan_build.html
+++ b/tcms/templates/report/testing-report/per_plan_build.html
@@ -1,17 +1,6 @@
 {% extends "report/common/search_run.html" %}
 {% block report %}
 {% if report_data %}
-	{% if queries %}
-	<div class="queries">
-		<ul>
-		{% for k, v in queries.items %}
-			<li><label>{{ k|title }}:</label>{{ v|safe }};</li>
-		{% endfor %}
-			<li class="clear"></li>
-		</ul>
-	</div>
-	{% endif %}
-
 	<div class="reportSummary01">
 		<ul>
 			<li>

--- a/tcms/templates/report/testing-report/per_plan_tag.html
+++ b/tcms/templates/report/testing-report/per_plan_tag.html
@@ -1,17 +1,6 @@
 {% extends "report/common/search_run.html" %}
 {% block report %}
 {% if report_data %}
-	{% if queries %}
-	<div class="queries">
-		<ul>
-		{% for k, v in queries.items %}
-			<li><label>{{ k|title }}:</label>{{ v|safe }};</li>
-		{% endfor %}
-			<li class="clear"></li>
-		</ul>
-	</div>
-	{% endif %}
-
 	<div class="reportSummary01">
 		<ul>
 			<li>

--- a/tcms/templates/report/testing-report/per_priority_report.html
+++ b/tcms/templates/report/testing-report/per_priority_report.html
@@ -3,17 +3,6 @@
 
 {% block report %}
 {% if report_data %}
-	{% if queries %}
-	<div class="queries">
-		<ul>
-		{% for k, v in queries.items %}
-			<li><label>{{ k|title }}:</label>{{ v|safe }};</li>
-		{% endfor %}
-			<li class="clear"></li>
-		</ul>
-	</div>
-	{% endif %}
-
 	<div class="reportSummary01">
 		<ul><li class="tagTab">Tester:<span>All Testers</span></li></ul>
 		<ul>


### PR DESCRIPTION
This removes the obsolete `fmt_queries` method. What it did, is replace some of the keys of the `queries` object. These keys are later exposed on the front-end, so after this change, we will be exposing the keys as they are. This may be a bit ugly at the beginning, but this problem may be solved by refactoring the templates in general.