### PR TITLE
Surround selectpicker call with try-catch. Fixes #695

### DIFF
--- a/tcms/static/js/utils.js
+++ b/tcms/static/js/utils.js
@@ -16,7 +16,12 @@ function updateSelect(data, selector, id_attr, value_attr) {
     });
 
     _select_tag.innerHTML = new_options;
-    $(selector).selectpicker('refresh');
+
+    try {
+        $(selector).selectpicker('refresh');
+    } catch(e) {
+        console.warn(e);
+    }
 }
 
 


### PR DESCRIPTION
A temporary workaround until this template is refactored
into Patternfly, when bootstrap-switch can be used,
and the following js code will work