### PR TITLE
Hot-fix for error caused by TestRun.update via API

### DIFF
--- a/tcms/xmlrpc/api/testrun.py
+++ b/tcms/xmlrpc/api/testrun.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from datetime import datetime
-
 from modernrpc.core import rpc_method, REQUEST_KEY
 
 from tcms.core.utils import form_errors_to_list
@@ -257,11 +255,12 @@ def _get_updated_test_run(run_id, values, form):
         if form.cleaned_data['notes']:
             test_run.notes = form.cleaned_data['notes']
 
-    test_run.stop_date = None
+    # todo: form doesn't allow stop_date to be updated
+    # test_run.stop_date = None
 
-    if isinstance(form.cleaned_data['status'], int) and \
-       form.cleaned_data['status']:
-        test_run.stop_date = datetime.now()
+    # if isinstance(form.cleaned_data['status'], int) and \
+    #   form.cleaned_data['status']:
+    #    test_run.stop_date = datetime.now()
 
     test_run.save()
     return test_run


### PR DESCRIPTION
The code that works with status field is broken and it must instead
work with stop_date field. This patch makes it possible to at least
use the API without crashing.

reported in:
https://stackoverflow.com/questions/52865463/xmlrpc-client-fault-when-calling-testrun-update