### PR TITLE
Form fields removal and form merges

### DIFF
--- a/docs/source/modules/tcms.xmlrpc.api.forms.rst
+++ b/docs/source/modules/tcms.xmlrpc.api.forms.rst
@@ -1,0 +1,15 @@
+tcms.xmlrpc.api.forms package
+=============================
+
+.. automodule:: tcms.xmlrpc.api.forms
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+Submodules
+----------
+
+.. toctree::
+
+   tcms.xmlrpc.api.forms.testplan
+

--- a/docs/source/modules/tcms.xmlrpc.api.forms.testplan.rst
+++ b/docs/source/modules/tcms.xmlrpc.api.forms.testplan.rst
@@ -1,0 +1,7 @@
+tcms.xmlrpc.api.forms.testplan module
+=====================================
+
+.. automodule:: tcms.xmlrpc.api.forms.testplan
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/tcms/testplans/forms.py
+++ b/tcms/testplans/forms.py
@@ -3,7 +3,7 @@ from django import forms
 
 from tcms.core.widgets import SimpleMDE
 from tcms.core.utils import string_to_list
-from tcms.core.forms.fields import UserField, StripURLField
+from tcms.core.forms.fields import StripURLField
 from tcms.management.models import Product, Version
 from .models import TestPlan, PlanType
 
@@ -58,6 +58,7 @@ class BasePlanForm(forms.Form):
 
 
 class NewPlanForm(BasePlanForm):
+
     auto_to_plan_author = forms.BooleanField(
         initial=True,
         required=False
@@ -79,10 +80,6 @@ class NewPlanForm(BasePlanForm):
         required=False
     )
     is_active = forms.BooleanField(required=False, initial=True)
-
-
-class EditPlanForm(NewPlanForm):
-    author = UserField(required=False)
 
 
 # =========== Forms for search/filter ==============
@@ -191,11 +188,11 @@ class ClonePlanForm(BasePlanForm):
 # =========== Forms for XML-RPC functions ==============
 
 
-class XMLRPCNewPlanForm(EditPlanForm):
+class XMLRPCNewPlanForm(NewPlanForm):
     text = forms.CharField()
 
 
-class XMLRPCEditPlanForm(EditPlanForm):
+class XMLRPCEditPlanForm(NewPlanForm):
     name = forms.CharField(
         label="Plan name", required=False
     )

--- a/tcms/testplans/forms.py
+++ b/tcms/testplans/forms.py
@@ -4,7 +4,7 @@ from django import forms
 from tcms.core.widgets import SimpleMDE
 from tcms.core.utils import string_to_list
 from tcms.core.forms.fields import UserField, StripURLField
-from tcms.management.models import Product, Version, Tag
+from tcms.management.models import Product, Version
 from .models import TestPlan, PlanType
 
 
@@ -58,8 +58,6 @@ class BasePlanForm(forms.Form):
 
 
 class NewPlanForm(BasePlanForm):
-    tag = forms.CharField(required=False)
-
     auto_to_plan_author = forms.BooleanField(
         initial=True,
         required=False
@@ -81,11 +79,6 @@ class NewPlanForm(BasePlanForm):
         required=False
     )
     is_active = forms.BooleanField(required=False, initial=True)
-
-    def clean_tag(self):
-        return Tag.objects.filter(
-            name__in=string_to_list(self.cleaned_data['tag'])
-        )
 
 
 class EditPlanForm(NewPlanForm):

--- a/tcms/testplans/forms.py
+++ b/tcms/testplans/forms.py
@@ -183,31 +183,3 @@ class ClonePlanForm(BasePlanForm):
                   'plan.',
         required=False
     )
-
-
-# =========== Forms for XML-RPC functions ==============
-
-
-class XMLRPCNewPlanForm(NewPlanForm):
-    text = forms.CharField()
-
-
-class XMLRPCEditPlanForm(NewPlanForm):
-    name = forms.CharField(
-        label="Plan name", required=False
-    )
-    type = forms.ModelChoiceField(
-        label="Type",
-        queryset=PlanType.objects.all(),
-        required=False
-    )
-    product = forms.ModelChoiceField(
-        label="Product",
-        queryset=Product.objects.all(),
-        required=False,
-    )
-    product_version = forms.ModelChoiceField(
-        label="Product Version",
-        queryset=Version.objects.none(),
-        required=False
-    )

--- a/tcms/testplans/views.py
+++ b/tcms/testplans/views.py
@@ -27,7 +27,6 @@ from tcms.testcases.models import TestCase, TestCasePlan
 from tcms.testcases.views import get_selected_testcases
 from tcms.testcases.views import printable as testcases_printable
 from tcms.testplans.forms import ClonePlanForm
