### PR TITLE
[api] TestCase.add_component() changes

### DIFF
--- a/tcms/xmlrpc/api/testcase.py
+++ b/tcms/xmlrpc/api/testcase.py
@@ -44,15 +44,17 @@ def add_component(case_id, component):
         :type case_id: int
         :param component: Name of Component to add
         :type component_id: str
-        :return: None
+        :return: Serialized :class:`tcms.testcases.models.TestCase` object
         :raises: PermissionDenied if missing the *testcases.add_testcasecomponent*
                  permission
         :raises: DoesNotExist if missing test case or component that match the
                  specified PKs
     """
-    TestCase.objects.get(pk=case_id).add_component(
-        Component.objects.get(name=component)
+    case = TestCase.objects.get(pk=case_id)
+    case.add_component(
+        Component.objects.get(name=component, product=case.category.product)
     )
+    return case.serialize()
 
 
 @rpc_method(name='TestCase.get_components')


### PR DESCRIPTION
- will now fail if trying to add components linked to another
  Product. This will prevent typing the component name in the UI
  (without autocomplete) and hitting enter from adding the
  component
- now returns serialized TestCase object