### PR TITLE
Convert New TestCase page to Patternfly 

### DIFF
--- a/tcms/locale/de_DE/LC_MESSAGES/django.po
+++ b/tcms/locale/de_DE/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: kiwitcms\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-01-24 21:57+0000\n"
+"POT-Creation-Date: 2019-01-26 10:28+0000\n"
 "PO-Revision-Date: 2019-01-16 11:47\n"
 "Last-Translator: atodorov <atodorov@otb.bg>\n"
 "Language-Team: German\n"
@@ -26,9 +26,9 @@ msgid "Core customized comments"
 msgstr "Basis angepasste Kommentare"
 
 #: tcms/core/contrib/comments/forms.py:14
-#: tcms/testcases/templates/testcases/get.html:327
-#: tcms/testcases/templates/testcases/get.html:353
-#: tcms/testcases/templates/testcases/get.html:390
+#: tcms/testcases/templates/testcases/get.html:311
+#: tcms/testcases/templates/testcases/get.html:337
+#: tcms/testcases/templates/testcases/get.html:374
 #: tcms/testplans/templates/testplans/mutable.html:23
 #: tcms/testplans/templates/testplans/search.html:11
 msgid "Name"
@@ -53,16 +53,21 @@ msgstr ""
 
 #: tcms/core/history.py:47
 #, python-format
-msgid "Updated on %(history_date)s\n"
-"Updated by %(username)s\n\n"
-"%(diff)s\n\n"
+msgid ""
+"Updated on %(history_date)s\n"
+"Updated by %(username)s\n"
+"\n"
+"%(diff)s\n"
+"\n"
 "For more information:\n"
 "%(instance_url)s"
 msgstr ""
 
 #: tcms/core/middleware.py:25
 #, python-format
-msgid "Base URL is not configured! See <a href=\"%(doc_url)s\">documentation</a> and <a href=\"%(admin_url)s\">change it</a>"
+msgid ""
+"Base URL is not configured! See <a href=\"%(doc_url)s\">documentation</a> "
+"and <a href=\"%(admin_url)s\">change it</a>"
 msgstr ""
 
 #: tcms/kiwi_auth/admin.py:24
@@ -87,12 +92,18 @@ msgid "Your new %s account confirmation"
 msgstr ""
 
 #: tcms/kiwi_auth/views.py:47
-msgid "Your account has been created, please check your mailbox for confirmation"
-msgstr "Ihr Konto wurde erstellt, bitte überprüfen Sie Ihre Mailbox für die Bestätigung"
+msgid ""
+"Your account has been created, please check your mailbox for confirmation"
+msgstr ""
+"Ihr Konto wurde erstellt, bitte überprüfen Sie Ihre Mailbox für die "
+"Bestätigung"
 
 #: tcms/kiwi_auth/views.py:53
-msgid "Your account has been created, but you need an administrator to activate it"
-msgstr "Ihr Konto wurde erstellt, wenden Sie sich an einen Administrator um es zu aktivieren"
+msgid ""
+"Your account has been created, but you need an administrator to activate it"
+msgstr ""
+"Ihr Konto wurde erstellt, wenden Sie sich an einen Administrator um es zu "
+"aktivieren"
 
 #: tcms/kiwi_auth/views.py:58
 msgid "Following is the administrator list"
@@ -225,12 +236,16 @@ msgstr "Gestartet am"
 
 #: tcms/templates/dashboard.html:26
 #, python-format
-msgid "\n"
-"                %(total_count)s TestRun(s) or TestCase(s) assigned to you need to be executed.\n"
+msgid ""
+"\n"
+"                %(total_count)s TestRun(s) or TestCase(s) assigned to you "
+"need to be executed.\n"
 "                Here are the latest %(count)s.\n"
 "                "
-msgstr "\n"
-"%(total_count)s dir zugewiesene Testläufe oder Testfälle sollen durchgeführt werden.\n"
+msgstr ""
+"\n"
+"%(total_count)s dir zugewiesene Testläufe oder Testfälle sollen durchgeführt "
+"werden.\n"
 "Hier sind die letzten %(count)s."
 
 #: tcms/templates/dashboard.html:32 tcms/templates/dashboard.html:78
@@ -250,9 +265,10 @@ msgid "TestPlan"
 msgstr "Testplan"
 
 #: tcms/templates/dashboard.html:49
-#: tcms/testcases/templates/testcases/get.html:75
-#: tcms/testcases/templates/testcases/get.html:330
-#: tcms/testcases/templates/testcases/search.html:34
+#: tcms/testcases/templates/testcases/get.html:59
+#: tcms/testcases/templates/testcases/get.html:314
+#: tcms/testcases/templates/testcases/mutable.html:35
+#: tcms/testcases/templates/testcases/search.html:30
 #: tcms/testplans/templates/testplans/mutable.html:32
 #: tcms/testplans/templates/testplans/search.html:66
 #: tcms/testplans/templates/testplans/search.html:136
@@ -263,7 +279,7 @@ msgid "Product"
 msgstr "Produkt"
 
 #: tcms/templates/dashboard.html:50
-#: tcms/testcases/templates/testcases/get.html:329
+#: tcms/testcases/templates/testcases/get.html:313
 #: tcms/testplans/templates/testplans/mutable.html:65
 #: tcms/testplans/templates/testplans/search.html:86
 #: tcms/testplans/templates/testplans/search.html:137
@@ -271,18 +287,22 @@ msgid "Type"
 msgstr "Typ"
 
 #: tcms/templates/dashboard.html:51
-#: tcms/testcases/templates/testcases/get.html:147
+#: tcms/testcases/templates/testcases/get.html:131
 msgid "Executions"
 msgstr "Ausführungen"
 
 #: tcms/templates/dashboard.html:72
 #, python-format
-msgid "\n"
-"                You manage %(total_count)s TestPlan(s), %(disabled_count)s are disabled.\n"
+msgid ""
+"\n"
+"                You manage %(total_count)s TestPlan(s), %(disabled_count)s "
+"are disabled.\n"
 "                Here are the latest %(count)s.\n"
 "                "
-msgstr "\n"
-"                Sie verwalten, %(total_count)s Testplan/-pläne, %(disabled_count)s ist/sind deaktiviert.\n"
+msgstr ""
+"\n"
+"                Sie verwalten, %(total_count)s Testplan/-pläne, "
+"%(disabled_count)s ist/sind deaktiviert.\n"
 "                Hier sind die neuesten %(count)s.\n"
 "                "
 
@@ -292,42 +312,54 @@ msgstr ""
 
 #: tcms/templates/email/confirm_registration.txt:1
 #, python-format
-msgid "Welcome %(user)s,\n"
-"thank you for signing up for an %(site_domain)s account!\n\n"
+msgid ""
+"Welcome %(user)s,\n"
+"thank you for signing up for an %(site_domain)s account!\n"
+"\n"
 "To activate your account, click this link:\n"
 "%(confirm_url)s\n"
 msgstr ""
 
 #: tcms/templates/email/post_case_delete/email.txt:2
 #, python-format
-msgid "\n"
+msgid ""
+"\n"
 "TestCase has been updated by %(username)s!\n"
-msgstr "\n"
+msgstr ""
+"\n"
 "Testfall wurde von %(username)s aktualisiert!\n"
 
 #: tcms/templates/email/post_run_save/email.txt:2
 #, python-format
-msgid "\n"
-"Test run %(pk)s has been created or updated for you.\n\n"
+msgid ""
+"\n"
+"Test run %(pk)s has been created or updated for you.\n"
+"\n"
 "### Links ###\n"
 "Test run: %(run_url)s\n"
-"Test plan: %(plan_url)s\n\n"
+"Test plan: %(plan_url)s\n"
+"\n"
 "### Basic run information ###\n"
-"Summary: %(summary)s\n\n"
+"Summary: %(summary)s\n"
+"\n"
 "Managed: %(manager)s.\n"
-"Default tester: %(default_tester)s.\n\n"
+"Default tester: %(default_tester)s.\n"
+"\n"
 "Product: %(product)s\n"
 "Product version: %(version)s\n"
-"Build: %(build)s\n\n"
+"Build: %(build)s\n"
+"\n"
 "Notes:\n"
 "%(notes)s\n"
 msgstr ""
 
 #: tcms/templates/email/user_registered/notify_admins.txt:2
 #, python-format
-msgid "Dear Administrator,\n"
+msgid ""
+"Dear Administrator,\n"
 "somebody just registered an account with username %(username)s at your\n"
-"Kiwi TCMS instance and is awaiting your approval!\n\n"
+"Kiwi TCMS instance and is awaiting your approval!\n"
+"\n"
 "Go to %(user_url)s to activate the account!\n"
 msgstr ""
 
@@ -353,7 +385,7 @@ msgstr "Letzte Seite"
 
 #: tcms/templates/registration/login.html:17
 #: tcms/templates/registration/registration_form.html:15
-#: tcms/testcases/templates/testcases/search.html:90
+#: tcms/testcases/templates/testcases/search.html:86
 #: tcms/testplans/templates/testplans/search.html:100
 #: tcms/testplans/templates/testplans/search.html:106
 #: tcms/testruns/templates/testruns/search.html:58
@@ -385,8 +417,12 @@ msgid "Change password"
 msgstr "Passwort ändern"
 
 #: tcms/templates/registration/password_reset_confirm.html:43
-msgid "Please enter your new password twice so we can verify you typed it in correctly"
-msgstr "Bitte geben Sie Ihr neues Kennwort erneut ein, damit wir überprüfen können das Sie es korrekt eingegeben haben"
+msgid ""
+"Please enter your new password twice so we can verify you typed it in "
+"correctly"
+msgstr ""
+"Bitte geben Sie Ihr neues Kennwort erneut ein, damit wir überprüfen können "
+"das Sie es korrekt eingegeben haben"
 
 #: tcms/templates/registration/password_reset_done.html:11
 msgid "Password reset email was sent"
@@ -413,40 +449,49 @@ msgstr "Neues Benutzerkonto anlegen"
 msgid "Register"
 msgstr "Registrieren"
 
-#: tcms/testcases/forms.py:36
-msgid "Please input valid case id(s). use comma to split more than one case id. e.g. \"111, 222\""
-msgstr "Bitte Eingabe gültiger Fall IDs. Verwenden Sie ein Komma um mehrere Fall-Ids zu trennen. z.B. \"111, 222\""
+#: tcms/testcases/forms.py:21
+msgid ""
+"Please input valid case id(s). use comma to split more than one case id. e."
+"g. \"111, 222\""
+msgstr ""
+"Bitte Eingabe gültiger Fall IDs. Verwenden Sie ein Komma um mehrere Fall-Ids "
+"zu trennen. z.B. \"111, 222\""
+
+#: tcms/testcases/forms.py:95
+msgid ""
+"**Scenario**: ... what behavior will be tested ...\n"
+"  **Given** ... conditions ...\n"
+"  **When** ... actions ...\n"
+"  **Then** ... expected results ...\n"
+"\n"
+"*Actions*:\n"
+"\n"
+"1. item\n"
+"2. item\n"
+"3. item\n"
+"\n"
+"*Expected results*:\n"
+"\n"
+"1. item\n"
+"2. item\n"
+"3. item\n"
+msgstr ""
 
 #: tcms/testcases/helpers/email.py:22
 #, python-brace-format
 msgid "DELETED: TestCase #%{pk}d - %{summary}s"
 msgstr "GELÖSCHT: Testfall #%{pk}d - %{summary}s"
 
-#: tcms/testcases/templates/testcases/get.html:29
-msgid "Setup"
-msgstr ""
-
-#: tcms/testcases/templates/testcases/get.html:34
-msgid "Actions"
-msgstr ""
-
-#: tcms/testcases/templates/testcases/get.html:39
-msgid "Expected result"
-msgstr ""
-
-#: tcms/testcases/templates/testcases/get.html:44
-msgid "Breakdown"
-msgstr ""
-
-#: tcms/testcases/templates/testcases/get.html:49
+#: tcms/testcases/templates/testcases/get.html:33
+#: tcms/testcases/templates/testcases/mutable.html:132
 #: tcms/testruns/templates/testruns/mutable.html:66
 msgid "Notes"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/get.html:59
-#: tcms/testcases/templates/testcases/get.html:328
-#: tcms/testcases/templates/testcases/search.html:88
-#: tcms/testcases/templates/testcases/search.html:122
+#: tcms/testcases/templates/testcases/get.html:43
+#: tcms/testcases/templates/testcases/get.html:312
+#: tcms/testcases/templates/testcases/search.html:84
+#: tcms/testcases/templates/testcases/search.html:118
 #: tcms/testplans/templates/testplans/mutable.html:101
 #: tcms/testplans/templates/testplans/search.html:98
 #: tcms/testplans/templates/testplans/search.html:135
@@ -454,115 +499,125 @@ msgstr ""
 msgid "Author"
 msgstr "Ersteller"
 
-#: tcms/testcases/templates/testcases/get.html:64
-#: tcms/testcases/templates/testcases/search.html:123
+#: tcms/testcases/templates/testcases/get.html:48
+#: tcms/testcases/templates/testcases/mutable.html:29
+#: tcms/testcases/templates/testcases/search.html:119
 #: tcms/testplans/templates/testplans/mutable.html:113
 #: tcms/testruns/templates/testruns/search.html:94
 msgid "Default tester"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/get.html:80
-#: tcms/testcases/templates/testcases/search.html:44
-#: tcms/testcases/templates/testcases/search.html:126
+#: tcms/testcases/templates/testcases/get.html:64
+#: tcms/testcases/templates/testcases/mutable.html:50
+#: tcms/testcases/templates/testcases/search.html:40
+#: tcms/testcases/templates/testcases/search.html:122
 #: tcms/testruns/templates/testruns/mutable.html:98
 msgid "Category"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/get.html:90
-#: tcms/testcases/templates/testcases/search.html:75
-#: tcms/testcases/templates/testcases/search.html:125
+#: tcms/testcases/templates/testcases/get.html:74
+#: tcms/testcases/templates/testcases/mutable.html:66
+#: tcms/testcases/templates/testcases/search.html:16
+#: tcms/testcases/templates/testcases/search.html:71
+#: tcms/testcases/templates/testcases/search.html:121
 #: tcms/testruns/templates/testruns/mutable.html:97
 msgid "Status"
 msgstr "Status"
 
-#: tcms/testcases/templates/testcases/get.html:95
-#: tcms/testcases/templates/testcases/search.html:66
-#: tcms/testcases/templates/testcases/search.html:127
+#: tcms/testcases/templates/testcases/get.html:79
+#: tcms/testcases/templates/testcases/mutable.html:78
+#: tcms/testcases/templates/testcases/search.html:62
+#: tcms/testcases/templates/testcases/search.html:123
 #: tcms/testruns/templates/testruns/mutable.html:99
 msgid "Priority"
 msgstr "Priorität"
 
-#: tcms/testcases/templates/testcases/get.html:109
-#: tcms/testcases/templates/testcases/search.html:16
-#: tcms/testcases/templates/testcases/search.html:124
+#: tcms/testcases/templates/testcases/get.html:93
+#: tcms/testcases/templates/testcases/mutable.html:90
+#: tcms/testcases/templates/testcases/search.html:19
+#: tcms/testcases/templates/testcases/search.html:120
 msgid "Automated"
 msgstr "Automatisiert"
 
-#: tcms/testcases/templates/testcases/get.html:114
+#: tcms/testcases/templates/testcases/get.html:98
+#: tcms/testcases/templates/testcases/mutable.html:105
 msgid "Script"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/get.html:119
+#: tcms/testcases/templates/testcases/get.html:103
+#: tcms/testcases/templates/testcases/mutable.html:111
 msgid "Arguments"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/get.html:124
+#: tcms/testcases/templates/testcases/get.html:108
 msgid "Requirements"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/get.html:129
+#: tcms/testcases/templates/testcases/get.html:113
+#: tcms/testcases/templates/testcases/mutable.html:124
 #: tcms/testplans/templates/testplans/mutable.html:83
 msgid "Reference link"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/get.html:300
+#: tcms/testcases/templates/testcases/get.html:284
 msgid "Bugs"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/get.html:307
+#: tcms/testcases/templates/testcases/get.html:291
 msgid "Bug URL"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/get.html:319
+#: tcms/testcases/templates/testcases/get.html:303
 msgid "Test plans"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/get.html:326
-#: tcms/testcases/templates/testcases/search.html:120
+#: tcms/testcases/templates/testcases/get.html:310
+#: tcms/testcases/templates/testcases/search.html:116
 #: tcms/testplans/templates/testplans/search.html:132
 #: tcms/testruns/templates/testruns/search.html:90
 msgid "ID"
 msgstr "ID"
 
-#: tcms/testcases/templates/testcases/get.html:346
+#: tcms/testcases/templates/testcases/get.html:330
 msgid "Tags"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/get.html:367
-#: tcms/testcases/templates/testcases/get.html:404
+#: tcms/testcases/templates/testcases/get.html:351
+#: tcms/testcases/templates/testcases/get.html:388
 msgid "Add"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/get.html:383
+#: tcms/testcases/templates/testcases/get.html:367
 msgid "Components"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/get.html:420
+#: tcms/testcases/templates/testcases/get.html:404
 msgid "Attachments"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/get.html:427
+#: tcms/testcases/templates/testcases/get.html:411
 msgid "File"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/get.html:428
+#: tcms/testcases/templates/testcases/get.html:412
 msgid "Owner"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/get.html:429
+#: tcms/testcases/templates/testcases/get.html:413
 msgid "Date"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/get.html:443
+#: tcms/testcases/templates/testcases/get.html:427
 msgid "No records found"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/search.html:5
-msgid "Search test cases"
-msgstr "Suche Testfall"
+#: tcms/testcases/templates/testcases/mutable.html:9
+msgid "New TestCase"
+msgstr ""
 
+#: tcms/testcases/templates/testcases/mutable.html:18
 #: tcms/testcases/templates/testcases/search.html:11
-#: tcms/testcases/templates/testcases/search.html:121
+#: tcms/testcases/templates/testcases/search.html:117
 #: tcms/testruns/templates/testruns/mutable.html:23
 #: tcms/testruns/templates/testruns/mutable.html:94
 #: tcms/testruns/templates/testruns/search.html:11
@@ -570,77 +625,105 @@ msgstr "Suche Testfall"
 msgid "Summary"
 msgstr "Zusammenfassung"
 
+#: tcms/testcases/templates/testcases/mutable.html:36
+#: tcms/testplans/templates/testplans/mutable.html:33
+msgid "add new Product"
+msgstr ""
+
+#: tcms/testcases/templates/testcases/mutable.html:51
+msgid "add new Category"
+msgstr ""
+
+#: tcms/testcases/templates/testcases/mutable.html:98
+msgid "Text"
+msgstr ""
+
+#: tcms/testcases/templates/testcases/mutable.html:119
+msgid "Requirments"
+msgstr ""
+
+#: tcms/testcases/templates/testcases/mutable.html:139
+#: tcms/testplans/templates/testplans/mutable.html:143
+#: tcms/testruns/templates/testruns/mutable.html:72
+msgid "Save"
+msgstr ""
+
+#: tcms/testcases/templates/testcases/search.html:5
+msgid "Search test cases"
+msgstr "Suche Testfall"
+
 #: tcms/testcases/templates/testcases/search.html:13
 #: tcms/testruns/templates/testruns/search.html:13
 msgid "Test run summary"
 msgstr "Zusammenfassung Testlauf"
 
-#: tcms/testcases/templates/testcases/search.html:26
-msgid "Proposed for automation"
+#: tcms/testcases/templates/testcases/search.html:22
+msgid "Manual"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/search.html:29
-msgid "Search all when OFF"
+#: tcms/testcases/templates/testcases/search.html:25
+msgid "Both"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/search.html:54
+#: tcms/testcases/templates/testcases/search.html:50
+#: tcms/testcases/templates/testcases/search.html:125
 msgid "Component"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/search.html:97
+#: tcms/testcases/templates/testcases/search.html:93
 #: tcms/testplans/templates/testplans/search.html:111
 #: tcms/testruns/templates/testruns/search.html:74
 msgid "Tag"
 msgstr "Schlagwort"
 
-#: tcms/testcases/templates/testcases/search.html:100
-#: tcms/testcases/templates/testcases/search.html:106
+#: tcms/testcases/templates/testcases/search.html:96
+#: tcms/testcases/templates/testcases/search.html:102
 #: tcms/testplans/templates/testplans/search.html:114
 #: tcms/testruns/templates/testruns/search.html:77
 msgid "Separate multiple values with comma (,)"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/search.html:103
-#: tcms/testcases/templates/testcases/search.html:105
+#: tcms/testcases/templates/testcases/search.html:99
+#: tcms/testcases/templates/testcases/search.html:101
 msgid "Bug ID"
 msgstr "Fehler-ID"
 
