### PR TITLE
[security], [medium] Explicitly require marked v0.6.1 to fix ReDoS

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "marked": "0.6.1",
     "patternfly": "3.59.1",
     "simplemde": "1.11.2",
     "typeahead.js": "0.11.1"


### PR DESCRIPTION
https://snyk.io/vuln/SNYK-JS-MARKED-73637