### PR TITLE
Remove unused parameter from plan_from_request_or_none. Refs #303

### DIFF
--- a/tcms/testcases/views.py
+++ b/tcms/testcases/views.py
@@ -48,26 +48,15 @@ TESTCASE_OPERATION_ACTIONS = (
 # helper functions
 
 
-def plan_from_request_or_none(request, pk_enough=False):
+def plan_from_request_or_none(request):
     """Get TestPlan from REQUEST
 
     This method relies on the existence of from_plan within REQUEST.
-
-    Arguments:
-    - pk_enough: a choice for invoker to determine whether the ID is enough.
     """
     test_plan_id = request.POST.get("from_plan") or request.GET.get("from_plan")
-    if test_plan_id:
-        if pk_enough:
-            try:
-                test_plan = int(test_plan_id)
-            except ValueError:
-                test_plan = None
-        else:
-            test_plan = get_object_or_404(TestPlan, plan_id=test_plan_id)
-    else:
-        test_plan = None
-    return test_plan
+    if not test_plan_id:
+        return None
+    return get_object_or_404(TestPlan, plan_id=test_plan_id)
 
 
 def update_case_email_settings(test_case, n_form):


### PR DESCRIPTION
Browsing through old issues I have created I found this one. Then, when looking for the method calls I saw that we are no longer passing the optional `pk_enough` param. IMO this is the most that can be done for this method as of now.