-#: tcms/testcases/templates/testcases/search.html:112
+#: tcms/testcases/templates/testcases/search.html:108
 #: tcms/testplans/templates/testplans/search.html:124
 #: tcms/testruns/templates/testruns/search.html:82
 msgid "Search"
 msgstr "Suche"
 
-#: tcms/testcases/templates/testcases/search.html:128
+#: tcms/testcases/templates/testcases/search.html:124
 msgid "Created at"
 msgstr "Angelegt am"
 
-#: tcms/testcases/views.py:463
+#: tcms/testcases/views.py:448
 msgid "TestPlan not specified or does not exist"
 msgstr ""
 
-#: tcms/testcases/views.py:642
+#: tcms/testcases/views.py:622
 msgid "Edit"
 msgstr ""
 
-#: tcms/testcases/views.py:646
+#: tcms/testcases/views.py:626
 msgid "Clone"
 msgstr ""
 
-#: tcms/testcases/views.py:650
+#: tcms/testcases/views.py:630
 msgid "History"
 msgstr ""
 
-#: tcms/testcases/views.py:655
+#: tcms/testcases/views.py:635
 msgid "Delete"
 msgstr ""
 
-#: tcms/testcases/views.py:934 tcms/testruns/views.py:499
-#: tcms/testruns/views.py:577
+#: tcms/testcases/views.py:861 tcms/testruns/views.py:497
+#: tcms/testruns/views.py:575
 msgid "At least one TestCase is required"
 msgstr "Mindestens ein Testfall ist erforderlich"
 
-#: tcms/testcases/views.py:1083
+#: tcms/testcases/views.py:998
 msgid "TestCase cloning was successful"
 msgstr "Das Konen des Testfalls war erfolgreich"
 
@@ -650,10 +733,6 @@ msgstr ""
 
 #: tcms/testplans/templates/testplans/mutable.html:12
 msgid "Create new TestPlan"
-msgstr ""
-
-#: tcms/testplans/templates/testplans/mutable.html:33
-msgid "add new Product"
 msgstr ""
 
 #: tcms/testplans/templates/testplans/mutable.html:47
@@ -698,11 +777,6 @@ msgstr ""
 #: tcms/testplans/templates/testplans/mutable.html:137
 #: tcms/testplans/templates/testplans/search.html:117
 msgid "Active"
-msgstr ""
-
-#: tcms/testplans/templates/testplans/mutable.html:143
-#: tcms/testruns/templates/testruns/mutable.html:72
-msgid "Save"
 msgstr ""
 
 #: tcms/testplans/templates/testplans/search.html:5
@@ -801,8 +875,10 @@ msgstr "Ausgewählte/r Testfall/-fälle:"
 
 #: tcms/testruns/templates/testruns/mutable.html:84
 #, python-format
-msgid "\n"
-"                    %(count)s of the pre-selected test cases is not CONFIRMED and will not be cloned!\n"
+msgid ""
+"\n"
+"                    %(count)s of the pre-selected test cases is not "
+"CONFIRMED and will not be cloned!\n"
 "                    See test plan for more details!\n"
 "                    "
 msgstr ""
@@ -833,21 +909,23 @@ msgstr "Abgeschlossen am"
 
 #: tcms/testruns/views.py:49
 msgid "Creating a TestRun requires a TestPlan, select one"
-msgstr "Das Erstellen eines Testlaufs erfordert einen Testplan, bitte wählen Sie einen aus"
+msgstr ""
+"Das Erstellen eines Testlaufs erfordert einen Testplan, bitte wählen Sie "
+"einen aus"
 
 #: tcms/testruns/views.py:59
 msgid "Creating a TestRun requires at least one TestCase"
 msgstr "Das Erstellen eines Testlaufs erfordert mindestens einen Testfall"
 
-#: tcms/testruns/views.py:503
+#: tcms/testruns/views.py:501
 msgid "Clone of "
 msgstr "Klon von "
 
-#: tcms/testruns/views.py:586
+#: tcms/testruns/views.py:584
 msgid "TestCase ID is not a valid integer"
 msgstr "Testfall-ID ist keine gültige Ganzzahl"
 
-#: tcms/testruns/views.py:713
+#: tcms/testruns/views.py:711
 #, python-format
 msgid "%d CaseRun(s) updated:"
 msgstr "%d einzelne Tests aktualisiert:"
@@ -904,23 +982,3 @@ msgstr "DEAKTIVIERT"
 #: vinaigrette-deleteme.py:13
 msgid "NEED_UPDATE"
 msgstr "MUSS_AKTUALISIERT_WERDEN"
-
-#: tcms/testcases/forms.py:95
-msgid ""
-"**Scenario**: ... what behavior will be tested ...\n"
-"  **Given** ... conditions ...\n"
-"  **When** ... actions ...\n"
-"  **Then** ... expected results ...\n"
-"\n"
-"*Actions*:\n"
-"\n"
-"1. item\n"
-"2. item\n"
-"3. item\n"
-"\n"
-"*Expected results*:\n"
-"\n"
-"1. item\n"
-"2. item\n"
-"3. item\n"
-msgstr ""

--- a/tcms/locale/en/LC_MESSAGES/django.po
+++ b/tcms/locale/en/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-01-24 21:57+0000\n"
+"POT-Creation-Date: 2019-01-26 10:28+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: tcms/core/ajax.py:157 tcms/testruns/views.py:765
+#: tcms/core/ajax.py:157 tcms/testruns/views.py:763
 #, python-format
 msgid "User %s not found!"
 msgstr ""
@@ -27,9 +27,9 @@ msgid "Core customized comments"
 msgstr ""
 
 #: tcms/core/contrib/comments/forms.py:14
-#: tcms/testcases/templates/testcases/get.html:327
-#: tcms/testcases/templates/testcases/get.html:353
-#: tcms/testcases/templates/testcases/get.html:390
+#: tcms/testcases/templates/testcases/get.html:311
+#: tcms/testcases/templates/testcases/get.html:337
+#: tcms/testcases/templates/testcases/get.html:374
 #: tcms/testplans/templates/testplans/mutable.html:23
 #: tcms/testplans/templates/testplans/search.html:11
 msgid "Name"
@@ -258,9 +258,10 @@ msgid "TestPlan"
 msgstr ""
 
 #: tcms/templates/dashboard.html:49
-#: tcms/testcases/templates/testcases/get.html:75
-#: tcms/testcases/templates/testcases/get.html:330
-#: tcms/testcases/templates/testcases/search.html:34
+#: tcms/testcases/templates/testcases/get.html:59
+#: tcms/testcases/templates/testcases/get.html:314
+#: tcms/testcases/templates/testcases/mutable.html:35
+#: tcms/testcases/templates/testcases/search.html:30
 #: tcms/testplans/templates/testplans/mutable.html:32
 #: tcms/testplans/templates/testplans/search.html:66
 #: tcms/testplans/templates/testplans/search.html:136
@@ -271,7 +272,7 @@ msgid "Product"
 msgstr ""
 
 #: tcms/templates/dashboard.html:50
-#: tcms/testcases/templates/testcases/get.html:329
+#: tcms/testcases/templates/testcases/get.html:313
 #: tcms/testplans/templates/testplans/mutable.html:65
 #: tcms/testplans/templates/testplans/search.html:86
 #: tcms/testplans/templates/testplans/search.html:137
@@ -279,7 +280,7 @@ msgid "Type"
 msgstr ""
 
 #: tcms/templates/dashboard.html:51
-#: tcms/testcases/templates/testcases/get.html:147
+#: tcms/testcases/templates/testcases/get.html:131
 msgid "Executions"
 msgstr ""
 
@@ -370,7 +371,7 @@ msgstr ""
 
 #: tcms/templates/registration/login.html:17
 #: tcms/templates/registration/registration_form.html:15
-#: tcms/testcases/templates/testcases/search.html:90
+#: tcms/testcases/templates/testcases/search.html:86
 #: tcms/testplans/templates/testplans/search.html:100
 #: tcms/testplans/templates/testplans/search.html:106
 #: tcms/testruns/templates/testruns/search.html:58
@@ -432,10 +433,30 @@ msgstr ""
 msgid "Register"
 msgstr ""
 
-#: tcms/testcases/forms.py:36
+#: tcms/testcases/forms.py:21
 msgid ""
 "Please input valid case id(s). use comma to split more than one case id. e."
 "g. \"111, 222\""
+msgstr ""
+
+#: tcms/testcases/forms.py:95
+msgid ""
+"**Scenario**: ... what behavior will be tested ...\n"
+"  **Given** ... conditions ...\n"
+"  **When** ... actions ...\n"
+"  **Then** ... expected results ...\n"
+"\n"
+"*Actions*:\n"
+"\n"
+"1. item\n"
+"2. item\n"
+"3. item\n"
+"\n"
+"*Expected results*:\n"
+"\n"
+"1. item\n"
+"2. item\n"
+"3. item\n"
 msgstr ""
 
 #: tcms/testcases/helpers/email.py:22
@@ -443,31 +464,16 @@ msgstr ""
 msgid "DELETED: TestCase #%{pk}d - %{summary}s"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/get.html:29
-msgid "Setup"
-msgstr ""
-
-#: tcms/testcases/templates/testcases/get.html:34
-msgid "Actions"
-msgstr ""
-
-#: tcms/testcases/templates/testcases/get.html:39
-msgid "Expected result"
-msgstr ""
-
-#: tcms/testcases/templates/testcases/get.html:44
-msgid "Breakdown"
-msgstr ""
-
-#: tcms/testcases/templates/testcases/get.html:49
+#: tcms/testcases/templates/testcases/get.html:33
+#: tcms/testcases/templates/testcases/mutable.html:132
 #: tcms/testruns/templates/testruns/mutable.html:66
 msgid "Notes"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/get.html:59
-#: tcms/testcases/templates/testcases/get.html:328
-#: tcms/testcases/templates/testcases/search.html:88
-#: tcms/testcases/templates/testcases/search.html:122
+#: tcms/testcases/templates/testcases/get.html:43
+#: tcms/testcases/templates/testcases/get.html:312
+#: tcms/testcases/templates/testcases/search.html:84
+#: tcms/testcases/templates/testcases/search.html:118
 #: tcms/testplans/templates/testplans/mutable.html:101
 #: tcms/testplans/templates/testplans/search.html:98
 #: tcms/testplans/templates/testplans/search.html:135
@@ -475,115 +481,125 @@ msgstr ""
 msgid "Author"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/get.html:64
-#: tcms/testcases/templates/testcases/search.html:123
+#: tcms/testcases/templates/testcases/get.html:48
+#: tcms/testcases/templates/testcases/mutable.html:29
+#: tcms/testcases/templates/testcases/search.html:119
 #: tcms/testplans/templates/testplans/mutable.html:113
 #: tcms/testruns/templates/testruns/search.html:94
 msgid "Default tester"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/get.html:80
-#: tcms/testcases/templates/testcases/search.html:44
-#: tcms/testcases/templates/testcases/search.html:126
+#: tcms/testcases/templates/testcases/get.html:64
+#: tcms/testcases/templates/testcases/mutable.html:50
+#: tcms/testcases/templates/testcases/search.html:40
+#: tcms/testcases/templates/testcases/search.html:122
 #: tcms/testruns/templates/testruns/mutable.html:98
 msgid "Category"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/get.html:90
-#: tcms/testcases/templates/testcases/search.html:75
-#: tcms/testcases/templates/testcases/search.html:125
+#: tcms/testcases/templates/testcases/get.html:74
+#: tcms/testcases/templates/testcases/mutable.html:66
+#: tcms/testcases/templates/testcases/search.html:16
+#: tcms/testcases/templates/testcases/search.html:71
+#: tcms/testcases/templates/testcases/search.html:121
 #: tcms/testruns/templates/testruns/mutable.html:97
 msgid "Status"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/get.html:95
-#: tcms/testcases/templates/testcases/search.html:66
-#: tcms/testcases/templates/testcases/search.html:127
+#: tcms/testcases/templates/testcases/get.html:79
+#: tcms/testcases/templates/testcases/mutable.html:78
+#: tcms/testcases/templates/testcases/search.html:62
+#: tcms/testcases/templates/testcases/search.html:123
 #: tcms/testruns/templates/testruns/mutable.html:99
 msgid "Priority"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/get.html:109
-#: tcms/testcases/templates/testcases/search.html:16
-#: tcms/testcases/templates/testcases/search.html:124
+#: tcms/testcases/templates/testcases/get.html:93
+#: tcms/testcases/templates/testcases/mutable.html:90
+#: tcms/testcases/templates/testcases/search.html:19
+#: tcms/testcases/templates/testcases/search.html:120
 msgid "Automated"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/get.html:114
+#: tcms/testcases/templates/testcases/get.html:98
+#: tcms/testcases/templates/testcases/mutable.html:105
 msgid "Script"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/get.html:119
+#: tcms/testcases/templates/testcases/get.html:103
+#: tcms/testcases/templates/testcases/mutable.html:111
 msgid "Arguments"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/get.html:124
+#: tcms/testcases/templates/testcases/get.html:108
 msgid "Requirements"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/get.html:129
+#: tcms/testcases/templates/testcases/get.html:113
+#: tcms/testcases/templates/testcases/mutable.html:124
 #: tcms/testplans/templates/testplans/mutable.html:83
 msgid "Reference link"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/get.html:300
+#: tcms/testcases/templates/testcases/get.html:284
 msgid "Bugs"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/get.html:307
+#: tcms/testcases/templates/testcases/get.html:291
 msgid "Bug URL"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/get.html:319
+#: tcms/testcases/templates/testcases/get.html:303
 msgid "Test plans"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/get.html:326
-#: tcms/testcases/templates/testcases/search.html:120
+#: tcms/testcases/templates/testcases/get.html:310
+#: tcms/testcases/templates/testcases/search.html:116
 #: tcms/testplans/templates/testplans/search.html:132
 #: tcms/testruns/templates/testruns/search.html:90
 msgid "ID"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/get.html:346
+#: tcms/testcases/templates/testcases/get.html:330
 msgid "Tags"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/get.html:367
-#: tcms/testcases/templates/testcases/get.html:404
+#: tcms/testcases/templates/testcases/get.html:351
+#: tcms/testcases/templates/testcases/get.html:388
 msgid "Add"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/get.html:383
+#: tcms/testcases/templates/testcases/get.html:367
 msgid "Components"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/get.html:420
+#: tcms/testcases/templates/testcases/get.html:404
 msgid "Attachments"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/get.html:427
+#: tcms/testcases/templates/testcases/get.html:411
 msgid "File"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/get.html:428
+#: tcms/testcases/templates/testcases/get.html:412
 msgid "Owner"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/get.html:429
+#: tcms/testcases/templates/testcases/get.html:413
 msgid "Date"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/get.html:443
+#: tcms/testcases/templates/testcases/get.html:427
 msgid "No records found"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/search.html:5
-msgid "Search test cases"
+#: tcms/testcases/templates/testcases/mutable.html:9
+msgid "New TestCase"
 msgstr ""
 
+#: tcms/testcases/templates/testcases/mutable.html:18
 #: tcms/testcases/templates/testcases/search.html:11
-#: tcms/testcases/templates/testcases/search.html:121
+#: tcms/testcases/templates/testcases/search.html:117
 #: tcms/testruns/templates/testruns/mutable.html:23
 #: tcms/testruns/templates/testruns/mutable.html:94
 #: tcms/testruns/templates/testruns/search.html:11
@@ -591,77 +607,105 @@ msgstr ""
 msgid "Summary"
 msgstr ""
 
+#: tcms/testcases/templates/testcases/mutable.html:36
+#: tcms/testplans/templates/testplans/mutable.html:33
+msgid "add new Product"
+msgstr ""
+
+#: tcms/testcases/templates/testcases/mutable.html:51
+msgid "add new Category"
+msgstr ""
+
+#: tcms/testcases/templates/testcases/mutable.html:98
+msgid "Text"
+msgstr ""
+
+#: tcms/testcases/templates/testcases/mutable.html:119
+msgid "Requirments"
+msgstr ""
+
+#: tcms/testcases/templates/testcases/mutable.html:139
+#: tcms/testplans/templates/testplans/mutable.html:143
+#: tcms/testruns/templates/testruns/mutable.html:72
+msgid "Save"
+msgstr ""
+
+#: tcms/testcases/templates/testcases/search.html:5
+msgid "Search test cases"
+msgstr ""
+
 #: tcms/testcases/templates/testcases/search.html:13
 #: tcms/testruns/templates/testruns/search.html:13
 msgid "Test run summary"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/search.html:26
-msgid "Proposed for automation"
+#: tcms/testcases/templates/testcases/search.html:22
+msgid "Manual"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/search.html:29
-msgid "Search all when OFF"
+#: tcms/testcases/templates/testcases/search.html:25
+msgid "Both"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/search.html:54
+#: tcms/testcases/templates/testcases/search.html:50
+#: tcms/testcases/templates/testcases/search.html:125
 msgid "Component"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/search.html:97
+#: tcms/testcases/templates/testcases/search.html:93
 #: tcms/testplans/templates/testplans/search.html:111
 #: tcms/testruns/templates/testruns/search.html:74
 msgid "Tag"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/search.html:100
-#: tcms/testcases/templates/testcases/search.html:106
+#: tcms/testcases/templates/testcases/search.html:96
+#: tcms/testcases/templates/testcases/search.html:102
 #: tcms/testplans/templates/testplans/search.html:114
 #: tcms/testruns/templates/testruns/search.html:77
 msgid "Separate multiple values with comma (,)"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/search.html:103
-#: tcms/testcases/templates/testcases/search.html:105
+#: tcms/testcases/templates/testcases/search.html:99
+#: tcms/testcases/templates/testcases/search.html:101
 msgid "Bug ID"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/search.html:112
+#: tcms/testcases/templates/testcases/search.html:108
 #: tcms/testplans/templates/testplans/search.html:124
 #: tcms/testruns/templates/testruns/search.html:82
 msgid "Search"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/search.html:128
+#: tcms/testcases/templates/testcases/search.html:124
 msgid "Created at"
 msgstr ""
 
-#: tcms/testcases/views.py:463
+#: tcms/testcases/views.py:448
 msgid "TestPlan not specified or does not exist"
 msgstr ""
 
-#: tcms/testcases/views.py:642
+#: tcms/testcases/views.py:622
 msgid "Edit"
 msgstr ""
 
-#: tcms/testcases/views.py:646
+#: tcms/testcases/views.py:626
 msgid "Clone"
 msgstr ""
 
-#: tcms/testcases/views.py:650
+#: tcms/testcases/views.py:630
 msgid "History"
 msgstr ""
 
-#: tcms/testcases/views.py:655
+#: tcms/testcases/views.py:635
 msgid "Delete"
 msgstr ""
 
-#: tcms/testcases/views.py:934 tcms/testruns/views.py:499
-#: tcms/testruns/views.py:577
+#: tcms/testcases/views.py:861 tcms/testruns/views.py:497
+#: tcms/testruns/views.py:575
 msgid "At least one TestCase is required"
 msgstr ""
 
-#: tcms/testcases/views.py:1083
+#: tcms/testcases/views.py:998
 msgid "TestCase cloning was successful"
 msgstr ""
 
@@ -671,10 +715,6 @@ msgstr ""
 
 #: tcms/testplans/templates/testplans/mutable.html:12
 msgid "Create new TestPlan"
-msgstr ""
-
-#: tcms/testplans/templates/testplans/mutable.html:33
-msgid "add new Product"
 msgstr ""
 
 #: tcms/testplans/templates/testplans/mutable.html:47
@@ -719,11 +759,6 @@ msgstr ""
 #: tcms/testplans/templates/testplans/mutable.html:137
 #: tcms/testplans/templates/testplans/search.html:117
 msgid "Active"
-msgstr ""
-
-#: tcms/testplans/templates/testplans/mutable.html:143
-#: tcms/testruns/templates/testruns/mutable.html:72
-msgid "Save"
 msgstr ""
 
 #: tcms/testplans/templates/testplans/search.html:5
@@ -862,15 +897,15 @@ msgstr ""
 msgid "Creating a TestRun requires at least one TestCase"
 msgstr ""
 
-#: tcms/testruns/views.py:503
+#: tcms/testruns/views.py:501
 msgid "Clone of "
 msgstr ""
 
-#: tcms/testruns/views.py:586
+#: tcms/testruns/views.py:584
 msgid "TestCase ID is not a valid integer"
 msgstr ""
 
-#: tcms/testruns/views.py:713
+#: tcms/testruns/views.py:711
 #, python-format
 msgid "%d CaseRun(s) updated:"
 msgstr ""
