### PR TITLE
Minor pylint fixes for tests

### DIFF
--- a/tcms/report/views.py
+++ b/tcms/report/views.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# pylint: disable=too-many-ancestors
 
 from django.core.exceptions import ObjectDoesNotExist
 from django.urls import reverse

--- a/tcms/testplans/tests/test_views.py
+++ b/tcms/testplans/tests/test_views.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# pylint: disable=too-many-ancestors
 
 from http import HTTPStatus
 

--- a/tcms/testruns/tests/test_data.py
+++ b/tcms/testruns/tests/test_data.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# pylint: disable=invalid-name
+# pylint: disable=invalid-name, too-many-ancestors
 
 from datetime import datetime
 

--- a/tcms/testruns/tests/test_models.py
+++ b/tcms/testruns/tests/test_models.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# pylint: disable=too-many-ancestors
 
 from mock import patch
 

--- a/tcms/testruns/tests/test_report_view.py
+++ b/tcms/testruns/tests/test_report_view.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# pylint: disable=invalid-name
+# pylint: disable=invalid-name, too-many-ancestors
 
 from http import HTTPStatus
 from django.urls import reverse

--- a/tcms/testruns/tests/test_update_caserun_status_view.py
+++ b/tcms/testruns/tests/test_update_caserun_status_view.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# pylint: too-many-ancestors
 
 from datetime import datetime
 

--- a/tcms/testruns/tests/test_views.py
+++ b/tcms/testruns/tests/test_views.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# pylint: disable=invalid-name
+# pylint: disable=invalid-name, too-many-ancestors
 
 from http import HTTPStatus
 


### PR DESCRIPTION
The `too-many-ancestors` warning was displayed many times for different test classes - there we have a lot inheritance. The maximum `pylint` allows is 8. We can override it with a `.pylintrc` file, but since all of them were in tests, I suggest we disable it inline. This way it would still be valid for the business logic, where it may come handy.

Another minor fix - disabled `no-member` warning for `test_run.cc.count` - `test_run` is created through calling `TestRunFactory()`. `TestRunFactory` has a method `cc` and `TestRun` has a member `cc` (which has `.count()`). However, `pylint` thinks `test_run` is a `TestRunFactory` instance and `test_run.cc` is a reference to the method, which has no `.count()`. Clearly, `pylint` is wrong and that is why we silence it.