-from tcms.testplans.forms import EditPlanForm
 from tcms.testplans.forms import NewPlanForm
 from tcms.testplans.forms import SearchPlanForm
 from tcms.testplans.models import TestPlan, PlanType
@@ -290,7 +289,7 @@ def edit(request, plan_id):
 
     # If the form is submitted
     if request.method == "POST":
-        form = EditPlanForm(request.POST)
+        form = NewPlanForm(request.POST)
         form.populate(product_id=request.POST.get('product'))
 
         # FIXME: Error handle
@@ -316,7 +315,7 @@ def edit(request, plan_id):
             return HttpResponseRedirect(
                 reverse('test_plan_url', args=[plan_id, slugify(test_plan.name)]))
     else:
-        form = EditPlanForm(initial={
+        form = NewPlanForm(initial={
             'name': test_plan.name,
             'product': test_plan.product_id,
             'product_version': test_plan.product_version_id,

--- a/tcms/xmlrpc/api/forms/testplan.py
+++ b/tcms/xmlrpc/api/forms/testplan.py
@@ -1,0 +1,31 @@
+from django.forms import BooleanField, CharField, ModelChoiceField
+
+from tcms.management.models import Product, Version
+from tcms.testplans import forms as testplan_forms
+from tcms.testplans.models import PlanType
+from tcms.xmlrpc.forms import XMLRPCCheckboxInput
+
+
+class NewPlanForm(testplan_forms.NewPlanForm):
+    is_active = BooleanField(
+        required=False,
+        widget=XMLRPCCheckboxInput
+    )
+
+
+class EditPlanForm(NewPlanForm):
+    name = CharField(
+        required=False
+    )
+    type = ModelChoiceField(
+        queryset=PlanType.objects.all(),
+        required=False
+    )
+    product = ModelChoiceField(
+        queryset=Product.objects.all(),
+        required=False,
+    )
+    product_version = ModelChoiceField(
+        queryset=Version.objects.none(),
+        required=False
+    )

--- a/tcms/xmlrpc/api/testplan.py
+++ b/tcms/xmlrpc/api/testplan.py
@@ -7,7 +7,7 @@ from tcms.management.models import Tag
 from tcms.testplans.models import TestPlan
 from tcms.testcases.models import TestCase, TestCasePlan
 
-from tcms.xmlrpc.forms import EditPlanForm, NewPlanForm
+from tcms.xmlrpc.api.forms.testplan import EditPlanForm, NewPlanForm
 from tcms.xmlrpc.decorators import permissions_required
 
 __all__ = (

--- a/tcms/xmlrpc/forms.py
+++ b/tcms/xmlrpc/forms.py
@@ -1,13 +1,10 @@
 # -*- coding: utf-8 -*-
 
-from django.forms import BooleanField, CharField, ModelChoiceField
+from django.forms import BooleanField
 from django.forms.widgets import CheckboxInput
 
-from tcms.management.models import Product, Version
 from tcms.testcases.forms import XMLRPCNewCaseForm
 from tcms.testcases.forms import XMLRPCUpdateCaseForm
-from tcms.testplans.forms import NewPlanForm
-from tcms.testplans.models import PlanType
 from tcms.xmlrpc.utils import parse_bool_value
 
 
@@ -29,32 +26,3 @@ class UpdateCaseForm(XMLRPCUpdateCaseForm):
     is_automated_proposed = BooleanField(label='Autoproposed',
                                          required=False,
                                          widget=XMLRPCCheckboxInput)
-
-
-class BasePlanForm(NewPlanForm):
-    is_active = BooleanField(
-        required=False,
-        widget=XMLRPCCheckboxInput
-    )
-
-
-class NewPlanForm(BasePlanForm):
-    text = CharField()
-
-
-class EditPlanForm(BasePlanForm):
-    name = CharField(
-        required=False
-    )
-    type = ModelChoiceField(
-        queryset=PlanType.objects.all(),
-        required=False
-    )
-    product = ModelChoiceField(
-        queryset=Product.objects.all(),
-        required=False,
-    )
-    product_version = ModelChoiceField(
-        queryset=Version.objects.none(),
-        required=False
-    )

--- a/tcms/xmlrpc/forms.py
+++ b/tcms/xmlrpc/forms.py
@@ -1,12 +1,13 @@
 # -*- coding: utf-8 -*-
 
-from django.forms import BooleanField
+from django.forms import BooleanField, CharField, ModelChoiceField
 from django.forms.widgets import CheckboxInput
 
+from tcms.management.models import Product, Version
 from tcms.testcases.forms import XMLRPCNewCaseForm
 from tcms.testcases.forms import XMLRPCUpdateCaseForm
-from tcms.testplans.forms import XMLRPCNewPlanForm
-from tcms.testplans.forms import XMLRPCEditPlanForm
+from tcms.testplans.forms import NewPlanForm
+from tcms.testplans.models import PlanType
 from tcms.xmlrpc.utils import parse_bool_value
 
 
@@ -30,11 +31,34 @@ class UpdateCaseForm(XMLRPCUpdateCaseForm):
                                          widget=XMLRPCCheckboxInput)
 
 
-class NewPlanForm(XMLRPCNewPlanForm):
-    is_active = BooleanField(label="Active", required=False,
-                             widget=XMLRPCCheckboxInput)
+class BasePlanForm(NewPlanForm):
+    is_active = BooleanField(
+        label="Active",
+        required=False,
+        widget=XMLRPCCheckboxInput
+    )
 
 
-class EditPlanForm(XMLRPCEditPlanForm):
-    is_active = BooleanField(label="Active", required=False,
-                             widget=XMLRPCCheckboxInput)
+class NewPlanForm(BasePlanForm):
+    text = CharField()
+
+
+class EditPlanForm(BasePlanForm):
+    name = CharField(
+        label="Plan name", required=False
+    )
+    type = ModelChoiceField(
+        label="Type",
+        queryset=PlanType.objects.all(),
+        required=False
+    )
+    product = ModelChoiceField(
+        label="Product",
+        queryset=Product.objects.all(),
+        required=False,
+    )
+    product_version = ModelChoiceField(
+        label="Product Version",
+        queryset=Version.objects.none(),
+        required=False
+    )

--- a/tcms/xmlrpc/forms.py
+++ b/tcms/xmlrpc/forms.py
@@ -33,7 +33,6 @@ class UpdateCaseForm(XMLRPCUpdateCaseForm):
 
 class BasePlanForm(NewPlanForm):
     is_active = BooleanField(
-        label="Active",
         required=False,
         widget=XMLRPCCheckboxInput
     )
@@ -45,20 +44,17 @@ class NewPlanForm(BasePlanForm):
 
 class EditPlanForm(BasePlanForm):
     name = CharField(
-        label="Plan name", required=False
+        required=False
     )
     type = ModelChoiceField(
-        label="Type",
         queryset=PlanType.objects.all(),
         required=False
     )
     product = ModelChoiceField(
-        label="Product",
         queryset=Product.objects.all(),
         required=False,
     )
     product_version = ModelChoiceField(
-        label="Product Version",
         queryset=Version.objects.none(),
         required=False
     )


### PR DESCRIPTION
As discussed in #677 

> delete NewPlanForm.tag and EditPlanForm.author since they are not used

DONE


> delete classes that are not used, but are only inherited once - XMLRPCNewPlanForm,XMLRPCEditPlanForm
copy the fields from these intermediate classes inside the ones found under xmlrpc/forms.py
remove the intermediate classes

DONE - The forms were removed and their field were put into their respective anchestors

>under xmlrpc/ better organize the forms into smaller groups, e.g. xmrpc/api/forms/testplan.py or similar and update the imports in the API modules.

DONE

> investigate all of the above form classes for unused fields
this is part of the change above (separate commits for everything) and you should be careful for:
Some of these fields are not properly covered by tests and my approach in the rare event I had removed some was to inspect every field one by one, inspect what tests are there (and what is validated inside of them) and then manually try both the UI and the API to make sure it all works.
all of these inherited forms redefine class fields and from what I've seen in practice many times there are duplicates. The only reason for redefining some field is if you want to make it required/not required or change some defaults, etc. which will be different between webUI and RPC. There's no other reason for these redefined fields to exist.

There are predefined fields, but there is a reason for that - in the RPC* forms all of the fields are not required, while in the regular forms all of them are. It looks like we can't remove any more code for these respecitve forms. Also all of the fields in RPC forms are used in their respective controllers, again, nothing we can delete

>move all of the RPC* classes to rpc package
Not now, open a separate issue for this. This is a rather big change which needs to be planned and accounted for. I would rather spend the time to refactor these as described above instead of just moving the around.

#681

>rename all XMLRPC* to RPC*
This is renaming only and making sure everything matches. We can rename the module itself easily but I prefer to update the classes and functions one-by-one to avoid massive changes.

>However the naming is only due to historical reasons and you are welcome to implement a pylint checker that will warn us about bogus names (and also drive the rename/refactor effort). Again new issue so we can plan this.

 #682