@@ -926,24 +961,4 @@ msgstr ""
 
 #: vinaigrette-deleteme.py:13
 msgid "NEED_UPDATE"
-msgstr ""
-
-#: tcms/testcases/forms.py:95
-msgid ""
-"**Scenario**: ... what behavior will be tested ...\n"
-"  **Given** ... conditions ...\n"
-"  **When** ... actions ...\n"
-"  **Then** ... expected results ...\n"
-"\n"
-"*Actions*:\n"
-"\n"
-"1. item\n"
-"2. item\n"
-"3. item\n"
-"\n"
-"*Expected results*:\n"
-"\n"
-"1. item\n"
-"2. item\n"
-"3. item\n"
 msgstr ""

--- a/tcms/locale/fr_FR/LC_MESSAGES/django.po
+++ b/tcms/locale/fr_FR/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: kiwitcms\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-01-15 22:16+0000\n"
+"POT-Creation-Date: 2019-01-26 10:28+0000\n"
 "PO-Revision-Date: 2019-01-16 12:31\n"
 "Last-Translator: atodorov <atodorov@otb.bg>\n"
 "Language-Team: French\n"
@@ -16,7 +16,7 @@ msgstr ""
 "X-Crowdin-Language: fr\n"
 "X-Crowdin-File: /master/tcms/locale/en/LC_MESSAGES/django.po\n"
 
-#: tcms/core/ajax.py:157 tcms/testruns/views.py:765
+#: tcms/core/ajax.py:157 tcms/testruns/views.py:763
 #, python-format
 msgid "User %s not found!"
 msgstr "L'utilisateur %s non trouvé!"
@@ -26,9 +26,9 @@ msgid "Core customized comments"
 msgstr "Commentaires de noyau personnalisé"
 
 #: tcms/core/contrib/comments/forms.py:14
-#: tcms/testcases/templates/testcases/get.html:327
-#: tcms/testcases/templates/testcases/get.html:353
-#: tcms/testcases/templates/testcases/get.html:390
+#: tcms/testcases/templates/testcases/get.html:311
+#: tcms/testcases/templates/testcases/get.html:337
+#: tcms/testcases/templates/testcases/get.html:374
 #: tcms/testplans/templates/testplans/mutable.html:23
 #: tcms/testplans/templates/testplans/search.html:11
 msgid "Name"
@@ -53,21 +53,31 @@ msgstr "MAJ: %(model_name)s #%(pk)d - %(title)s"
 
 #: tcms/core/history.py:47
 #, python-format
-msgid "Updated on %(history_date)s\n"
-"Updated by %(username)s\n\n"
-"%(diff)s\n\n"
+msgid ""
+"Updated on %(history_date)s\n"
+"Updated by %(username)s\n"
+"\n"
+"%(diff)s\n"
+"\n"
 "For more information:\n"
 "%(instance_url)s"
-msgstr "Mise à jour le %(history_date)s\n"
-"Mise à jour par %(username)s\n\n"
-"%(diff)s\n\n"
+msgstr ""
+"Mise à jour le %(history_date)s\n"
+"Mise à jour par %(username)s\n"
+"\n"
+"%(diff)s\n"
+"\n"
 "Pour plus d'information:\n"
 "%(instance_url)s"
 
 #: tcms/core/middleware.py:25
 #, python-format
-msgid "Base URL is not configured! See <a href=\"%(doc_url)s\">documentation</a> and <a href=\"%(admin_url)s\">change it</a>"
-msgstr "L'URL de base n'est pas configurée! Voir <a href=\"%(doc_url)s\">la documentation</a> et<a href=\"%(admin_url)s\">Pour la changer</a>"
+msgid ""
+"Base URL is not configured! See <a href=\"%(doc_url)s\">documentation</a> "
+"and <a href=\"%(admin_url)s\">change it</a>"
+msgstr ""
+"L'URL de base n'est pas configurée! Voir <a href=\"%(doc_url)s\">la "
+"documentation</a> et<a href=\"%(admin_url)s\">Pour la changer</a>"
 
 #: tcms/kiwi_auth/admin.py:24
 msgid "This email address is already in use"
@@ -91,12 +101,18 @@ msgid "Your new %s account confirmation"
 msgstr "Votre confirmation du nouveau compte %s"
 
 #: tcms/kiwi_auth/views.py:47
-msgid "Your account has been created, please check your mailbox for confirmation"
-msgstr "Votre compte a été créé. Veuillez Vérifier votre boite de courriel pour le lien de confirmation"
+msgid ""
+"Your account has been created, please check your mailbox for confirmation"
+msgstr ""
+"Votre compte a été créé. Veuillez Vérifier votre boite de courriel pour le "
+"lien de confirmation"
 
 #: tcms/kiwi_auth/views.py:53
-msgid "Your account has been created, but you need an administrator to activate it"
-msgstr "Votre compte a été créé, mais vous avez besoin d’un administrateur pour l’activer"
+msgid ""
+"Your account has been created, but you need an administrator to activate it"
+msgstr ""
+"Votre compte a été créé, mais vous avez besoin d’un administrateur pour "
+"l’activer"
 
 #: tcms/kiwi_auth/views.py:58
 msgid "Following is the administrator list"
@@ -229,12 +245,16 @@ msgstr "Démarré le"
 
 #: tcms/templates/dashboard.html:26
 #, python-format
-msgid "\n"
-"                %(total_count)s TestRun(s) or TestCase(s) assigned to you need to be executed.\n"
+msgid ""
+"\n"
+"                %(total_count)s TestRun(s) or TestCase(s) assigned to you "
+"need to be executed.\n"
 "                Here are the latest %(count)s.\n"
 "                "
-msgstr "\n"
-"                %(total_count)s essai de test ou cas de tests qui vous sont assignés pour être exécuté.\n"
+msgstr ""
+"\n"
+"                %(total_count)s essai de test ou cas de tests qui vous sont "
+"assignés pour être exécuté.\n"
 "                Voici le dernier %(count)s.\n"
 "                "
 
@@ -255,9 +275,10 @@ msgid "TestPlan"
 msgstr "Plan de test"
 
 #: tcms/templates/dashboard.html:49
-#: tcms/testcases/templates/testcases/get.html:75
-#: tcms/testcases/templates/testcases/get.html:330
-#: tcms/testcases/templates/testcases/search.html:34
+#: tcms/testcases/templates/testcases/get.html:59
+#: tcms/testcases/templates/testcases/get.html:314
+#: tcms/testcases/templates/testcases/mutable.html:35
+#: tcms/testcases/templates/testcases/search.html:30
 #: tcms/testplans/templates/testplans/mutable.html:32
 #: tcms/testplans/templates/testplans/search.html:66
 #: tcms/testplans/templates/testplans/search.html:136
@@ -268,7 +289,7 @@ msgid "Product"
 msgstr "Produit"
 
 #: tcms/templates/dashboard.html:50
-#: tcms/testcases/templates/testcases/get.html:329
+#: tcms/testcases/templates/testcases/get.html:313
 #: tcms/testplans/templates/testplans/mutable.html:65
 #: tcms/testplans/templates/testplans/search.html:86
 #: tcms/testplans/templates/testplans/search.html:137
@@ -276,18 +297,22 @@ msgid "Type"
 msgstr "Type"
 
 #: tcms/templates/dashboard.html:51
-#: tcms/testcases/templates/testcases/get.html:147
+#: tcms/testcases/templates/testcases/get.html:131
 msgid "Executions"
 msgstr "Exécutions"
 
 #: tcms/templates/dashboard.html:72
 #, python-format
-msgid "\n"
-"                You manage %(total_count)s TestPlan(s), %(disabled_count)s are disabled.\n"
+msgid ""
+"\n"
+"                You manage %(total_count)s TestPlan(s), %(disabled_count)s "
+"are disabled.\n"
 "                Here are the latest %(count)s.\n"
 "                "
-msgstr "\n"
-"                Vous gérez %(total_count)s plan(s) de test, %(disabled_count)s sont désactivés.\n"
+msgstr ""
+"\n"
+"                Vous gérez %(total_count)s plan(s) de test, "
+"%(disabled_count)s sont désactivés.\n"
 "                Voici le dernier %(count)s.\n"
 "                "
 
@@ -297,62 +322,85 @@ msgstr "Il n’y a aucun plan(s) de test qui vous est assigné"
 
 #: tcms/templates/email/confirm_registration.txt:1
 #, python-format
-msgid "Welcome %(user)s,\n"
-"thank you for signing up for an %(site_domain)s account!\n\n"
+msgid ""
+"Welcome %(user)s,\n"
+"thank you for signing up for an %(site_domain)s account!\n"
+"\n"
 "To activate your account, click this link:\n"
 "%(confirm_url)s\n"
-msgstr "Bienvenu %(user)s,\n"
-"Merci pour votre inscription sur %(site_domain)s!\n\n"
+msgstr ""
+"Bienvenu %(user)s,\n"
+"Merci pour votre inscription sur %(site_domain)s!\n"
+"\n"
 "Pour activer votre compte cliquer sur le lien suivant:\n"
 "%(confirm_url)s\n"
 
 #: tcms/templates/email/post_case_delete/email.txt:2
 #, python-format
-msgid "\n"
+msgid ""
+"\n"
 "TestCase has been updated by %(username)s!\n"
-msgstr "\n"
+msgstr ""
+"\n"
 "Le cas de test a été mis à jour par %(username)s!\n"
 
 #: tcms/templates/email/post_run_save/email.txt:2
 #, python-format
-msgid "\n"
-"Test run %(pk)s has been created or updated for you.\n\n"
+msgid ""
+"\n"
+"Test run %(pk)s has been created or updated for you.\n"
+"\n"
 "### Links ###\n"
 "Test run: %(run_url)s\n"
-"Test plan: %(plan_url)s\n\n"
+"Test plan: %(plan_url)s\n"
+"\n"
 "### Basic run information ###\n"
-"Summary: %(summary)s\n\n"
+"Summary: %(summary)s\n"
+"\n"
 "Managed: %(manager)s.\n"
-"Default tester: %(default_tester)s.\n\n"
+"Default tester: %(default_tester)s.\n"
+"\n"
 "Product: %(product)s\n"
 "Product version: %(version)s\n"
-"Build: %(build)s\n\n"
+"Build: %(build)s\n"
+"\n"
 "Notes:\n"
 "%(notes)s\n"
-msgstr "\n"
-"L'essai de test %(pk)s à été créé ou mis à jour pour vous.\n\n"
+msgstr ""
+"\n"
+"L'essai de test %(pk)s à été créé ou mis à jour pour vous.\n"
+"\n"
 "### Liens ###\n"
 "Essai de test: %(run_url)s\n"
-"Plan de test: %(plan_url)s\n\n"
+"Plan de test: %(plan_url)s\n"
+"\n"
 "### Information de lancement ###\n"
-"Résumé: %(summary)s\n\n"
+"Résumé: %(summary)s\n"
+"\n"
 "Géré par: %(manager)s.\n"
-"Testeur par défaut: %(default_tester)s.\n\n"
+"Testeur par défaut: %(default_tester)s.\n"
+"\n"
 "Produit: %(product)s\n"
 "Version du produit: %(version)s\n"
-"Construction: %(build)s\n\n"
+"Construction: %(build)s\n"
+"\n"
 "Récapitulatif:\n"
 "%(notes)s\n"
 
 #: tcms/templates/email/user_registered/notify_admins.txt:2
 #, python-format
-msgid "Dear Administrator,\n"
+msgid ""
+"Dear Administrator,\n"
 "somebody just registered an account with username %(username)s at your\n"
-"Kiwi TCMS instance and is awaiting your approval!\n\n"
+"Kiwi TCMS instance and is awaiting your approval!\n"
+"\n"
 "Go to %(user_url)s to activate the account!\n"
-msgstr "Chèr(e) Administra(teur/trice),\n"
-"une personne s'est enregistré un compte avec le nom %(username)s sur votre instance\n"
-"Kiwi TCMS et attend votre approbation!\n\n"
+msgstr ""
+"Chèr(e) Administra(teur/trice),\n"
+"une personne s'est enregistré un compte avec le nom %(username)s sur votre "
+"instance\n"
+"Kiwi TCMS et attend votre approbation!\n"
+"\n"
 "Aller à l'adresse %(user_url)s pour activer ce compte!\n"
 
 #: tcms/templates/pagination.html:7
@@ -377,7 +425,7 @@ msgstr "Dernière page"
 
 #: tcms/templates/registration/login.html:17
 #: tcms/templates/registration/registration_form.html:15
-#: tcms/testcases/templates/testcases/search.html:90
+#: tcms/testcases/templates/testcases/search.html:86
 #: tcms/testplans/templates/testplans/search.html:100
 #: tcms/testplans/templates/testplans/search.html:106
 #: tcms/testruns/templates/testruns/search.html:58
@@ -409,8 +457,12 @@ msgid "Change password"
 msgstr "Changer le mot de passe"
 
 #: tcms/templates/registration/password_reset_confirm.html:43
-msgid "Please enter your new password twice so we can verify you typed it in correctly"
-msgstr "Entrez votre nouveau mot de passe deux fois, afin de vérifier qu'il est bien écrit"
+msgid ""
+"Please enter your new password twice so we can verify you typed it in "
+"correctly"
+msgstr ""
+"Entrez votre nouveau mot de passe deux fois, afin de vérifier qu'il est bien "
+"écrit"
 
 #: tcms/templates/registration/password_reset_done.html:11
 msgid "Password reset email was sent"
@@ -437,40 +489,49 @@ msgstr "Créer un nouveau compte"
 msgid "Register"
 msgstr "Inscription"
 
-#: tcms/testcases/forms.py:36
-msgid "Please input valid case id(s). use comma to split more than one case id. e.g. \"111, 222\""
-msgstr "Veuillez entrer un/des id(s) de cas valide(s). utiliser le virgule pour séparer plus d'un id de cas.ex: \"111, 222\""
+#: tcms/testcases/forms.py:21
+msgid ""
+"Please input valid case id(s). use comma to split more than one case id. e."
+"g. \"111, 222\""
+msgstr ""
+"Veuillez entrer un/des id(s) de cas valide(s). utiliser le virgule pour "
+"séparer plus d'un id de cas.ex: \"111, 222\""
+
+#: tcms/testcases/forms.py:95
+msgid ""
+"**Scenario**: ... what behavior will be tested ...\n"
+"  **Given** ... conditions ...\n"
+"  **When** ... actions ...\n"
+"  **Then** ... expected results ...\n"
+"\n"
+"*Actions*:\n"
+"\n"
+"1. item\n"
+"2. item\n"
+"3. item\n"
+"\n"
+"*Expected results*:\n"
+"\n"
+"1. item\n"
+"2. item\n"
+"3. item\n"
+msgstr ""
 
 #: tcms/testcases/helpers/email.py:22
 #, python-brace-format
 msgid "DELETED: TestCase #%{pk}d - %{summary}s"
 msgstr "SUPPRIMÉ: Cas de test #%{pk}d - %{summary}s"
 
-#: tcms/testcases/templates/testcases/get.html:29
-msgid "Setup"
-msgstr "Configuration"
-
-#: tcms/testcases/templates/testcases/get.html:34
-msgid "Actions"
-msgstr "Actions"
-
-#: tcms/testcases/templates/testcases/get.html:39
-msgid "Expected result"
-msgstr "Résultats attendus"
-
-#: tcms/testcases/templates/testcases/get.html:44
-msgid "Breakdown"
-msgstr "Panne"
-
-#: tcms/testcases/templates/testcases/get.html:49
+#: tcms/testcases/templates/testcases/get.html:33
+#: tcms/testcases/templates/testcases/mutable.html:132
 #: tcms/testruns/templates/testruns/mutable.html:66
 msgid "Notes"
 msgstr "Remarques"
 
-#: tcms/testcases/templates/testcases/get.html:59
-#: tcms/testcases/templates/testcases/get.html:328
-#: tcms/testcases/templates/testcases/search.html:88
-#: tcms/testcases/templates/testcases/search.html:122
+#: tcms/testcases/templates/testcases/get.html:43
+#: tcms/testcases/templates/testcases/get.html:312
+#: tcms/testcases/templates/testcases/search.html:84
+#: tcms/testcases/templates/testcases/search.html:118
 #: tcms/testplans/templates/testplans/mutable.html:101
 #: tcms/testplans/templates/testplans/search.html:98
 #: tcms/testplans/templates/testplans/search.html:135
@@ -478,115 +539,125 @@ msgstr "Remarques"
 msgid "Author"
 msgstr "Auteur"
 
-#: tcms/testcases/templates/testcases/get.html:64
-#: tcms/testcases/templates/testcases/search.html:123
+#: tcms/testcases/templates/testcases/get.html:48
+#: tcms/testcases/templates/testcases/mutable.html:29
+#: tcms/testcases/templates/testcases/search.html:119
 #: tcms/testplans/templates/testplans/mutable.html:113
 #: tcms/testruns/templates/testruns/search.html:94
 msgid "Default tester"
 msgstr "Testeur par défaut"
 
-#: tcms/testcases/templates/testcases/get.html:80
-#: tcms/testcases/templates/testcases/search.html:44
-#: tcms/testcases/templates/testcases/search.html:126
+#: tcms/testcases/templates/testcases/get.html:64
+#: tcms/testcases/templates/testcases/mutable.html:50
+#: tcms/testcases/templates/testcases/search.html:40
+#: tcms/testcases/templates/testcases/search.html:122
 #: tcms/testruns/templates/testruns/mutable.html:98
 msgid "Category"
 msgstr "Catégorie"
 
-#: tcms/testcases/templates/testcases/get.html:90
-#: tcms/testcases/templates/testcases/search.html:75
-#: tcms/testcases/templates/testcases/search.html:125
+#: tcms/testcases/templates/testcases/get.html:74
+#: tcms/testcases/templates/testcases/mutable.html:66
+#: tcms/testcases/templates/testcases/search.html:16
+#: tcms/testcases/templates/testcases/search.html:71
+#: tcms/testcases/templates/testcases/search.html:121
 #: tcms/testruns/templates/testruns/mutable.html:97
 msgid "Status"
 msgstr "Statut"
 
-#: tcms/testcases/templates/testcases/get.html:95
-#: tcms/testcases/templates/testcases/search.html:66
-#: tcms/testcases/templates/testcases/search.html:127
+#: tcms/testcases/templates/testcases/get.html:79
+#: tcms/testcases/templates/testcases/mutable.html:78
+#: tcms/testcases/templates/testcases/search.html:62
+#: tcms/testcases/templates/testcases/search.html:123
 #: tcms/testruns/templates/testruns/mutable.html:99
 msgid "Priority"
 msgstr "Priorité"
 
-#: tcms/testcases/templates/testcases/get.html:109
-#: tcms/testcases/templates/testcases/search.html:16
-#: tcms/testcases/templates/testcases/search.html:124
+#: tcms/testcases/templates/testcases/get.html:93
+#: tcms/testcases/templates/testcases/mutable.html:90
+#: tcms/testcases/templates/testcases/search.html:19
+#: tcms/testcases/templates/testcases/search.html:120
 msgid "Automated"
 msgstr "Automatiser"
 
-#: tcms/testcases/templates/testcases/get.html:114
+#: tcms/testcases/templates/testcases/get.html:98
+#: tcms/testcases/templates/testcases/mutable.html:105
 msgid "Script"
 msgstr "Script"
 
-#: tcms/testcases/templates/testcases/get.html:119
+#: tcms/testcases/templates/testcases/get.html:103
+#: tcms/testcases/templates/testcases/mutable.html:111
 msgid "Arguments"
 msgstr "Arguments"
 
-#: tcms/testcases/templates/testcases/get.html:124
+#: tcms/testcases/templates/testcases/get.html:108
 msgid "Requirements"
 msgstr "Spécifications requises"
 
-#: tcms/testcases/templates/testcases/get.html:129
+#: tcms/testcases/templates/testcases/get.html:113
+#: tcms/testcases/templates/testcases/mutable.html:124
 #: tcms/testplans/templates/testplans/mutable.html:83
 msgid "Reference link"
 msgstr "Lien référencé"
 
-#: tcms/testcases/templates/testcases/get.html:300
+#: tcms/testcases/templates/testcases/get.html:284
 msgid "Bugs"
 msgstr "Anomalies"
 
-#: tcms/testcases/templates/testcases/get.html:307
+#: tcms/testcases/templates/testcases/get.html:291
 msgid "Bug URL"
 msgstr "URL de remonter d'anomalie"
 
-#: tcms/testcases/templates/testcases/get.html:319
+#: tcms/testcases/templates/testcases/get.html:303
 msgid "Test plans"
 msgstr "Plans de test"
 
