### PR TITLE
Fix TestRun.update API not processing stop_date

### DIFF
--- a/tcms/testruns/forms.py
+++ b/tcms/testruns/forms.py
@@ -72,6 +72,13 @@ class XMLRPCUpdateRunForm(XMLRPCNewRunForm):
         queryset=Build.objects.all(),
         required=False
     )
+    stop_date = forms.DateTimeField(
+        required=False,
+        input_formats=['%Y-%m-%d'],
+        error_messages={
+            'invalid': 'The stop date is invalid. The valid format is YYYY-MM-DD.'
+        }
+    )
 
     def clean_status(self):
         return self.cleaned_data.get('status')

--- a/tcms/testruns/forms.py
+++ b/tcms/testruns/forms.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from django import forms
 from django.contrib.auth.models import User
+from django.utils.translation import ugettext_lazy as _
 
 from tcms.core.utils import string_to_list
 from tcms.core.forms.fields import UserField
@@ -76,7 +77,7 @@ class XMLRPCUpdateRunForm(XMLRPCNewRunForm):
         required=False,
         input_formats=['%Y-%m-%d'],
         error_messages={
-            'invalid': 'The stop date is invalid. The valid format is YYYY-MM-DD.'
+            'invalid': _('The stop date is invalid. The valid format is YYYY-MM-DD.')
         }
     )
 


### PR DESCRIPTION
This PR fixes #554 . Also,I have added an test for successful update. @atodorov do tell if you think I need to add more test cases. 

On a side note, I am thinking of opening an issue about renaming all of the classes and methods that cointain `XMLRPC`, to something more generic, because now we have JSON-RPC API as well, and the same methods are used by it, so their names are a bit misleading. Do you think this kind of change in necessary?