### PR TITLE
Remove left-over js from deletion of plan/new.html

### DIFF
--- a/tcms/static/js/tcms_actions.js
+++ b/tcms/static/js/tcms_actions.js
@@ -454,30 +454,6 @@ var reloadWindow = function(t) {
   window.location.reload(true);
 };
 
-// Enhanced from showAddAnotherPopup in RelatedObjectLookups.js for Admin
-// todo: this duplicates existing functionality in admin/grappelli in the
-// above mentioned JS files. Needs to be refactored.
-function popupAddAnotherWindow(triggeringLink, parameters) {
-  var name = triggeringLink.id.replace(/^add_/, '');
-  name = id_to_windowname(name);
-  href = triggeringLink.href;
-  if (href.indexOf('?') === -1) {
-    href += '?_popup=1';
-  } else {
-    href += '&_popup=1';
-  }
-
-  // IMPOROMENT: Add parameters.
-  // FIXME: Add multiple parameters here
-  if (parameters) {
-    href += '&' + parameters + '=' + jQ('#id_' + parameters).val();
-  }
-
-  var win = window.open(href, name, 'height=500,width=800,resizable=yes,scrollbars=no');
-  win.focus();
-  return false;
-}
-
 function printableCases(url, form, table) {
   var selection = serializeCaseFromInputList2(table);
   var emptySelection = !selection.selectAll & selection.selectedCasesIds.length === 0;

--- a/tcms/static/js/testplan_actions.js
+++ b/tcms/static/js/testplan_actions.js
@@ -1,5 +1,4 @@
 Nitrate.TestPlans = {};
-Nitrate.TestPlans.Create = {};
 Nitrate.TestPlans.Details = {};
 Nitrate.TestPlans.Edit = {};
 Nitrate.TestPlans.SearchCase = {};
@@ -261,22 +260,6 @@ function configure_product_on_load() {
         update_version_select_from_product($(this), '#id_product_version')
     });
 }
-
-Nitrate.TestPlans.Create.on_load = function() {
-    configure_product_on_load();
-    update_version_select_from_product($('#id_product'), '#id_product_version')
-
-
-  jQ('#add_id_product').bind('click', function() {
-    return popupAddAnotherWindow(this);
-  });
-  jQ('#add_id_product_version').bind('click', function() {
-    return popupAddAnotherWindow(this, 'product');
-  });
-  jQ('.js-cancel-button').bind('click', function() {
-    window.history.back();
-  });
-};
 
 Nitrate.TestPlans.Edit.on_load = function() {
     configure_product_on_load();


### PR DESCRIPTION
The purpose of this PR is to clear the left-overs from #636 

After examining the JS files, used by the existing template I found out that these two ids - `add_id_product` and `add_id_product_version` have `onclick` handlers, but are not present in any other files. Therefore, the existing handlers are never used anymore. Also, the custom `popupAddAnotherWindow` was used only by these handlers, so I had to remove that too. The `js-cancel-button` is used in `plan/clone.html`, so we cannot yet remove it.