-#: tcms/testcases/templates/testcases/get.html:326
-#: tcms/testcases/templates/testcases/search.html:120
+#: tcms/testcases/templates/testcases/get.html:310
+#: tcms/testcases/templates/testcases/search.html:116
 #: tcms/testplans/templates/testplans/search.html:132
 #: tcms/testruns/templates/testruns/search.html:90
 msgid "ID"
 msgstr "ID"
 
-#: tcms/testcases/templates/testcases/get.html:346
+#: tcms/testcases/templates/testcases/get.html:330
 msgid "Tags"
 msgstr "Étiquettes"
 
-#: tcms/testcases/templates/testcases/get.html:367
-#: tcms/testcases/templates/testcases/get.html:404
+#: tcms/testcases/templates/testcases/get.html:351
+#: tcms/testcases/templates/testcases/get.html:388
 msgid "Add"
 msgstr "Ajouter"
 
-#: tcms/testcases/templates/testcases/get.html:383
+#: tcms/testcases/templates/testcases/get.html:367
 msgid "Components"
 msgstr "Composants"
 
-#: tcms/testcases/templates/testcases/get.html:420
+#: tcms/testcases/templates/testcases/get.html:404
 msgid "Attachments"
 msgstr "Pièces jointes"
 
-#: tcms/testcases/templates/testcases/get.html:427
+#: tcms/testcases/templates/testcases/get.html:411
 msgid "File"
 msgstr "Fichier"
 
-#: tcms/testcases/templates/testcases/get.html:428
+#: tcms/testcases/templates/testcases/get.html:412
 msgid "Owner"
 msgstr "Propriétaire"
 
-#: tcms/testcases/templates/testcases/get.html:429
+#: tcms/testcases/templates/testcases/get.html:413
 msgid "Date"
 msgstr "Date"
 
-#: tcms/testcases/templates/testcases/get.html:443
+#: tcms/testcases/templates/testcases/get.html:427
 msgid "No records found"
 msgstr "Pas d'enregistrements trouvés"
 
-#: tcms/testcases/templates/testcases/search.html:5
-msgid "Search test cases"
-msgstr "Rechercher des cas de tests"
+#: tcms/testcases/templates/testcases/mutable.html:9
+msgid "New TestCase"
+msgstr ""
 
+#: tcms/testcases/templates/testcases/mutable.html:18
 #: tcms/testcases/templates/testcases/search.html:11
-#: tcms/testcases/templates/testcases/search.html:121
+#: tcms/testcases/templates/testcases/search.html:117
 #: tcms/testruns/templates/testruns/mutable.html:23
 #: tcms/testruns/templates/testruns/mutable.html:94
 #: tcms/testruns/templates/testruns/search.html:11
@@ -594,77 +665,105 @@ msgstr "Rechercher des cas de tests"
 msgid "Summary"
 msgstr "Récapitulatif"
 
+#: tcms/testcases/templates/testcases/mutable.html:36
+#: tcms/testplans/templates/testplans/mutable.html:33
+msgid "add new Product"
+msgstr "Ajouter un nouveau produit"
+
+#: tcms/testcases/templates/testcases/mutable.html:51
+msgid "add new Category"
+msgstr ""
+
+#: tcms/testcases/templates/testcases/mutable.html:98
+msgid "Text"
+msgstr ""
+
+#: tcms/testcases/templates/testcases/mutable.html:119
+msgid "Requirments"
+msgstr ""
+
+#: tcms/testcases/templates/testcases/mutable.html:139
+#: tcms/testplans/templates/testplans/mutable.html:143
+#: tcms/testruns/templates/testruns/mutable.html:72
+msgid "Save"
+msgstr "Sauvegarder"
+
+#: tcms/testcases/templates/testcases/search.html:5
+msgid "Search test cases"
+msgstr "Rechercher des cas de tests"
+
 #: tcms/testcases/templates/testcases/search.html:13
 #: tcms/testruns/templates/testruns/search.html:13
 msgid "Test run summary"
 msgstr "Résumé des essais de test"
 
-#: tcms/testcases/templates/testcases/search.html:26
-msgid "Proposed for automation"
-msgstr "Proposé pour l’automatisation"
+#: tcms/testcases/templates/testcases/search.html:22
+msgid "Manual"
+msgstr ""
 
-#: tcms/testcases/templates/testcases/search.html:29
-msgid "Search all when OFF"
-msgstr "Recherché tous les ETEINTS"
+#: tcms/testcases/templates/testcases/search.html:25
+msgid "Both"
+msgstr ""
 
-#: tcms/testcases/templates/testcases/search.html:54
+#: tcms/testcases/templates/testcases/search.html:50
+#: tcms/testcases/templates/testcases/search.html:125
 msgid "Component"
 msgstr "Composant"
 
-#: tcms/testcases/templates/testcases/search.html:97
+#: tcms/testcases/templates/testcases/search.html:93
 #: tcms/testplans/templates/testplans/search.html:111
 #: tcms/testruns/templates/testruns/search.html:74
 msgid "Tag"
 msgstr "Étiquette"
 
-#: tcms/testcases/templates/testcases/search.html:100
-#: tcms/testcases/templates/testcases/search.html:106
+#: tcms/testcases/templates/testcases/search.html:96
+#: tcms/testcases/templates/testcases/search.html:102
 #: tcms/testplans/templates/testplans/search.html:114
 #: tcms/testruns/templates/testruns/search.html:77
 msgid "Separate multiple values with comma (,)"
 msgstr "Séparez les valeurs multiples avec une virgule (,)"
 
-#: tcms/testcases/templates/testcases/search.html:103
-#: tcms/testcases/templates/testcases/search.html:105
+#: tcms/testcases/templates/testcases/search.html:99
+#: tcms/testcases/templates/testcases/search.html:101
 msgid "Bug ID"
 msgstr "ID de l'anomalie"
 
-#: tcms/testcases/templates/testcases/search.html:112
+#: tcms/testcases/templates/testcases/search.html:108
 #: tcms/testplans/templates/testplans/search.html:124
 #: tcms/testruns/templates/testruns/search.html:82
 msgid "Search"
 msgstr "Recherche"
 
-#: tcms/testcases/templates/testcases/search.html:128
+#: tcms/testcases/templates/testcases/search.html:124
 msgid "Created at"
 msgstr "Créé le"
 
-#: tcms/testcases/views.py:463
+#: tcms/testcases/views.py:448
 msgid "TestPlan not specified or does not exist"
 msgstr "Plan de test non spécifié ou n'existe pas"
 
-#: tcms/testcases/views.py:642
+#: tcms/testcases/views.py:622
 msgid "Edit"
 msgstr "Modifier"
 
-#: tcms/testcases/views.py:646
+#: tcms/testcases/views.py:626
 msgid "Clone"
 msgstr "Dupliquer"
 
-#: tcms/testcases/views.py:650
+#: tcms/testcases/views.py:630
 msgid "History"
 msgstr "Historique"
 
-#: tcms/testcases/views.py:655
+#: tcms/testcases/views.py:635
 msgid "Delete"
 msgstr "Supprimer"
 
-#: tcms/testcases/views.py:934 tcms/testruns/views.py:499
-#: tcms/testruns/views.py:577
+#: tcms/testcases/views.py:861 tcms/testruns/views.py:497
+#: tcms/testruns/views.py:575
 msgid "At least one TestCase is required"
 msgstr "Au moins un cas de test est requis"
 
-#: tcms/testcases/views.py:1083
+#: tcms/testcases/views.py:998
 msgid "TestCase cloning was successful"
 msgstr "Le clonage du cas de test a été réalisé avec succès"
 
@@ -675,10 +774,6 @@ msgstr "Modifier le plan de test"
 #: tcms/testplans/templates/testplans/mutable.html:12
 msgid "Create new TestPlan"
 msgstr "Créer un nouveau plan de test"
-
-#: tcms/testplans/templates/testplans/mutable.html:33
-msgid "add new Product"
-msgstr "Ajouter un nouveau produit"
 
 #: tcms/testplans/templates/testplans/mutable.html:47
 #: tcms/testplans/templates/testplans/search.html:76
@@ -723,11 +818,6 @@ msgstr "Les plans de test ont été mis à jour"
 #: tcms/testplans/templates/testplans/search.html:117
 msgid "Active"
 msgstr "Actif"
-
-#: tcms/testplans/templates/testplans/mutable.html:143
-#: tcms/testruns/templates/testruns/mutable.html:72
-msgid "Save"
-msgstr "Sauvegarder"
 
 #: tcms/testplans/templates/testplans/search.html:5
 msgid "Search test plans"
@@ -825,12 +915,16 @@ msgstr "Sélectionner des Cas de Tests:"
 
 #: tcms/testruns/templates/testruns/mutable.html:84
 #, python-format
-msgid "\n"
-"                    %(count)s of the pre-selected test cases is not CONFIRMED and will not be cloned!\n"
+msgid ""
+"\n"
+"                    %(count)s of the pre-selected test cases is not "
+"CONFIRMED and will not be cloned!\n"
 "                    See test plan for more details!\n"
 "                    "
-msgstr "\n"
-"                    %(count)s cas de test pré-sélectionné et qui ne sont pas confirmé et qui n'ont pas été cloné!\n"
+msgstr ""
+"\n"
+"                    %(count)s cas de test pré-sélectionné et qui ne sont pas "
+"confirmé et qui n'ont pas été cloné!\n"
 "                    Voir le plan de test pour plus de détail!\n"
 "                    "
 
@@ -860,21 +954,22 @@ msgstr "Fini à"
 
 #: tcms/testruns/views.py:49
 msgid "Creating a TestRun requires a TestPlan, select one"
-msgstr "Créé un essai de test requiert un plan de test, veuillez en sélectionné un"
+msgstr ""
+"Créé un essai de test requiert un plan de test, veuillez en sélectionné un"
 
 #: tcms/testruns/views.py:59
 msgid "Creating a TestRun requires at least one TestCase"
 msgstr "Créé un essai de test requiert au moins un cas de test"
 
-#: tcms/testruns/views.py:503
+#: tcms/testruns/views.py:501
 msgid "Clone of "
 msgstr "Clone de "
 
-#: tcms/testruns/views.py:586
+#: tcms/testruns/views.py:584
 msgid "TestCase ID is not a valid integer"
 msgstr "ID du cas de test n'est plus un entier valide"
 
-#: tcms/testruns/views.py:713
+#: tcms/testruns/views.py:711
 #, python-format
 msgid "%d CaseRun(s) updated:"
 msgstr "Essai du cas %d mis à jour:"
@@ -882,7 +977,9 @@ msgstr "Essai du cas %d mis à jour:"
 #: tcms/xmlrpc/serializer.py:287
 #, python-format
 msgid "Model %s has no primary key. You have to specify such field manually."
-msgstr "Le modèle %s ne possède aucune clé primaire. Vous devez spécifier tel champ manuellement."
+msgstr ""
+"Le modèle %s ne possède aucune clé primaire. Vous devez spécifier tel champ "
+"manuellement."
 
 #: vinaigrette-deleteme.py:2
 msgid "IDLE"
@@ -931,23 +1028,3 @@ msgstr "DÉSACTIVÉ"
 #: vinaigrette-deleteme.py:13
 msgid "NEED_UPDATE"
 msgstr "DOIT_ÊTRE_MAJ"
-
-#: tcms/testcases/forms.py:95
-msgid ""
-"**Scenario**: ... what behavior will be tested ...\n"
-"  **Given** ... conditions ...\n"
-"  **When** ... actions ...\n"
-"  **Then** ... expected results ...\n"
-"\n"
-"*Actions*:\n"
-"\n"
-"1. item\n"
-"2. item\n"
-"3. item\n"
-"\n"
-"*Expected results*:\n"
-"\n"
-"1. item\n"
-"2. item\n"
-"3. item\n"
-msgstr ""

--- a/tcms/locale/sl_SI/LC_MESSAGES/django.po
+++ b/tcms/locale/sl_SI/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: kiwitcms\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-01-24 21:57+0000\n"
+"POT-Creation-Date: 2019-01-26 10:28+0000\n"
 "PO-Revision-Date: 2019-01-25 06:42\n"
 "Last-Translator: atodorov <atodorov@otb.bg>\n"
 "Language-Team: Slovenian\n"
@@ -10,13 +10,14 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=4; plural=(n%100==1 ? 1 : n%100==2 ? 2 : n%100==3 || n%100==4 ? 3 : 0);\n"
+"Plural-Forms: nplurals=4; plural=(n%100==1 ? 1 : n%100==2 ? 2 : n%100==3 || n"
+"%100==4 ? 3 : 0);\n"
 "X-Generator: crowdin.com\n"
 "X-Crowdin-Project: kiwitcms\n"
 "X-Crowdin-Language: sl\n"
 "X-Crowdin-File: /master/tcms/locale/en/LC_MESSAGES/django.po\n"
 
-#: tcms/core/ajax.py:157 tcms/testruns/views.py:765
+#: tcms/core/ajax.py:157 tcms/testruns/views.py:763
 #, python-format
 msgid "User %s not found!"
 msgstr "Uporabnika %s ni bilo mogoče najti!"
@@ -26,9 +27,9 @@ msgid "Core customized comments"
 msgstr "Jedrni komentarji - po meri"
 
 #: tcms/core/contrib/comments/forms.py:14
-#: tcms/testcases/templates/testcases/get.html:327
-#: tcms/testcases/templates/testcases/get.html:353
-#: tcms/testcases/templates/testcases/get.html:390
+#: tcms/testcases/templates/testcases/get.html:311
+#: tcms/testcases/templates/testcases/get.html:337
+#: tcms/testcases/templates/testcases/get.html:374
 #: tcms/testplans/templates/testplans/mutable.html:23
 #: tcms/testplans/templates/testplans/search.html:11
 msgid "Name"
@@ -53,21 +54,31 @@ msgstr "POSODOBITEV: %(model_name)s #%(pk)d - %(title)s"
 
 #: tcms/core/history.py:47
 #, python-format
-msgid "Updated on %(history_date)s\n"
-"Updated by %(username)s\n\n"
-"%(diff)s\n\n"
+msgid ""
+"Updated on %(history_date)s\n"
+"Updated by %(username)s\n"
+"\n"
+"%(diff)s\n"
+"\n"
 "For more information:\n"
 "%(instance_url)s"
-msgstr "Čas posodobitve %(history_date)s\n"
-"Posodobil %(username)s\n\n"
-"%(diff)s\n\n"
+msgstr ""
+"Čas posodobitve %(history_date)s\n"
+"Posodobil %(username)s\n"
+"\n"
+"%(diff)s\n"
+"\n"
 "Dodatne informacije:\n"
 "%(instance_url)s"
 
 #: tcms/core/middleware.py:25
 #, python-format
-msgid "Base URL is not configured! See <a href=\"%(doc_url)s\">documentation</a> and <a href=\"%(admin_url)s\">change it</a>"
-msgstr "URL aplikacije ni nastavljen! <a href=\"%(doc_url)s\">Preverite dokumentacijo</a> in ga <a href=\"%(admin_url)s\">spremenite</a>"
+msgid ""
+"Base URL is not configured! See <a href=\"%(doc_url)s\">documentation</a> "
+"and <a href=\"%(admin_url)s\">change it</a>"
+msgstr ""
+"URL aplikacije ni nastavljen! <a href=\"%(doc_url)s\">Preverite "
+"dokumentacijo</a> in ga <a href=\"%(admin_url)s\">spremenite</a>"
 
 #: tcms/kiwi_auth/admin.py:24
 msgid "This email address is already in use"
@@ -91,12 +102,18 @@ msgid "Your new %s account confirmation"
 msgstr "Informacije o uporabniškem računu %s ."
 
 #: tcms/kiwi_auth/views.py:47
-msgid "Your account has been created, please check your mailbox for confirmation"
-msgstr "Uporabniški račun je bil uspešno kreiran, preverite vaš e-poštni nabiralnik za potrditveno povezavo preko katere ga aktivirate"
+msgid ""
+"Your account has been created, please check your mailbox for confirmation"
+msgstr ""
+"Uporabniški račun je bil uspešno kreiran, preverite vaš e-poštni nabiralnik "
+"za potrditveno povezavo preko katere ga aktivirate"
 
 #: tcms/kiwi_auth/views.py:53
-msgid "Your account has been created, but you need an administrator to activate it"
-msgstr "Uporabniški račun je bil ustvarjen. Pred uporabo ga mora potrditi še administrator"
+msgid ""
+"Your account has been created, but you need an administrator to activate it"
+msgstr ""
+"Uporabniški račun je bil ustvarjen. Pred uporabo ga mora potrditi še "
+"administrator"
 
 #: tcms/kiwi_auth/views.py:58
 msgid "Following is the administrator list"
@@ -229,12 +246,16 @@ msgstr "Začeto ob"
 
 #: tcms/templates/dashboard.html:26
 #, python-format
-msgid "\n"
-"                %(total_count)s TestRun(s) or TestCase(s) assigned to you need to be executed.\n"
+msgid ""
+"\n"
+"                %(total_count)s TestRun(s) or TestCase(s) assigned to you "
+"need to be executed.\n"
 "                Here are the latest %(count)s.\n"
 "                "
-msgstr "\n"
-"                %(total_count)s testiranj in/ali testov na katere ste dodeljeni scenarijev čaka na izvedbo.\n"
+msgstr ""
+"\n"
+"                %(total_count)s testiranj in/ali testov na katere ste "
+"dodeljeni scenarijev čaka na izvedbo.\n"
 "               Prikazanih je zadnjih %(count)s.\n"
 "                "
 
@@ -255,9 +276,10 @@ msgid "TestPlan"
 msgstr "Repozitorij testov"
 
 #: tcms/templates/dashboard.html:49
-#: tcms/testcases/templates/testcases/get.html:75
-#: tcms/testcases/templates/testcases/get.html:330
-#: tcms/testcases/templates/testcases/search.html:34
+#: tcms/testcases/templates/testcases/get.html:59
+#: tcms/testcases/templates/testcases/get.html:314
+#: tcms/testcases/templates/testcases/mutable.html:35
+#: tcms/testcases/templates/testcases/search.html:30
 #: tcms/testplans/templates/testplans/mutable.html:32
 #: tcms/testplans/templates/testplans/search.html:66
 #: tcms/testplans/templates/testplans/search.html:136
@@ -268,7 +290,7 @@ msgid "Product"
 msgstr "Izdelek"
 
 #: tcms/templates/dashboard.html:50
-#: tcms/testcases/templates/testcases/get.html:329
+#: tcms/testcases/templates/testcases/get.html:313
 #: tcms/testplans/templates/testplans/mutable.html:65
 #: tcms/testplans/templates/testplans/search.html:86
 #: tcms/testplans/templates/testplans/search.html:137
@@ -276,18 +298,22 @@ msgid "Type"
 msgstr "Tip"
 
 #: tcms/templates/dashboard.html:51
-#: tcms/testcases/templates/testcases/get.html:147
+#: tcms/testcases/templates/testcases/get.html:131
 msgid "Executions"
 msgstr "Izvedbe"
 
 #: tcms/templates/dashboard.html:72
 #, python-format
-msgid "\n"
-"                You manage %(total_count)s TestPlan(s), %(disabled_count)s are disabled.\n"
+msgid ""
+"\n"
+"                You manage %(total_count)s TestPlan(s), %(disabled_count)s "
+"are disabled.\n"
 "                Here are the latest %(count)s.\n"
 "                "
-msgstr "\n"
-"                Imate %(total_count)s reopozitorijev testov, %(disabled_count)s je onemogočenih.\n"
+msgstr ""
+"\n"
+"                Imate %(total_count)s reopozitorijev testov, "
+"%(disabled_count)s je onemogočenih.\n"
 "                Tukaj so zadnji %(count)s.\n"
 "                "
 
@@ -297,61 +323,84 @@ msgstr "Noben testni plan vam ni dodeljen"
 
 #: tcms/templates/email/confirm_registration.txt:1
 #, python-format
-msgid "Welcome %(user)s,\n"
-"thank you for signing up for an %(site_domain)s account!\n\n"
+msgid ""
+"Welcome %(user)s,\n"
+"thank you for signing up for an %(site_domain)s account!\n"
+"\n"
 "To activate your account, click this link:\n"
 "%(confirm_url)s\n"
-msgstr "Pozdravljen-/a %(user)s,\n"
-"uspešno je bil kreiran uporabniški račun za domeno %(site_domain)s !\n\n"
+msgstr ""
+"Pozdravljen-/a %(user)s,\n"
+"uspešno je bil kreiran uporabniški račun za domeno %(site_domain)s !\n"
+"\n"
 "Za aktivacijo računa kliknite na spodnjo povezavo\n"
 "%(confirm_url)s\n"
 
 #: tcms/templates/email/post_case_delete/email.txt:2
 #, python-format
-msgid "\n"
+msgid ""
+"\n"
 "TestCase has been updated by %(username)s!\n"
-msgstr "\n"
+msgstr ""
+"\n"
 "Testni scenarij je posodobil %(username)s!\n"
 
 #: tcms/templates/email/post_run_save/email.txt:2
 #, python-format
-msgid "\n"
-"Test run %(pk)s has been created or updated for you.\n\n"
+msgid ""
+"\n"
+"Test run %(pk)s has been created or updated for you.\n"
+"\n"
 "### Links ###\n"
 "Test run: %(run_url)s\n"
-"Test plan: %(plan_url)s\n\n"
+"Test plan: %(plan_url)s\n"
+"\n"
 "### Basic run information ###\n"
-"Summary: %(summary)s\n\n"
+"Summary: %(summary)s\n"
+"\n"
 "Managed: %(manager)s.\n"
-"Default tester: %(default_tester)s.\n\n"
+"Default tester: %(default_tester)s.\n"
+"\n"
 "Product: %(product)s\n"
 "Product version: %(version)s\n"
-"Build: %(build)s\n\n"
+"Build: %(build)s\n"
+"\n"
 "Notes:\n"
 "%(notes)s\n"
-msgstr "\n"
-"Testiranje %(pk)s je bilo ustvarjeno ali posobljeno.\n\n"
+msgstr ""
+"\n"
+"Testiranje %(pk)s je bilo ustvarjeno ali posobljeno.\n"
+"\n"
 "### Povezano ###\n"
 "Testiranje: %(run_url)s\n"
-"Baza testnih scenarijev: %(plan_url)s\n\n"
+"Baza testnih scenarijev: %(plan_url)s\n"
+"\n"
 "### Osnovne informacije o testiranju ###\n"
-"Povzetek: %(summary)s\n\n"
+"Povzetek: %(summary)s\n"
+"\n"
 "Vodja testiranja: %(manager)s.\n"
-"Zadolženi tester: %(default_tester)s.\n\n"
+"Zadolženi tester: %(default_tester)s.\n"
+"\n"
 "Produkt: %(product)s\n"
 "Verzija produkta: %(version)s\n"
-"Build: %(build)s\n\n"
+"Build: %(build)s\n"
+"\n"
 "Zapiski:\n"
 "%(notes)s\n"
 
 #: tcms/templates/email/user_registered/notify_admins.txt:2
 #, python-format
-msgid "Dear Administrator,\n"
+msgid ""
+"Dear Administrator,\n"
 "somebody just registered an account with username %(username)s at your\n"
-"Kiwi TCMS instance and is awaiting your approval!\n\n"
+"Kiwi TCMS instance and is awaiting your approval!\n"
+"\n"
 "Go to %(user_url)s to activate the account!\n"
-msgstr "Spoštovani administrator,\n"
-"uporabnik %(username)s je kreiral nov uporabniški račun v sistemu Kiwi TCMS, kateri čaka na potrditev.\n\n"
+msgstr ""
+"Spoštovani administrator,\n"
+"uporabnik %(username)s je kreiral nov uporabniški račun v sistemu Kiwi TCMS, "
+"kateri čaka na potrditev.\n"
+"\n"
 "Aktivacija računa je mogoča na sledeči povezavi %(user_url)s !\n"
 
 #: tcms/templates/pagination.html:7
@@ -376,7 +425,7 @@ msgstr "Zadnja stran"
 
 #: tcms/templates/registration/login.html:17
 #: tcms/templates/registration/registration_form.html:15
-#: tcms/testcases/templates/testcases/search.html:90
+#: tcms/testcases/templates/testcases/search.html:86
 #: tcms/testplans/templates/testplans/search.html:100
 #: tcms/testplans/templates/testplans/search.html:106
 #: tcms/testruns/templates/testruns/search.html:58
@@ -408,7 +457,9 @@ msgid "Change password"
 msgstr "Spremeni geslo"
 
 #: tcms/templates/registration/password_reset_confirm.html:43
-msgid "Please enter your new password twice so we can verify you typed it in correctly"
+msgid ""
+"Please enter your new password twice so we can verify you typed it in "
+"correctly"
 msgstr "Novo geslo vnesite dvakrat"
 
 #: tcms/templates/registration/password_reset_done.html:11
@@ -436,40 +487,65 @@ msgstr "Registriraj nov račun"
 msgid "Register"
 msgstr "Registracija"
 
-#: tcms/testcases/forms.py:36
-msgid "Please input valid case id(s). use comma to split more than one case id. e.g. \"111, 222\""
-msgstr "Prosimo vnesite veljavne Id-je testni scenarijev. Uporabite vejico za več primerov npr. \"111, 222\""
+#: tcms/testcases/forms.py:21
+msgid ""
+"Please input valid case id(s). use comma to split more than one case id. e."
+"g. \"111, 222\""
+msgstr ""
+"Prosimo vnesite veljavne Id-je testni scenarijev. Uporabite vejico za več "
+"primerov npr. \"111, 222\""
+
+#: tcms/testcases/forms.py:95
+msgid ""
+"**Scenario**: ... what behavior will be tested ...\n"
+"  **Given** ... conditions ...\n"
+"  **When** ... actions ...\n"
+"  **Then** ... expected results ...\n"
+"\n"
+"*Actions*:\n"
+"\n"
+"1. item\n"
+"2. item\n"
+"3. item\n"
+"\n"
+"*Expected results*:\n"
+"\n"
+"1. item\n"
+"2. item\n"
+"3. item\n"
+msgstr ""
+"**Scenarij**: ... kaj testiramo..\n"
+"  **Pogoj** ... pogoji potrebni za izvedbo testa ...\n"
+"  **Ko** ... koraki za izvedbo testa...\n"
+"  **Potem** ... pričakovani rezultati...\n"
+"\n"
+"*Ko*:\n"
+"\n"
+"1. korak\n"
+"2. korak\n"
+"3. korak\n"
+"\n"
+"*Potem*:\n"
+"\n"
+"1. rezultat\n"
+"2. rezultat\n"
+"3. rezultat\n"
 
 #: tcms/testcases/helpers/email.py:22
 #, python-brace-format
 msgid "DELETED: TestCase #%{pk}d - %{summary}s"
 msgstr "Izbrisan: Testni scenarij #%{pk}d - %{summary}s"
 
-#: tcms/testcases/templates/testcases/get.html:29
-msgid "Setup"
-msgstr "Priprava"
-
-#: tcms/testcases/templates/testcases/get.html:34
-msgid "Actions"
-msgstr "Koraki"
-
-#: tcms/testcases/templates/testcases/get.html:39
-msgid "Expected result"
-msgstr "Pričakovan rezultat"
-
-#: tcms/testcases/templates/testcases/get.html:44
-msgid "Breakdown"
-msgstr "Po končanem testu"
-
-#: tcms/testcases/templates/testcases/get.html:49
+#: tcms/testcases/templates/testcases/get.html:33
+#: tcms/testcases/templates/testcases/mutable.html:132
 #: tcms/testruns/templates/testruns/mutable.html:66
 msgid "Notes"
 msgstr "Opombe"
 
-#: tcms/testcases/templates/testcases/get.html:59
-#: tcms/testcases/templates/testcases/get.html:328
-#: tcms/testcases/templates/testcases/search.html:88
-#: tcms/testcases/templates/testcases/search.html:122
+#: tcms/testcases/templates/testcases/get.html:43
+#: tcms/testcases/templates/testcases/get.html:312
+#: tcms/testcases/templates/testcases/search.html:84
+#: tcms/testcases/templates/testcases/search.html:118
 #: tcms/testplans/templates/testplans/mutable.html:101
 #: tcms/testplans/templates/testplans/search.html:98
 #: tcms/testplans/templates/testplans/search.html:135
@@ -477,115 +553,125 @@ msgstr "Opombe"
 msgid "Author"
 msgstr "Avtor"
 
-#: tcms/testcases/templates/testcases/get.html:64
-#: tcms/testcases/templates/testcases/search.html:123
+#: tcms/testcases/templates/testcases/get.html:48
+#: tcms/testcases/templates/testcases/mutable.html:29
+#: tcms/testcases/templates/testcases/search.html:119
 #: tcms/testplans/templates/testplans/mutable.html:113
 #: tcms/testruns/templates/testruns/search.html:94
 msgid "Default tester"
 msgstr "Privzeti tester"
 
-#: tcms/testcases/templates/testcases/get.html:80
-#: tcms/testcases/templates/testcases/search.html:44
-#: tcms/testcases/templates/testcases/search.html:126
+#: tcms/testcases/templates/testcases/get.html:64
+#: tcms/testcases/templates/testcases/mutable.html:50
+#: tcms/testcases/templates/testcases/search.html:40
+#: tcms/testcases/templates/testcases/search.html:122
 #: tcms/testruns/templates/testruns/mutable.html:98
 msgid "Category"
 msgstr "Kategorija"
 
-#: tcms/testcases/templates/testcases/get.html:90
-#: tcms/testcases/templates/testcases/search.html:75
-#: tcms/testcases/templates/testcases/search.html:125
+#: tcms/testcases/templates/testcases/get.html:74
+#: tcms/testcases/templates/testcases/mutable.html:66
+#: tcms/testcases/templates/testcases/search.html:16
+#: tcms/testcases/templates/testcases/search.html:71
+#: tcms/testcases/templates/testcases/search.html:121
 #: tcms/testruns/templates/testruns/mutable.html:97
 msgid "Status"
 msgstr "Status"
 
-#: tcms/testcases/templates/testcases/get.html:95
-#: tcms/testcases/templates/testcases/search.html:66
-#: tcms/testcases/templates/testcases/search.html:127
+#: tcms/testcases/templates/testcases/get.html:79
+#: tcms/testcases/templates/testcases/mutable.html:78
+#: tcms/testcases/templates/testcases/search.html:62
+#: tcms/testcases/templates/testcases/search.html:123
 #: tcms/testruns/templates/testruns/mutable.html:99
 msgid "Priority"
 msgstr "Prioriteta"
 
-#: tcms/testcases/templates/testcases/get.html:109
-#: tcms/testcases/templates/testcases/search.html:16
-#: tcms/testcases/templates/testcases/search.html:124
+#: tcms/testcases/templates/testcases/get.html:93
+#: tcms/testcases/templates/testcases/mutable.html:90
+#: tcms/testcases/templates/testcases/search.html:19
+#: tcms/testcases/templates/testcases/search.html:120
 msgid "Automated"
 msgstr "Avtomatizirano"
 
-#: tcms/testcases/templates/testcases/get.html:114
+#: tcms/testcases/templates/testcases/get.html:98
+#: tcms/testcases/templates/testcases/mutable.html:105
 msgid "Script"
 msgstr "Skripta"
 
-#: tcms/testcases/templates/testcases/get.html:119
+#: tcms/testcases/templates/testcases/get.html:103
+#: tcms/testcases/templates/testcases/mutable.html:111
 msgid "Arguments"
 msgstr "Argumenti"
 
-#: tcms/testcases/templates/testcases/get.html:124
+#: tcms/testcases/templates/testcases/get.html:108
 msgid "Requirements"
 msgstr "Zahteve"
 
-#: tcms/testcases/templates/testcases/get.html:129
+#: tcms/testcases/templates/testcases/get.html:113
+#: tcms/testcases/templates/testcases/mutable.html:124
 #: tcms/testplans/templates/testplans/mutable.html:83
 msgid "Reference link"
 msgstr "Referenčna povezava"
 
-#: tcms/testcases/templates/testcases/get.html:300
+#: tcms/testcases/templates/testcases/get.html:284
 msgid "Bugs"
 msgstr "Napake"
 
-#: tcms/testcases/templates/testcases/get.html:307
+#: tcms/testcases/templates/testcases/get.html:291
 msgid "Bug URL"
 msgstr "URL napake"
 
-#: tcms/testcases/templates/testcases/get.html:319
+#: tcms/testcases/templates/testcases/get.html:303
 msgid "Test plans"
 msgstr "Načrti testiranj"
 
-#: tcms/testcases/templates/testcases/get.html:326
-#: tcms/testcases/templates/testcases/search.html:120
+#: tcms/testcases/templates/testcases/get.html:310
+#: tcms/testcases/templates/testcases/search.html:116
 #: tcms/testplans/templates/testplans/search.html:132
 #: tcms/testruns/templates/testruns/search.html:90
 msgid "ID"
 msgstr "ID"
 
-#: tcms/testcases/templates/testcases/get.html:346
+#: tcms/testcases/templates/testcases/get.html:330
 msgid "Tags"
 msgstr "Značke"
 
-#: tcms/testcases/templates/testcases/get.html:367
-#: tcms/testcases/templates/testcases/get.html:404
+#: tcms/testcases/templates/testcases/get.html:351
+#: tcms/testcases/templates/testcases/get.html:388
 msgid "Add"
 msgstr "Dodaj"
 
-#: tcms/testcases/templates/testcases/get.html:383
+#: tcms/testcases/templates/testcases/get.html:367
 msgid "Components"
 msgstr "Komponente"
 
-#: tcms/testcases/templates/testcases/get.html:420
+#: tcms/testcases/templates/testcases/get.html:404
 msgid "Attachments"
 msgstr "Priloge"
 
-#: tcms/testcases/templates/testcases/get.html:427
+#: tcms/testcases/templates/testcases/get.html:411
 msgid "File"
 msgstr "Datoteka"
 
-#: tcms/testcases/templates/testcases/get.html:428
+#: tcms/testcases/templates/testcases/get.html:412
 msgid "Owner"
 msgstr "Zadolženi"
 
-#: tcms/testcases/templates/testcases/get.html:429
+#: tcms/testcases/templates/testcases/get.html:413
 msgid "Date"
 msgstr "Datum"
 
-#: tcms/testcases/templates/testcases/get.html:443
+#: tcms/testcases/templates/testcases/get.html:427
 msgid "No records found"
 msgstr "Ni iskalnih zadetkov"
 
-#: tcms/testcases/templates/testcases/search.html:5
-msgid "Search test cases"
-msgstr "Iskanje testnih scenarijev"
+#: tcms/testcases/templates/testcases/mutable.html:9
+msgid "New TestCase"
+msgstr ""
 
+#: tcms/testcases/templates/testcases/mutable.html:18
 #: tcms/testcases/templates/testcases/search.html:11
-#: tcms/testcases/templates/testcases/search.html:121
+#: tcms/testcases/templates/testcases/search.html:117
 #: tcms/testruns/templates/testruns/mutable.html:23
 #: tcms/testruns/templates/testruns/mutable.html:94
 #: tcms/testruns/templates/testruns/search.html:11
@@ -593,77 +679,105 @@ msgstr "Iskanje testnih scenarijev"
 msgid "Summary"
 msgstr "Povzetek"
 
+#: tcms/testcases/templates/testcases/mutable.html:36
+#: tcms/testplans/templates/testplans/mutable.html:33
+msgid "add new Product"
+msgstr "dodaj produkt"
+
+#: tcms/testcases/templates/testcases/mutable.html:51
+msgid "add new Category"
+msgstr ""
+
+#: tcms/testcases/templates/testcases/mutable.html:98
+msgid "Text"
+msgstr ""
+
+#: tcms/testcases/templates/testcases/mutable.html:119
+msgid "Requirments"
+msgstr ""
+
+#: tcms/testcases/templates/testcases/mutable.html:139
+#: tcms/testplans/templates/testplans/mutable.html:143
+#: tcms/testruns/templates/testruns/mutable.html:72
+msgid "Save"
+msgstr "Shrani"
+
+#: tcms/testcases/templates/testcases/search.html:5
+msgid "Search test cases"
+msgstr "Iskanje testnih scenarijev"
+
 #: tcms/testcases/templates/testcases/search.html:13
 #: tcms/testruns/templates/testruns/search.html:13
 msgid "Test run summary"
 msgstr "Povzetek testiranja"
 
-#: tcms/testcases/templates/testcases/search.html:26
-msgid "Proposed for automation"
-msgstr "Predlagano za avtomatizacijo"
+#: tcms/testcases/templates/testcases/search.html:22
+msgid "Manual"
+msgstr ""
 
-#: tcms/testcases/templates/testcases/search.html:29
-msgid "Search all when OFF"
-msgstr "Išči ko je vse nastavljeno na IZKLOPLJENO"
+#: tcms/testcases/templates/testcases/search.html:25
+msgid "Both"
+msgstr ""
 
-#: tcms/testcases/templates/testcases/search.html:54
+#: tcms/testcases/templates/testcases/search.html:50
+#: tcms/testcases/templates/testcases/search.html:125
 msgid "Component"
 msgstr "Komponenta"
 
-#: tcms/testcases/templates/testcases/search.html:97
+#: tcms/testcases/templates/testcases/search.html:93
 #: tcms/testplans/templates/testplans/search.html:111
 #: tcms/testruns/templates/testruns/search.html:74
 msgid "Tag"
 msgstr "Značka"
 
-#: tcms/testcases/templates/testcases/search.html:100
-#: tcms/testcases/templates/testcases/search.html:106
+#: tcms/testcases/templates/testcases/search.html:96
+#: tcms/testcases/templates/testcases/search.html:102
 #: tcms/testplans/templates/testplans/search.html:114
 #: tcms/testruns/templates/testruns/search.html:77
 msgid "Separate multiple values with comma (,)"
 msgstr "Ločite več oznak z vejicami (,)"
 
-#: tcms/testcases/templates/testcases/search.html:103
-#: tcms/testcases/templates/testcases/search.html:105
+#: tcms/testcases/templates/testcases/search.html:99
+#: tcms/testcases/templates/testcases/search.html:101
 msgid "Bug ID"
 msgstr "Identifikator buga"
 
-#: tcms/testcases/templates/testcases/search.html:112
+#: tcms/testcases/templates/testcases/search.html:108
 #: tcms/testplans/templates/testplans/search.html:124
 #: tcms/testruns/templates/testruns/search.html:82
 msgid "Search"
 msgstr "Iskanje"
 
-#: tcms/testcases/templates/testcases/search.html:128
+#: tcms/testcases/templates/testcases/search.html:124
 msgid "Created at"
 msgstr "Ustvarjeno ob"
 
-#: tcms/testcases/views.py:463
+#: tcms/testcases/views.py:448
 msgid "TestPlan not specified or does not exist"
 msgstr "Baza testnih scenarijev ni izbrana ali ne obstaja"
 
-#: tcms/testcases/views.py:642
+#: tcms/testcases/views.py:622
 msgid "Edit"
 msgstr "Uredi"
 
-#: tcms/testcases/views.py:646
+#: tcms/testcases/views.py:626
 msgid "Clone"
 msgstr "Podvoji"
 
-#: tcms/testcases/views.py:650
+#: tcms/testcases/views.py:630
 msgid "History"
 msgstr "Zgodovina"
 
-#: tcms/testcases/views.py:655
+#: tcms/testcases/views.py:635
 msgid "Delete"
 msgstr "Izbriši"
 
-#: tcms/testcases/views.py:934 tcms/testruns/views.py:499
-#: tcms/testruns/views.py:577
+#: tcms/testcases/views.py:861 tcms/testruns/views.py:497
+#: tcms/testruns/views.py:575
 msgid "At least one TestCase is required"
 msgstr "Vsaj en testni scenarij je zahtevan"
 
-#: tcms/testcases/views.py:1083
+#: tcms/testcases/views.py:998
 msgid "TestCase cloning was successful"
 msgstr "Kloniranje testnega scenarija je uspelo"
 
@@ -674,10 +788,6 @@ msgstr "Uredi testni načrt"
 #: tcms/testplans/templates/testplans/mutable.html:12
 msgid "Create new TestPlan"
 msgstr "Ustvari nov testni plan"
-
-#: tcms/testplans/templates/testplans/mutable.html:33
-msgid "add new Product"
-msgstr "dodaj produkt"
 
 #: tcms/testplans/templates/testplans/mutable.html:47
 #: tcms/testplans/templates/testplans/search.html:76
@@ -722,11 +832,6 @@ msgstr "Testni scenariji so posodobljeni"
 #: tcms/testplans/templates/testplans/search.html:117
 msgid "Active"
 msgstr "Aktiven"
-
-#: tcms/testplans/templates/testplans/mutable.html:143
-#: tcms/testruns/templates/testruns/mutable.html:72
-msgid "Save"
-msgstr "Shrani"
 
 #: tcms/testplans/templates/testplans/search.html:5
 msgid "Search test plans"
@@ -824,12 +929,16 @@ msgstr "Izbrani testni scenariji(s):"
 
 #: tcms/testruns/templates/testruns/mutable.html:84
 #, python-format
-msgid "\n"
-"                    %(count)s of the pre-selected test cases is not CONFIRMED and will not be cloned!\n"
+msgid ""
+"\n"
+"                    %(count)s of the pre-selected test cases is not "
+"CONFIRMED and will not be cloned!\n"
 "                    See test plan for more details!\n"
 "                    "
-msgstr "\n"
-"                    %(count)s testni scenarijev ni v statusu potrjen in se ne bodo prenesli.\n"
+msgstr ""
+"\n"
+"                    %(count)s testni scenarijev ni v statusu potrjen in se "
+"ne bodo prenesli.\n"
 "                    Več podrobnosti je na voljo v informacijah testiranja!\n"
 "                    "
 
@@ -859,21 +968,25 @@ msgstr "Končano ob"
 
 #: tcms/testruns/views.py:49
 msgid "Creating a TestRun requires a TestPlan, select one"
-msgstr "V kolikor želite kreirati novo testiranje morate imeti ustvarjen testni repozitorij"
+msgstr ""
+"V kolikor želite kreirati novo testiranje morate imeti ustvarjen testni "
+"repozitorij"
 
 #: tcms/testruns/views.py:59
 msgid "Creating a TestRun requires at least one TestCase"
-msgstr "V kolikor želite kreirati novo testiranje morate dodati najmanj en testni scenarij"
+msgstr ""
+"V kolikor želite kreirati novo testiranje morate dodati najmanj en testni "
+"scenarij"
 
-#: tcms/testruns/views.py:503
+#: tcms/testruns/views.py:501
 msgid "Clone of "
 msgstr "Klon "
 
-#: tcms/testruns/views.py:586
+#: tcms/testruns/views.py:584
 msgid "TestCase ID is not a valid integer"
 msgstr "ID testnega scenarija ni celo število"
 
-#: tcms/testruns/views.py:713
+#: tcms/testruns/views.py:711
 #, python-format
 msgid "%d CaseRun(s) updated:"
 msgstr "%d testiranje posodobljeno:"
@@ -930,30 +1043,3 @@ msgstr "ONEMOGOČEN"
 #: vinaigrette-deleteme.py:13
 msgid "NEED_UPDATE"
 msgstr "ZA POPRAVITI"
-
-#: tcms/testcases/forms.py:95
-msgid "**Scenario**: ... what behavior will be tested ...\n"
-"  **Given** ... conditions ...\n"
-"  **When** ... actions ...\n"
-"  **Then** ... expected results ...\n\n"
-"*Actions*:\n\n"
-"1. item\n"
-"2. item\n"
-"3. item\n\n"
-"*Expected results*:\n\n"
-"1. item\n"
-"2. item\n"
-"3. item\n"
-msgstr "**Scenarij**: ... kaj testiramo..\n"
-"  **Pogoj** ... pogoji potrebni za izvedbo testa ...\n"
-"  **Ko** ... koraki za izvedbo testa...\n"
-"  **Potem** ... pričakovani rezultati...\n\n"
-"*Ko*:\n\n"
-"1. korak\n"
-"2. korak\n"
-"3. korak\n\n"
-"*Potem*:\n\n"
-"1. rezultat\n"
-"2. rezultat\n"
-"3. rezultat\n"
-

--- a/tcms/locale/zh_CN/LC_MESSAGES/django.po
+++ b/tcms/locale/zh_CN/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: kiwitcms\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-01-15 22:16+0000\n"
+"POT-Creation-Date: 2019-01-26 10:28+0000\n"
 "PO-Revision-Date: 2019-01-16 11:47\n"
 "Last-Translator: atodorov <atodorov@otb.bg>\n"
 "Language-Team: Chinese Simplified\n"
@@ -16,7 +16,7 @@ msgstr ""
 "X-Crowdin-Language: zh-CN\n"
 "X-Crowdin-File: /master/tcms/locale/en/LC_MESSAGES/django.po\n"
 
-#: tcms/core/ajax.py:157 tcms/testruns/views.py:765
+#: tcms/core/ajax.py:157 tcms/testruns/views.py:763
 #, python-format
 msgid "User %s not found!"
 msgstr ""
@@ -26,9 +26,9 @@ msgid "Core customized comments"
 msgstr "核心定制评论"
 
 #: tcms/core/contrib/comments/forms.py:14
-#: tcms/testcases/templates/testcases/get.html:327
-#: tcms/testcases/templates/testcases/get.html:353
-#: tcms/testcases/templates/testcases/get.html:390
+#: tcms/testcases/templates/testcases/get.html:311
+#: tcms/testcases/templates/testcases/get.html:337
+#: tcms/testcases/templates/testcases/get.html:374
 #: tcms/testplans/templates/testplans/mutable.html:23
 #: tcms/testplans/templates/testplans/search.html:11
 msgid "Name"
@@ -53,16 +53,21 @@ msgstr ""
 
 #: tcms/core/history.py:47
 #, python-format
-msgid "Updated on %(history_date)s\n"
-"Updated by %(username)s\n\n"
-"%(diff)s\n\n"
+msgid ""
+"Updated on %(history_date)s\n"
+"Updated by %(username)s\n"
+"\n"
+"%(diff)s\n"
+"\n"
 "For more information:\n"
 "%(instance_url)s"
 msgstr ""
 
 #: tcms/core/middleware.py:25
 #, python-format
-msgid "Base URL is not configured! See <a href=\"%(doc_url)s\">documentation</a> and <a href=\"%(admin_url)s\">change it</a>"
+msgid ""
+"Base URL is not configured! See <a href=\"%(doc_url)s\">documentation</a> "
+"and <a href=\"%(admin_url)s\">change it</a>"
 msgstr ""
 
 #: tcms/kiwi_auth/admin.py:24
@@ -87,11 +92,13 @@ msgid "Your new %s account confirmation"
 msgstr ""
 
 #: tcms/kiwi_auth/views.py:47
-msgid "Your account has been created, please check your mailbox for confirmation"
+msgid ""
+"Your account has been created, please check your mailbox for confirmation"
 msgstr "您的账户已创建，请检查您的收件箱进行确认"
 
 #: tcms/kiwi_auth/views.py:53
-msgid "Your account has been created, but you need an administrator to activate it"
+msgid ""
+"Your account has been created, but you need an administrator to activate it"
 msgstr "您的账户已创建，但您需要管理员来激活它"
 
 #: tcms/kiwi_auth/views.py:58
@@ -225,8 +232,10 @@ msgstr ""
 
 #: tcms/templates/dashboard.html:26
 #, python-format
-msgid "\n"
-"                %(total_count)s TestRun(s) or TestCase(s) assigned to you need to be executed.\n"
+msgid ""
+"\n"
+"                %(total_count)s TestRun(s) or TestCase(s) assigned to you "
+"need to be executed.\n"
 "                Here are the latest %(count)s.\n"
 "                "
 msgstr ""
@@ -248,9 +257,10 @@ msgid "TestPlan"
 msgstr ""
 
 #: tcms/templates/dashboard.html:49
-#: tcms/testcases/templates/testcases/get.html:75
-#: tcms/testcases/templates/testcases/get.html:330
-#: tcms/testcases/templates/testcases/search.html:34
+#: tcms/testcases/templates/testcases/get.html:59
+#: tcms/testcases/templates/testcases/get.html:314
+#: tcms/testcases/templates/testcases/mutable.html:35
+#: tcms/testcases/templates/testcases/search.html:30
 #: tcms/testplans/templates/testplans/mutable.html:32
 #: tcms/testplans/templates/testplans/search.html:66
 #: tcms/testplans/templates/testplans/search.html:136
@@ -261,7 +271,7 @@ msgid "Product"
 msgstr ""
 
 #: tcms/templates/dashboard.html:50
-#: tcms/testcases/templates/testcases/get.html:329
+#: tcms/testcases/templates/testcases/get.html:313
 #: tcms/testplans/templates/testplans/mutable.html:65
 #: tcms/testplans/templates/testplans/search.html:86
 #: tcms/testplans/templates/testplans/search.html:137
@@ -269,14 +279,16 @@ msgid "Type"
 msgstr ""
 
 #: tcms/templates/dashboard.html:51
-#: tcms/testcases/templates/testcases/get.html:147
+#: tcms/testcases/templates/testcases/get.html:131
 msgid "Executions"
 msgstr ""
 
 #: tcms/templates/dashboard.html:72
 #, python-format
-msgid "\n"
-"                You manage %(total_count)s TestPlan(s), %(disabled_count)s are disabled.\n"
+msgid ""
+"\n"
+"                You manage %(total_count)s TestPlan(s), %(disabled_count)s "
+"are disabled.\n"
 "                Here are the latest %(count)s.\n"
 "                "
 msgstr ""
@@ -287,57 +299,77 @@ msgstr ""
 
 #: tcms/templates/email/confirm_registration.txt:1
 #, python-format
-msgid "Welcome %(user)s,\n"
-"thank you for signing up for an %(site_domain)s account!\n\n"
+msgid ""
+"Welcome %(user)s,\n"
+"thank you for signing up for an %(site_domain)s account!\n"
+"\n"
 "To activate your account, click this link:\n"
 "%(confirm_url)s\n"
 msgstr ""
 
 #: tcms/templates/email/post_case_delete/email.txt:2
 #, python-format
-msgid "\n"
+msgid ""
+"\n"
 "TestCase has been updated by %(username)s!\n"
 msgstr ""
 
 #: tcms/templates/email/post_run_save/email.txt:2
 #, python-format
-msgid "\n"
-"Test run %(pk)s has been created or updated for you.\n\n"
+msgid ""
+"\n"
+"Test run %(pk)s has been created or updated for you.\n"
+"\n"
 "### Links ###\n"
 "Test run: %(run_url)s\n"
-"Test plan: %(plan_url)s\n\n"
+"Test plan: %(plan_url)s\n"
+"\n"
 "### Basic run information ###\n"
-"Summary: %(summary)s\n\n"
+"Summary: %(summary)s\n"
+"\n"
 "Managed: %(manager)s.\n"
-"Default tester: %(default_tester)s.\n\n"
+"Default tester: %(default_tester)s.\n"
+"\n"
 "Product: %(product)s\n"
 "Product version: %(version)s\n"
-"Build: %(build)s\n\n"
+"Build: %(build)s\n"
+"\n"
 "Notes:\n"
 "%(notes)s\n"
-msgstr "\n"
-"已为您新建或更新测试运行 %(pk)s 。\n\n"
+msgstr ""
+"\n"
+"已为您新建或更新测试运行 %(pk)s 。\n"
+"\n"
 "### 链接 ###\n"
 "测试运行: %(run_url)s\n"
-"测试计划: %(plan_url)s\n\n"
+"测试计划: %(plan_url)s\n"
+"\n"
 "### 基本运行信息 ###\n"
-"摘要: %(summary)s\n\n"
+"摘要: %(summary)s\n"
+"\n"
 "管理: %(manager)s.\n"
-"默认测试者: %(default_tester)s.\n\n"
+"默认测试者: %(default_tester)s.\n"
+"\n"
 "产品: %(product)s\n"
 "产品版本: %(version)s\n"
-"构建版本: %(build)s\n\n"
+"构建版本: %(build)s\n"
+"\n"
 "备注:\n"
 "%(notes)s\n"
 
 #: tcms/templates/email/user_registered/notify_admins.txt:2
 #, python-format
-msgid "Dear Administrator,\n"
+msgid ""
+"Dear Administrator,\n"
 "somebody just registered an account with username %(username)s at your\n"
-"Kiwi TCMS instance and is awaiting your approval!\n\n"
+"Kiwi TCMS instance and is awaiting your approval!\n"
+"\n"
 "Go to %(user_url)s to activate the account!\n"
-msgstr "亲爱的管理员,\n"
-"有人刚刚在您的 Kiwi TCMS 实例上注册了以 %(username)s 为名的用户并等待您的审批通过！\n\n"
+msgstr ""
+"亲爱的管理员,\n"
+"有人刚刚在您的 Kiwi TCMS 实例上注册了以 %(username)s 为名的用户并等待您的审批"
+"通过！\n"
+"\n"
 "请前往 %(user_url)s 激活账户！\n"
 
 #: tcms/templates/pagination.html:7
@@ -362,7 +394,7 @@ msgstr ""
 
 #: tcms/templates/registration/login.html:17
 #: tcms/templates/registration/registration_form.html:15
-#: tcms/testcases/templates/testcases/search.html:90
+#: tcms/testcases/templates/testcases/search.html:86
 #: tcms/testplans/templates/testplans/search.html:100
 #: tcms/testplans/templates/testplans/search.html:106
 #: tcms/testruns/templates/testruns/search.html:58
@@ -394,7 +426,9 @@ msgid "Change password"
 msgstr ""
 
 #: tcms/templates/registration/password_reset_confirm.html:43
-msgid "Please enter your new password twice so we can verify you typed it in correctly"
+msgid ""
+"Please enter your new password twice so we can verify you typed it in "
+"correctly"
 msgstr ""
 
 #: tcms/templates/registration/password_reset_done.html:11
@@ -422,8 +456,30 @@ msgstr ""
 msgid "Register"
 msgstr ""
 
-#: tcms/testcases/forms.py:36
-msgid "Please input valid case id(s). use comma to split more than one case id. e.g. \"111, 222\""
+#: tcms/testcases/forms.py:21
+msgid ""
+"Please input valid case id(s). use comma to split more than one case id. e."
+"g. \"111, 222\""
+msgstr ""
+
+#: tcms/testcases/forms.py:95
+msgid ""
+"**Scenario**: ... what behavior will be tested ...\n"
+"  **Given** ... conditions ...\n"
+"  **When** ... actions ...\n"
+"  **Then** ... expected results ...\n"
+"\n"
+"*Actions*:\n"
+"\n"
+"1. item\n"
+"2. item\n"
+"3. item\n"
+"\n"
+"*Expected results*:\n"
+"\n"
+"1. item\n"
+"2. item\n"
+"3. item\n"
 msgstr ""
 
 #: tcms/testcases/helpers/email.py:22
@@ -431,31 +487,16 @@ msgstr ""
 msgid "DELETED: TestCase #%{pk}d - %{summary}s"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/get.html:29
-msgid "Setup"
-msgstr ""
-
-#: tcms/testcases/templates/testcases/get.html:34
-msgid "Actions"
-msgstr ""
-
-#: tcms/testcases/templates/testcases/get.html:39
-msgid "Expected result"
-msgstr ""
-
-#: tcms/testcases/templates/testcases/get.html:44
-msgid "Breakdown"
-msgstr ""
-
-#: tcms/testcases/templates/testcases/get.html:49
+#: tcms/testcases/templates/testcases/get.html:33
+#: tcms/testcases/templates/testcases/mutable.html:132
 #: tcms/testruns/templates/testruns/mutable.html:66
 msgid "Notes"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/get.html:59
-#: tcms/testcases/templates/testcases/get.html:328
-#: tcms/testcases/templates/testcases/search.html:88
-#: tcms/testcases/templates/testcases/search.html:122
+#: tcms/testcases/templates/testcases/get.html:43
+#: tcms/testcases/templates/testcases/get.html:312
+#: tcms/testcases/templates/testcases/search.html:84
+#: tcms/testcases/templates/testcases/search.html:118
 #: tcms/testplans/templates/testplans/mutable.html:101
 #: tcms/testplans/templates/testplans/search.html:98
 #: tcms/testplans/templates/testplans/search.html:135
@@ -463,115 +504,125 @@ msgstr ""
 msgid "Author"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/get.html:64
-#: tcms/testcases/templates/testcases/search.html:123
+#: tcms/testcases/templates/testcases/get.html:48
+#: tcms/testcases/templates/testcases/mutable.html:29
+#: tcms/testcases/templates/testcases/search.html:119
 #: tcms/testplans/templates/testplans/mutable.html:113
 #: tcms/testruns/templates/testruns/search.html:94
 msgid "Default tester"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/get.html:80
-#: tcms/testcases/templates/testcases/search.html:44
-#: tcms/testcases/templates/testcases/search.html:126
+#: tcms/testcases/templates/testcases/get.html:64
+#: tcms/testcases/templates/testcases/mutable.html:50
+#: tcms/testcases/templates/testcases/search.html:40
+#: tcms/testcases/templates/testcases/search.html:122
 #: tcms/testruns/templates/testruns/mutable.html:98
 msgid "Category"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/get.html:90
-#: tcms/testcases/templates/testcases/search.html:75
-#: tcms/testcases/templates/testcases/search.html:125
+#: tcms/testcases/templates/testcases/get.html:74
+#: tcms/testcases/templates/testcases/mutable.html:66
+#: tcms/testcases/templates/testcases/search.html:16
+#: tcms/testcases/templates/testcases/search.html:71
+#: tcms/testcases/templates/testcases/search.html:121
 #: tcms/testruns/templates/testruns/mutable.html:97
 msgid "Status"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/get.html:95
-#: tcms/testcases/templates/testcases/search.html:66
-#: tcms/testcases/templates/testcases/search.html:127
+#: tcms/testcases/templates/testcases/get.html:79
+#: tcms/testcases/templates/testcases/mutable.html:78
+#: tcms/testcases/templates/testcases/search.html:62
+#: tcms/testcases/templates/testcases/search.html:123
 #: tcms/testruns/templates/testruns/mutable.html:99
 msgid "Priority"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/get.html:109
-#: tcms/testcases/templates/testcases/search.html:16
-#: tcms/testcases/templates/testcases/search.html:124
+#: tcms/testcases/templates/testcases/get.html:93
+#: tcms/testcases/templates/testcases/mutable.html:90
+#: tcms/testcases/templates/testcases/search.html:19
+#: tcms/testcases/templates/testcases/search.html:120
 msgid "Automated"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/get.html:114
+#: tcms/testcases/templates/testcases/get.html:98
+#: tcms/testcases/templates/testcases/mutable.html:105
 msgid "Script"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/get.html:119
+#: tcms/testcases/templates/testcases/get.html:103
+#: tcms/testcases/templates/testcases/mutable.html:111
 msgid "Arguments"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/get.html:124
+#: tcms/testcases/templates/testcases/get.html:108
 msgid "Requirements"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/get.html:129
+#: tcms/testcases/templates/testcases/get.html:113
+#: tcms/testcases/templates/testcases/mutable.html:124
 #: tcms/testplans/templates/testplans/mutable.html:83
 msgid "Reference link"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/get.html:300
+#: tcms/testcases/templates/testcases/get.html:284
 msgid "Bugs"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/get.html:307
+#: tcms/testcases/templates/testcases/get.html:291
 msgid "Bug URL"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/get.html:319
+#: tcms/testcases/templates/testcases/get.html:303
 msgid "Test plans"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/get.html:326
-#: tcms/testcases/templates/testcases/search.html:120
+#: tcms/testcases/templates/testcases/get.html:310
+#: tcms/testcases/templates/testcases/search.html:116
 #: tcms/testplans/templates/testplans/search.html:132
 #: tcms/testruns/templates/testruns/search.html:90
 msgid "ID"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/get.html:346
+#: tcms/testcases/templates/testcases/get.html:330
 msgid "Tags"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/get.html:367
-#: tcms/testcases/templates/testcases/get.html:404
+#: tcms/testcases/templates/testcases/get.html:351
+#: tcms/testcases/templates/testcases/get.html:388
 msgid "Add"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/get.html:383
+#: tcms/testcases/templates/testcases/get.html:367
 msgid "Components"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/get.html:420
+#: tcms/testcases/templates/testcases/get.html:404
 msgid "Attachments"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/get.html:427
+#: tcms/testcases/templates/testcases/get.html:411
 msgid "File"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/get.html:428
+#: tcms/testcases/templates/testcases/get.html:412
 msgid "Owner"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/get.html:429
+#: tcms/testcases/templates/testcases/get.html:413
 msgid "Date"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/get.html:443
+#: tcms/testcases/templates/testcases/get.html:427
 msgid "No records found"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/search.html:5
-msgid "Search test cases"
+#: tcms/testcases/templates/testcases/mutable.html:9
+msgid "New TestCase"
 msgstr ""
 
+#: tcms/testcases/templates/testcases/mutable.html:18
 #: tcms/testcases/templates/testcases/search.html:11
-#: tcms/testcases/templates/testcases/search.html:121
+#: tcms/testcases/templates/testcases/search.html:117
 #: tcms/testruns/templates/testruns/mutable.html:23
 #: tcms/testruns/templates/testruns/mutable.html:94
 #: tcms/testruns/templates/testruns/search.html:11
@@ -579,77 +630,105 @@ msgstr ""
 msgid "Summary"
 msgstr ""
 
+#: tcms/testcases/templates/testcases/mutable.html:36
+#: tcms/testplans/templates/testplans/mutable.html:33
+msgid "add new Product"
+msgstr ""
+
+#: tcms/testcases/templates/testcases/mutable.html:51
+msgid "add new Category"
+msgstr ""
+
+#: tcms/testcases/templates/testcases/mutable.html:98
+msgid "Text"
+msgstr ""
+
+#: tcms/testcases/templates/testcases/mutable.html:119
+msgid "Requirments"
+msgstr ""
+
+#: tcms/testcases/templates/testcases/mutable.html:139
+#: tcms/testplans/templates/testplans/mutable.html:143
+#: tcms/testruns/templates/testruns/mutable.html:72
+msgid "Save"
+msgstr ""
+
+#: tcms/testcases/templates/testcases/search.html:5
+msgid "Search test cases"
+msgstr ""
+
 #: tcms/testcases/templates/testcases/search.html:13
 #: tcms/testruns/templates/testruns/search.html:13
 msgid "Test run summary"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/search.html:26
-msgid "Proposed for automation"
+#: tcms/testcases/templates/testcases/search.html:22
+msgid "Manual"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/search.html:29
-msgid "Search all when OFF"
+#: tcms/testcases/templates/testcases/search.html:25
+msgid "Both"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/search.html:54
+#: tcms/testcases/templates/testcases/search.html:50
+#: tcms/testcases/templates/testcases/search.html:125
 msgid "Component"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/search.html:97
+#: tcms/testcases/templates/testcases/search.html:93
 #: tcms/testplans/templates/testplans/search.html:111
 #: tcms/testruns/templates/testruns/search.html:74
 msgid "Tag"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/search.html:100
-#: tcms/testcases/templates/testcases/search.html:106
+#: tcms/testcases/templates/testcases/search.html:96
+#: tcms/testcases/templates/testcases/search.html:102
 #: tcms/testplans/templates/testplans/search.html:114
 #: tcms/testruns/templates/testruns/search.html:77
 msgid "Separate multiple values with comma (,)"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/search.html:103
-#: tcms/testcases/templates/testcases/search.html:105
+#: tcms/testcases/templates/testcases/search.html:99
+#: tcms/testcases/templates/testcases/search.html:101
 msgid "Bug ID"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/search.html:112
+#: tcms/testcases/templates/testcases/search.html:108
 #: tcms/testplans/templates/testplans/search.html:124
 #: tcms/testruns/templates/testruns/search.html:82
 msgid "Search"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/search.html:128
+#: tcms/testcases/templates/testcases/search.html:124
 msgid "Created at"
 msgstr ""
 
-#: tcms/testcases/views.py:463
+#: tcms/testcases/views.py:448
 msgid "TestPlan not specified or does not exist"
 msgstr "测试计划未指定或不存在"
 
-#: tcms/testcases/views.py:642
+#: tcms/testcases/views.py:622
 msgid "Edit"
 msgstr ""
 
-#: tcms/testcases/views.py:646
+#: tcms/testcases/views.py:626
 msgid "Clone"
 msgstr ""
 
-#: tcms/testcases/views.py:650
+#: tcms/testcases/views.py:630
 msgid "History"
 msgstr ""
 
-#: tcms/testcases/views.py:655
+#: tcms/testcases/views.py:635
 msgid "Delete"
 msgstr ""
 
-#: tcms/testcases/views.py:934 tcms/testruns/views.py:499
-#: tcms/testruns/views.py:577
+#: tcms/testcases/views.py:861 tcms/testruns/views.py:497
+#: tcms/testruns/views.py:575
 msgid "At least one TestCase is required"
 msgstr "需要至少一个测试实例"
 
-#: tcms/testcases/views.py:1083
+#: tcms/testcases/views.py:998
 msgid "TestCase cloning was successful"
 msgstr "测试实例克隆成功"
 
@@ -659,10 +738,6 @@ msgstr ""
 
 #: tcms/testplans/templates/testplans/mutable.html:12
 msgid "Create new TestPlan"
-msgstr ""
-
-#: tcms/testplans/templates/testplans/mutable.html:33
-msgid "add new Product"
 msgstr ""
 
 #: tcms/testplans/templates/testplans/mutable.html:47
@@ -707,11 +782,6 @@ msgstr ""
 #: tcms/testplans/templates/testplans/mutable.html:137
 #: tcms/testplans/templates/testplans/search.html:117
 msgid "Active"
-msgstr ""
-
-#: tcms/testplans/templates/testplans/mutable.html:143
-#: tcms/testruns/templates/testruns/mutable.html:72
-msgid "Save"
 msgstr ""
 
 #: tcms/testplans/templates/testplans/search.html:5
@@ -810,8 +880,10 @@ msgstr ""
 
 #: tcms/testruns/templates/testruns/mutable.html:84
 #, python-format
-msgid "\n"
-"                    %(count)s of the pre-selected test cases is not CONFIRMED and will not be cloned!\n"
+msgid ""
+"\n"
+"                    %(count)s of the pre-selected test cases is not "
+"CONFIRMED and will not be cloned!\n"
 "                    See test plan for more details!\n"
 "                    "
 msgstr ""
@@ -848,15 +920,15 @@ msgstr ""
 msgid "Creating a TestRun requires at least one TestCase"
 msgstr "新建测试计划至少需要一个测试实例"
 
-#: tcms/testruns/views.py:503
+#: tcms/testruns/views.py:501
 msgid "Clone of "
 msgstr ""
 
-#: tcms/testruns/views.py:586
+#: tcms/testruns/views.py:584
 msgid "TestCase ID is not a valid integer"
 msgstr "测试实例编号不是有效的整数"
 
-#: tcms/testruns/views.py:713
+#: tcms/testruns/views.py:711
 #, python-format
 msgid "%d CaseRun(s) updated:"
 msgstr "已更新 %d 个测试运行:"
@@ -913,23 +985,3 @@ msgstr "已禁用"
 #: vinaigrette-deleteme.py:13
 msgid "NEED_UPDATE"
 msgstr "需要更新"
-
-#: tcms/testcases/forms.py:95
-msgid ""
-"**Scenario**: ... what behavior will be tested ...\n"
-"  **Given** ... conditions ...\n"
-"  **When** ... actions ...\n"
-"  **Then** ... expected results ...\n"
-"\n"
-"*Actions*:\n"
-"\n"
-"1. item\n"
-"2. item\n"
-"3. item\n"
-"\n"
-"*Expected results*:\n"
-"\n"
-"1. item\n"
-"2. item\n"
-"3. item\n"
-msgstr ""

--- a/tcms/locale/zh_TW/LC_MESSAGES/django.po
+++ b/tcms/locale/zh_TW/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: kiwitcms\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-01-15 22:16+0000\n"
+"POT-Creation-Date: 2019-01-26 10:28+0000\n"
 "PO-Revision-Date: 2019-01-16 11:47\n"
 "Last-Translator: atodorov <atodorov@otb.bg>\n"
 "Language-Team: Chinese Traditional\n"
@@ -16,7 +16,7 @@ msgstr ""
 "X-Crowdin-Language: zh-TW\n"
 "X-Crowdin-File: /master/tcms/locale/en/LC_MESSAGES/django.po\n"
 
-#: tcms/core/ajax.py:157 tcms/testruns/views.py:765
+#: tcms/core/ajax.py:157 tcms/testruns/views.py:763
 #, python-format
 msgid "User %s not found!"
 msgstr "找不到用戶 %s"
@@ -26,9 +26,9 @@ msgid "Core customized comments"
 msgstr "核心客製化附註"
 
 #: tcms/core/contrib/comments/forms.py:14
-#: tcms/testcases/templates/testcases/get.html:327
-#: tcms/testcases/templates/testcases/get.html:353
-#: tcms/testcases/templates/testcases/get.html:390
+#: tcms/testcases/templates/testcases/get.html:311
+#: tcms/testcases/templates/testcases/get.html:337
+#: tcms/testcases/templates/testcases/get.html:374
 #: tcms/testplans/templates/testplans/mutable.html:23
 #: tcms/testplans/templates/testplans/search.html:11
 msgid "Name"
@@ -53,16 +53,21 @@ msgstr ""
 
 #: tcms/core/history.py:47
 #, python-format
-msgid "Updated on %(history_date)s\n"
-"Updated by %(username)s\n\n"
-"%(diff)s\n\n"
+msgid ""
+"Updated on %(history_date)s\n"
+"Updated by %(username)s\n"
+"\n"
+"%(diff)s\n"
+"\n"
 "For more information:\n"
 "%(instance_url)s"
 msgstr ""
 
 #: tcms/core/middleware.py:25
 #, python-format
-msgid "Base URL is not configured! See <a href=\"%(doc_url)s\">documentation</a> and <a href=\"%(admin_url)s\">change it</a>"
+msgid ""
+"Base URL is not configured! See <a href=\"%(doc_url)s\">documentation</a> "
+"and <a href=\"%(admin_url)s\">change it</a>"
 msgstr ""
 
 #: tcms/kiwi_auth/admin.py:24
@@ -87,11 +92,13 @@ msgid "Your new %s account confirmation"
 msgstr "您的新帳戶 %s 確認"
 
 #: tcms/kiwi_auth/views.py:47
-msgid "Your account has been created, please check your mailbox for confirmation"
+msgid ""
+"Your account has been created, please check your mailbox for confirmation"
 msgstr "您的帳戶已經新增完畢，請確認您的 E-mail 是否有啟動連結的信件。"
 
 #: tcms/kiwi_auth/views.py:53
-msgid "Your account has been created, but you need an administrator to activate it"
+msgid ""
+"Your account has been created, but you need an administrator to activate it"
 msgstr "您的帳戶已創建, 但您需要管理員來啟用它"
 
 #: tcms/kiwi_auth/views.py:58
@@ -225,8 +232,10 @@ msgstr ""
 
 #: tcms/templates/dashboard.html:26
 #, python-format
-msgid "\n"
-"                %(total_count)s TestRun(s) or TestCase(s) assigned to you need to be executed.\n"
+msgid ""
+"\n"
+"                %(total_count)s TestRun(s) or TestCase(s) assigned to you "
+"need to be executed.\n"
 "                Here are the latest %(count)s.\n"
 "                "
 msgstr ""
@@ -248,9 +257,10 @@ msgid "TestPlan"
 msgstr ""
 
 #: tcms/templates/dashboard.html:49
-#: tcms/testcases/templates/testcases/get.html:75
-#: tcms/testcases/templates/testcases/get.html:330
-#: tcms/testcases/templates/testcases/search.html:34
+#: tcms/testcases/templates/testcases/get.html:59
+#: tcms/testcases/templates/testcases/get.html:314
+#: tcms/testcases/templates/testcases/mutable.html:35
+#: tcms/testcases/templates/testcases/search.html:30
 #: tcms/testplans/templates/testplans/mutable.html:32
 #: tcms/testplans/templates/testplans/search.html:66
 #: tcms/testplans/templates/testplans/search.html:136
@@ -261,7 +271,7 @@ msgid "Product"
 msgstr ""
 
 #: tcms/templates/dashboard.html:50
-#: tcms/testcases/templates/testcases/get.html:329
+#: tcms/testcases/templates/testcases/get.html:313
 #: tcms/testplans/templates/testplans/mutable.html:65
 #: tcms/testplans/templates/testplans/search.html:86
 #: tcms/testplans/templates/testplans/search.html:137
@@ -269,14 +279,16 @@ msgid "Type"
 msgstr ""
 
 #: tcms/templates/dashboard.html:51
-#: tcms/testcases/templates/testcases/get.html:147
+#: tcms/testcases/templates/testcases/get.html:131
 msgid "Executions"
 msgstr ""
 
 #: tcms/templates/dashboard.html:72
 #, python-format
-msgid "\n"
-"                You manage %(total_count)s TestPlan(s), %(disabled_count)s are disabled.\n"
+msgid ""
+"\n"
+"                You manage %(total_count)s TestPlan(s), %(disabled_count)s "
+"are disabled.\n"
 "                Here are the latest %(count)s.\n"
 "                "
 msgstr ""
@@ -287,52 +299,71 @@ msgstr ""
 
 #: tcms/templates/email/confirm_registration.txt:1
 #, python-format
-msgid "Welcome %(user)s,\n"
-"thank you for signing up for an %(site_domain)s account!\n\n"
+msgid ""
+"Welcome %(user)s,\n"
+"thank you for signing up for an %(site_domain)s account!\n"
+"\n"
 "To activate your account, click this link:\n"
 "%(confirm_url)s\n"
-msgstr "歡迎 %(user)s, 感謝您註冊了 %(site_domain)s 帳戶! 要啟動您的帳戶, 請按一下此連結:\n"
+msgstr ""
+"歡迎 %(user)s, 感謝您註冊了 %(site_domain)s 帳戶! 要啟動您的帳戶, 請按一下此"
+"連結:\n"
 "%(confirm_url)s\n"
 
 #: tcms/templates/email/post_case_delete/email.txt:2
 #, python-format
-msgid "\n"
+msgid ""
+"\n"
 "TestCase has been updated by %(username)s!\n"
 msgstr ""
 
 #: tcms/templates/email/post_run_save/email.txt:2
 #, python-format
-msgid "\n"
-"Test run %(pk)s has been created or updated for you.\n\n"
+msgid ""
+"\n"
+"Test run %(pk)s has been created or updated for you.\n"
+"\n"
 "### Links ###\n"
 "Test run: %(run_url)s\n"
-"Test plan: %(plan_url)s\n\n"
+"Test plan: %(plan_url)s\n"
+"\n"
 "### Basic run information ###\n"
-"Summary: %(summary)s\n\n"
+"Summary: %(summary)s\n"
+"\n"
 "Managed: %(manager)s.\n"
-"Default tester: %(default_tester)s.\n\n"
+"Default tester: %(default_tester)s.\n"
+"\n"
 "Product: %(product)s\n"
 "Product version: %(version)s\n"
-"Build: %(build)s\n\n"
+"Build: %(build)s\n"
+"\n"
 "Notes:\n"
 "%(notes)s\n"
-msgstr "\n"
+msgstr ""
+"\n"
 "已為您創建或更新了Test run %(pk)s 。 # # # # # Test run: %(run_url)s\n"
-"Test plan: %(plan_url)s\n\n"
-"# 基本運行資訊 # # 摘要: %(summary)s\n\n"
+"Test plan: %(plan_url)s\n"
+"\n"
+"# 基本運行資訊 # # 摘要: %(summary)s\n"
+"\n"
 "管理人員: %(manager)s。預設測試人員: %(default_tester)s。 產品: %(product)s\n"
 "產品版本: %(version)s\n"
-"生成版本: %(build)s\n\n"
+"生成版本: %(build)s\n"
+"\n"
 "備註:\n"
 "%(notes)s\n"
 
 #: tcms/templates/email/user_registered/notify_admins.txt:2
 #, python-format
-msgid "Dear Administrator,\n"
+msgid ""
+"Dear Administrator,\n"
 "somebody just registered an account with username %(username)s at your\n"
-"Kiwi TCMS instance and is awaiting your approval!\n\n"
+"Kiwi TCMS instance and is awaiting your approval!\n"
+"\n"
 "Go to %(user_url)s to activate the account!\n"
-msgstr "親愛的管理員, 有人剛剛在您的Kiwi TCMS 註冊了一個帳戶與使用者名 %(username)s, 並等待您的批准! 至 %(user_url)s 以啟動帳戶!\n"
+msgstr ""
+"親愛的管理員, 有人剛剛在您的Kiwi TCMS 註冊了一個帳戶與使用者名 %(username)s, "
+"並等待您的批准! 至 %(user_url)s 以啟動帳戶!\n"
 
 #: tcms/templates/pagination.html:7
 msgid "First page"
@@ -356,7 +387,7 @@ msgstr ""
 
 #: tcms/templates/registration/login.html:17
 #: tcms/templates/registration/registration_form.html:15
-#: tcms/testcases/templates/testcases/search.html:90
+#: tcms/testcases/templates/testcases/search.html:86
 #: tcms/testplans/templates/testplans/search.html:100
 #: tcms/testplans/templates/testplans/search.html:106
 #: tcms/testruns/templates/testruns/search.html:58
@@ -388,7 +419,9 @@ msgid "Change password"
 msgstr ""
 
 #: tcms/templates/registration/password_reset_confirm.html:43
-msgid "Please enter your new password twice so we can verify you typed it in correctly"
+msgid ""
+"Please enter your new password twice so we can verify you typed it in "
+"correctly"
 msgstr ""
 
 #: tcms/templates/registration/password_reset_done.html:11
@@ -416,8 +449,30 @@ msgstr ""
 msgid "Register"
 msgstr ""
 
-#: tcms/testcases/forms.py:36
-msgid "Please input valid case id(s). use comma to split more than one case id. e.g. \"111, 222\""
+#: tcms/testcases/forms.py:21
+msgid ""
+"Please input valid case id(s). use comma to split more than one case id. e."
+"g. \"111, 222\""
+msgstr ""
+
+#: tcms/testcases/forms.py:95
+msgid ""
+"**Scenario**: ... what behavior will be tested ...\n"
+"  **Given** ... conditions ...\n"
+"  **When** ... actions ...\n"
+"  **Then** ... expected results ...\n"
+"\n"
+"*Actions*:\n"
+"\n"
+"1. item\n"
+"2. item\n"
+"3. item\n"
+"\n"
+"*Expected results*:\n"
+"\n"
+"1. item\n"
+"2. item\n"
+"3. item\n"
 msgstr ""
 
 #: tcms/testcases/helpers/email.py:22
@@ -425,31 +480,16 @@ msgstr ""
 msgid "DELETED: TestCase #%{pk}d - %{summary}s"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/get.html:29
-msgid "Setup"
-msgstr ""
-
-#: tcms/testcases/templates/testcases/get.html:34
-msgid "Actions"
-msgstr ""
-
-#: tcms/testcases/templates/testcases/get.html:39
-msgid "Expected result"
-msgstr ""
-
-#: tcms/testcases/templates/testcases/get.html:44
-msgid "Breakdown"
-msgstr ""
-
-#: tcms/testcases/templates/testcases/get.html:49
+#: tcms/testcases/templates/testcases/get.html:33
+#: tcms/testcases/templates/testcases/mutable.html:132
 #: tcms/testruns/templates/testruns/mutable.html:66
 msgid "Notes"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/get.html:59
-#: tcms/testcases/templates/testcases/get.html:328
-#: tcms/testcases/templates/testcases/search.html:88
-#: tcms/testcases/templates/testcases/search.html:122
+#: tcms/testcases/templates/testcases/get.html:43
+#: tcms/testcases/templates/testcases/get.html:312
+#: tcms/testcases/templates/testcases/search.html:84
+#: tcms/testcases/templates/testcases/search.html:118
 #: tcms/testplans/templates/testplans/mutable.html:101
 #: tcms/testplans/templates/testplans/search.html:98
 #: tcms/testplans/templates/testplans/search.html:135
@@ -457,115 +497,125 @@ msgstr ""
 msgid "Author"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/get.html:64
-#: tcms/testcases/templates/testcases/search.html:123
+#: tcms/testcases/templates/testcases/get.html:48
+#: tcms/testcases/templates/testcases/mutable.html:29
+#: tcms/testcases/templates/testcases/search.html:119
 #: tcms/testplans/templates/testplans/mutable.html:113
 #: tcms/testruns/templates/testruns/search.html:94
 msgid "Default tester"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/get.html:80
-#: tcms/testcases/templates/testcases/search.html:44
-#: tcms/testcases/templates/testcases/search.html:126
+#: tcms/testcases/templates/testcases/get.html:64
+#: tcms/testcases/templates/testcases/mutable.html:50
+#: tcms/testcases/templates/testcases/search.html:40
+#: tcms/testcases/templates/testcases/search.html:122
 #: tcms/testruns/templates/testruns/mutable.html:98
 msgid "Category"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/get.html:90
-#: tcms/testcases/templates/testcases/search.html:75
-#: tcms/testcases/templates/testcases/search.html:125
+#: tcms/testcases/templates/testcases/get.html:74
+#: tcms/testcases/templates/testcases/mutable.html:66
+#: tcms/testcases/templates/testcases/search.html:16
+#: tcms/testcases/templates/testcases/search.html:71
+#: tcms/testcases/templates/testcases/search.html:121
 #: tcms/testruns/templates/testruns/mutable.html:97
 msgid "Status"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/get.html:95
-#: tcms/testcases/templates/testcases/search.html:66
-#: tcms/testcases/templates/testcases/search.html:127
+#: tcms/testcases/templates/testcases/get.html:79
+#: tcms/testcases/templates/testcases/mutable.html:78
+#: tcms/testcases/templates/testcases/search.html:62
+#: tcms/testcases/templates/testcases/search.html:123
 #: tcms/testruns/templates/testruns/mutable.html:99
 msgid "Priority"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/get.html:109
-#: tcms/testcases/templates/testcases/search.html:16
-#: tcms/testcases/templates/testcases/search.html:124
+#: tcms/testcases/templates/testcases/get.html:93
+#: tcms/testcases/templates/testcases/mutable.html:90
+#: tcms/testcases/templates/testcases/search.html:19
+#: tcms/testcases/templates/testcases/search.html:120
 msgid "Automated"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/get.html:114
+#: tcms/testcases/templates/testcases/get.html:98
+#: tcms/testcases/templates/testcases/mutable.html:105
 msgid "Script"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/get.html:119
+#: tcms/testcases/templates/testcases/get.html:103
+#: tcms/testcases/templates/testcases/mutable.html:111
 msgid "Arguments"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/get.html:124
+#: tcms/testcases/templates/testcases/get.html:108
 msgid "Requirements"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/get.html:129
+#: tcms/testcases/templates/testcases/get.html:113
+#: tcms/testcases/templates/testcases/mutable.html:124
 #: tcms/testplans/templates/testplans/mutable.html:83
 msgid "Reference link"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/get.html:300
+#: tcms/testcases/templates/testcases/get.html:284
 msgid "Bugs"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/get.html:307
+#: tcms/testcases/templates/testcases/get.html:291
 msgid "Bug URL"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/get.html:319
+#: tcms/testcases/templates/testcases/get.html:303
 msgid "Test plans"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/get.html:326
-#: tcms/testcases/templates/testcases/search.html:120
+#: tcms/testcases/templates/testcases/get.html:310
+#: tcms/testcases/templates/testcases/search.html:116
 #: tcms/testplans/templates/testplans/search.html:132
 #: tcms/testruns/templates/testruns/search.html:90
 msgid "ID"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/get.html:346
+#: tcms/testcases/templates/testcases/get.html:330
 msgid "Tags"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/get.html:367
-#: tcms/testcases/templates/testcases/get.html:404
+#: tcms/testcases/templates/testcases/get.html:351
+#: tcms/testcases/templates/testcases/get.html:388
 msgid "Add"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/get.html:383
+#: tcms/testcases/templates/testcases/get.html:367
 msgid "Components"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/get.html:420
+#: tcms/testcases/templates/testcases/get.html:404
 msgid "Attachments"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/get.html:427
+#: tcms/testcases/templates/testcases/get.html:411
 msgid "File"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/get.html:428
+#: tcms/testcases/templates/testcases/get.html:412
 msgid "Owner"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/get.html:429
+#: tcms/testcases/templates/testcases/get.html:413
 msgid "Date"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/get.html:443
+#: tcms/testcases/templates/testcases/get.html:427
 msgid "No records found"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/search.html:5
-msgid "Search test cases"
+#: tcms/testcases/templates/testcases/mutable.html:9
+msgid "New TestCase"
 msgstr ""
 
+#: tcms/testcases/templates/testcases/mutable.html:18
 #: tcms/testcases/templates/testcases/search.html:11
-#: tcms/testcases/templates/testcases/search.html:121
+#: tcms/testcases/templates/testcases/search.html:117
 #: tcms/testruns/templates/testruns/mutable.html:23
 #: tcms/testruns/templates/testruns/mutable.html:94
 #: tcms/testruns/templates/testruns/search.html:11
@@ -573,77 +623,105 @@ msgstr ""
 msgid "Summary"
 msgstr ""
 
+#: tcms/testcases/templates/testcases/mutable.html:36
+#: tcms/testplans/templates/testplans/mutable.html:33
+msgid "add new Product"
+msgstr ""
+
+#: tcms/testcases/templates/testcases/mutable.html:51
+msgid "add new Category"
+msgstr ""
+
+#: tcms/testcases/templates/testcases/mutable.html:98
+msgid "Text"
+msgstr ""
+
+#: tcms/testcases/templates/testcases/mutable.html:119
+msgid "Requirments"
+msgstr ""
+
+#: tcms/testcases/templates/testcases/mutable.html:139
+#: tcms/testplans/templates/testplans/mutable.html:143
+#: tcms/testruns/templates/testruns/mutable.html:72
+msgid "Save"
+msgstr ""
+
+#: tcms/testcases/templates/testcases/search.html:5
+msgid "Search test cases"
+msgstr ""
+
 #: tcms/testcases/templates/testcases/search.html:13
 #: tcms/testruns/templates/testruns/search.html:13
 msgid "Test run summary"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/search.html:26
-msgid "Proposed for automation"
+#: tcms/testcases/templates/testcases/search.html:22
+msgid "Manual"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/search.html:29
-msgid "Search all when OFF"
+#: tcms/testcases/templates/testcases/search.html:25
+msgid "Both"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/search.html:54
+#: tcms/testcases/templates/testcases/search.html:50
+#: tcms/testcases/templates/testcases/search.html:125
 msgid "Component"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/search.html:97
+#: tcms/testcases/templates/testcases/search.html:93
 #: tcms/testplans/templates/testplans/search.html:111
 #: tcms/testruns/templates/testruns/search.html:74
 msgid "Tag"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/search.html:100
-#: tcms/testcases/templates/testcases/search.html:106
+#: tcms/testcases/templates/testcases/search.html:96
+#: tcms/testcases/templates/testcases/search.html:102
 #: tcms/testplans/templates/testplans/search.html:114
 #: tcms/testruns/templates/testruns/search.html:77
 msgid "Separate multiple values with comma (,)"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/search.html:103
-#: tcms/testcases/templates/testcases/search.html:105
+#: tcms/testcases/templates/testcases/search.html:99
+#: tcms/testcases/templates/testcases/search.html:101
 msgid "Bug ID"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/search.html:112
+#: tcms/testcases/templates/testcases/search.html:108
 #: tcms/testplans/templates/testplans/search.html:124
 #: tcms/testruns/templates/testruns/search.html:82
 msgid "Search"
 msgstr ""
 
-#: tcms/testcases/templates/testcases/search.html:128
+#: tcms/testcases/templates/testcases/search.html:124
 msgid "Created at"
 msgstr ""
 
-#: tcms/testcases/views.py:463
+#: tcms/testcases/views.py:448
 msgid "TestPlan not specified or does not exist"
 msgstr "TestPlan 未指定或不存在"
 
-#: tcms/testcases/views.py:642
+#: tcms/testcases/views.py:622
 msgid "Edit"
 msgstr ""
 
-#: tcms/testcases/views.py:646
+#: tcms/testcases/views.py:626
 msgid "Clone"
 msgstr ""
 
-#: tcms/testcases/views.py:650
+#: tcms/testcases/views.py:630
 msgid "History"
 msgstr ""
 
-#: tcms/testcases/views.py:655
+#: tcms/testcases/views.py:635
 msgid "Delete"
 msgstr ""
 
-#: tcms/testcases/views.py:934 tcms/testruns/views.py:499
-#: tcms/testruns/views.py:577
+#: tcms/testcases/views.py:861 tcms/testruns/views.py:497
+#: tcms/testruns/views.py:575
 msgid "At least one TestCase is required"
 msgstr "至少需要一個 TestCase"
 
-#: tcms/testcases/views.py:1083
+#: tcms/testcases/views.py:998
 msgid "TestCase cloning was successful"
 msgstr "TestCase 複製成功"
 
@@ -653,10 +731,6 @@ msgstr ""
 
 #: tcms/testplans/templates/testplans/mutable.html:12
 msgid "Create new TestPlan"
-msgstr ""
-
-#: tcms/testplans/templates/testplans/mutable.html:33
-msgid "add new Product"
 msgstr ""
 
 #: tcms/testplans/templates/testplans/mutable.html:47
@@ -701,11 +775,6 @@ msgstr ""
 #: tcms/testplans/templates/testplans/mutable.html:137
 #: tcms/testplans/templates/testplans/search.html:117
 msgid "Active"
-msgstr ""
-
-#: tcms/testplans/templates/testplans/mutable.html:143
-#: tcms/testruns/templates/testruns/mutable.html:72
-msgid "Save"
 msgstr ""
 
 #: tcms/testplans/templates/testplans/search.html:5
@@ -804,8 +873,10 @@ msgstr ""
 
 #: tcms/testruns/templates/testruns/mutable.html:84
 #, python-format
-msgid "\n"
-"                    %(count)s of the pre-selected test cases is not CONFIRMED and will not be cloned!\n"
+msgid ""
+"\n"
+"                    %(count)s of the pre-selected test cases is not "
+"CONFIRMED and will not be cloned!\n"
 "                    See test plan for more details!\n"
 "                    "
 msgstr ""
@@ -842,15 +913,15 @@ msgstr ""
 msgid "Creating a TestRun requires at least one TestCase"
 msgstr "創建 TestRun 至少需要一個 TestCase"
 
-#: tcms/testruns/views.py:503
+#: tcms/testruns/views.py:501
 msgid "Clone of "
 msgstr ""
 
-#: tcms/testruns/views.py:586
+#: tcms/testruns/views.py:584
 msgid "TestCase ID is not a valid integer"
 msgstr "TestCase ID 不是有效的整數"
 
-#: tcms/testruns/views.py:713
+#: tcms/testruns/views.py:711
 #, python-format
 msgid "%d CaseRun(s) updated:"
 msgstr "%d CaseRun 已更新:"
@@ -907,23 +978,3 @@ msgstr "禁用"
 #: vinaigrette-deleteme.py:13
 msgid "NEED_UPDATE"
 msgstr "需要更新"
-
-#: tcms/testcases/forms.py:95
-msgid ""
-"**Scenario**: ... what behavior will be tested ...\n"
-"  **Given** ... conditions ...\n"
-"  **When** ... actions ...\n"
-"  **Then** ... expected results ...\n"
-"\n"
-"*Actions*:\n"
-"\n"
-"1. item\n"
-"2. item\n"
-"3. item\n"
-"\n"
-"*Expected results*:\n"
-"\n"
-"1. item\n"
-"2. item\n"
-"3. item\n"
-msgstr ""

--- a/tcms/testcases/static/testcases/js/mutable.js
+++ b/tcms/testcases/static/testcases/js/mutable.js
@@ -1,0 +1,33 @@
+$(document).ready((function () {
+    populateProductCategory();
+
+    $('#add_id_product').click(function () {
+        return showRelatedObjectPopup(this);
+    });
+
+    $('#add_id_category').click(function () {
+        return showRelatedObjectPopup(this);
+    });
+
+    document.getElementById('id_product').onchange = function () {
+        $('#id_product').selectpicker('refresh');
+        populateProductCategory();
+    };
+
+    document.getElementById('id_category').onchange = function () {
+        $('#id_category').selectpicker('refresh');
+    };
+
+    $('.selectpicker').selectpicker();
+    $('.bootstrap-switch').bootstrapSwitch();
+}));
+
+function populateProductCategory() {
+    let href = $('#add_id_category')[0].href;
+    $('#add_id_category')[0].href = href.slice(0, href.indexOf('&product'));
+    $('#add_id_category')[0].href += `&product=${$('#id_product').val()}`;
+
+    $('#id_category').find('option').remove();
+
+    update_category_select_from_product();
+}

--- a/tcms/testcases/templates/testcases/mutable.html
+++ b/tcms/testcases/templates/testcases/mutable.html
@@ -1,0 +1,156 @@
+{% extends "base.html" %}
+{% load i18n %}
+{% load static %}
+
+{% block head %}
+    {{ form.media }}
+{% endblock %}
+{% block title %}
+    {% trans "New TestCase" %}
+{% endblock %}
+
+{% block contents %}
+
+    <div class="container-fluid container-cards-pf">
+        <form class="form-horizontal" action="{% url 'testcases-new' %}" method="post">
+
+            <div class="form-group">
+                <label class="col-md-1 col-lg-1" for="id_summary">{% trans "Summary" %}</label>
+                <div class="col-md-11 col-lg-11 {% if form.summary.errors %}has-error{% endif %}">
+                    <input type="text" id="id_summary" name="summary" value="{{ form.summary.value|default:'' }}" class="form-control" required>
+                    {% if test_plan %}
+                        <p class="help-block"><a href="{% url 'test_plan_url_short' test_plan.pk %}">TP-{{ test_plan.pk }}: {{ test_plan.name }}</a></p>
+                    {% endif %}
+                    {{ form.name.errors }}
+                </div>
+            </div>
+
+            <div class="form-group">
+                <label class="col-md-1 col-lg-1" for="id_default_tester">{% trans "Default tester" %}</label>
+                <div class="col-md-3 col-lg-3">
+                    <input type="text" id="id_default_tester" name="default_tester" value="{{ form.default_tester.value|default:'' }}" class="form-control">
+                </div>
+
+                <div class="col-md-1 col-lg-1">
+                    <label for="id_product">{% trans "Product" %}</label>
+                    <a href="{% url 'admin:management_product_add' %}?_popup" id="add_id_product" alt="{% trans 'add new Product' %}" title="{% trans 'add new Product' %}">+</a>
+                </div>
+                <div class="col-md-3 col-lg-3 {% if form.product.errors %}has-error{% endif %}">
+                    <select id="id_product" name="product" class="form-control selectpicker">
+                        {% for product in form.product.field.queryset %}
+                            <option value="{{ product.pk }}" {% if product.pk == form.product.value %}selected{% endif %}>
+                                {{ product.name }}
+                            </option>
+                        {% endfor %}
+                    </select>
+                    {{ form.product.errors }}
+                </div>
+
+                <div class="col-md-1 col-lg-1">
+                    <label for="id_category">{% trans "Category" %}</label>
+                    <a href="{% url 'admin:testcases_category_add' %}?_popup&product=" id="add_id_category" alt="{% trans 'add new Category' %}" title="{% trans 'add new Category' %}">+</a>
+                </div>
+                <div class="col-md-3 col-lg-3 {% if form.category.errors %}has-error{% endif %}">
+                    <select id="id_category" name="category" class="form-control selectpicker">
+                        {% for category in form.category.field.queryset %}
+                            <option value="{{ category.pk }}" {% if category.pk == form.category.value %}selected{% endif %}>
+                                {{ category.name }}
+                            </option>
+                        {% endfor %}
+                    </select>
+                    {{ form.category.errors }}
+                </div>
+            </div>
+
+            <div class="form-group">
+                <label class="col-md-1 col-lg-1" for="id_status">{% trans "Status" %}</label>
+                <div class="col-md-3 col-lg-3 {% if form.case_status.errors %}has-error{% endif %}">
+                    <select id="id_status" name="case_status" class="form-control selectpicker">
+                        {% for case_status in form.case_status.field.queryset %}
+                            <option value="{{ case_status.pk }}" {% if case_status.pk == form.case_status.value %}selected{% endif %}>
+                                {{ case_status.name }}
+                            </option>
+                        {% endfor %}
+                    </select>
+                    {{ form.case_status.errors }}
+                </div>
+
+                <label class="col-md-1 col-lg-1" for="id_priority">{% trans "Priority" %}</label>
+                <div class="col-md-3 col-lg-3 {% if form.case_status.errors %}has-error{% endif %}">
+                    <select id="id_priority" name="priority" class="form-control selectpicker">
+                        {% for priority in form.priority.field.queryset %}
+                            <option value="{{ priority.pk }}" {% if priority.pk == form.priority.pk %}selected{% endif %}>
+                                {{ priority.value }}
+                            </option>
+                        {% endfor %}
+                    </select>
+                    {{ form.priority.errors }}
+                </div>
+
+                <label class="col-md-1 col-lg-1">{% trans "Automated" %}</label>
+                <div class="col-md-3 col-lg-3">
+                    <input class="bootstrap-switch" name="is_automated" type="checkbox">
+                </div>
+            </div>
+
+            <div class="form-group">
+                <div class="col-md-12 col-lg-12">
+                    <label class="{% if form.setup.errors %}has-error{% endif %}">{% trans "Text" %}:</label>
+                    <div>{{ form.text }}</div>
+                    {{ form.text.errors }}
+                </div>
+            </div>
+
+            <div class="form-group">
+                <label class="col-md-1 col-lg-1" for="id_script">{% trans "Script" %}</label>
+                <div class="col-md-5 col-lg-5 {% if form.script.errors %}has-error{% endif %}">
+                    <input type="text" id="id_script" name="script" value="" class="form-control">
+                    {{ form.script.errors }}
+                </div>
+
+                <label class="col-md-1 col-lg-1" for="id_arguments">{% trans "Arguments" %}</label>
+                <div class="col-md-5 col-lg-5 {% if form.arguments.errors %}has-error{% endif %}">
+                    <input type="text" id="id_arguments" name="arguments" value="" class="form-control">
+                    {{ form.arguments.errors }}
+                </div>
+            </div>
+
+            <div class="form-group">
+                <label class="col-md-1 col-lg-1" for="id_requirments">{% trans "Requirments" %}</label>
+                <div class="col-md-5 col-lg-5 {% if form.requirment.errors %}has-error{% endif %}">
+                    <input type="text" id="id_requirments" name="requirement" value="" class="form-control">
+                    {{ form.requirment.errors }}
+                </div>
+                <label class="col-md-1 col-lg-1" for="id_reference_link">{% trans "Reference link" %}</label>
+                <div class="col-md-5 col-lg-5 {% if form.extra_link.errors %}has-error{% endif %}">
+                    <input type="text" id="id_reference_link" name="extra_link" value="" class="form-control">
+                    {{ form.extra_link.errors }}
+                </div>
+            </div>
+
+            <div class="form-group">
+                <label for="id_notes" class="col-md-1 col-lg-1">{% trans "Notes" %}</label>
+                <div class="col-md-12 col-lg-12">
+                    <textarea id="id_notes" rows="4" name="notes" class="form-control"></textarea>
+                    {{ form.notes.errors }}
+                </div>
+            </div>
+
+            <button type="submit" class="btn btn-default btn-lg">{% trans "Save" %}</button>
+
+        </form>
+    </div>
+
+<script src="{% static 'bootstrap-select/dist/js/bootstrap-select.min.js' %}"></script>
+<script src="{% static 'bootstrap-switch/dist/js/bootstrap-switch.min.js' %}"></script>
+<script src="{% static "grappelli/jquery/jquery.min.js" %}"></script>
+<script src="{% static "grappelli/js/grappelli.min.js" %}"></script>
+<script src="{% static "admin/js/admin/RelatedObjectLookups.js" %}"></script>
+
+<script src="{% static 'js/jsonrpc.js' %}"></script>
+<script src="{% static 'js/utils.js' %}"></script>
+
+<script src="{% static 'testcases/js/mutable.js' %}"></script>
+
+{% endblock %}
+

--- a/tcms/testcases/views.py
+++ b/tcms/testcases/views.py
@@ -154,7 +154,7 @@ class ReturnActions:
 
 
 @permission_required('testcases.add_testcase')
-def new(request, template_name='case/edit.html'):
+def new(request):
     """New testcase"""
     test_plan = plan_from_request_or_none(request)
     default_form_parameters = {}
@@ -195,7 +195,7 @@ def new(request, template_name='case/edit.html'):
         'test_plan': test_plan,
         'form': form
     }
-    return render(request, template_name, context_data)
+    return render(request, 'testcases/mutable.html', context_data)
 
 
 def get_testcaseplan_sortkey_pk_for_testcases(plan, tc_ids):


### PR DESCRIPTION
things left to be done:
* currently, the `is_automated` switch is not working. I am going to spend time on this once #727

`configure_product_on_load ` has been copied to `utils.js` since it is already defined in two place - `testcase_actions.js` and `testplan_actions.js`. Since those files are going to be deleted at some moment, I suppose that the right place for this util function is `utils.js`. I suppose we can live with this duplication for now

`testcases/js/mutable.js` introduces some more duplication - 
```javascript
$('#add_id_product').click(function () {
    return showRelatedObjectPopup(this);
});

document.getElementById('id_product').onchange = function () {
    $('#id_product').selectpicker('refresh');
    update_category_select_from_product();
};

$('.selectpicker').selectpicker();
$('.bootstrap-switch').bootstrapSwitch();
```
these lines are present both here and at `testplans/js/mutable.js`. maybe we can think of a way to reduce the duplication. one idea is to create a util function like:
```javascript
// utils.js
function showPopupFor(selector) {
    $(selector).click(function () {
        return showRelatedObjectPopup(this);
    });
}
```
this way both `testplans/js/mutable.js` and `testcases/js/mutable.js` will look smaller and something like this:
```javascript
$(document).ready((function () {
    // code

    showPopupFor('#add_id_product');
    showPopupFor('#add_id_category');

    // maybe extract these too, since the ids are the same anywhere
    $('.selectpicker').selectpicker();
    $('.bootstrap-switch').bootstrapSwitch();
}));
```

otherwise, the form seems to be working and the experience of the new form plus the new case view seems really nice
