### PR TITLE
TestPlan.add_case() sets the sortkey to highest in plan + 10

### DIFF
--- a/tcms/testplans/models.py
+++ b/tcms/testplans/models.py
@@ -94,15 +94,22 @@ class TestPlan(TCMSActionModel):
     def confirmed_case(self):
         return self.case.filter(case_status__name='CONFIRMED')
 
-    def add_case(self, case, sortkey=0):
+    def add_case(self, case, sortkey=None):
 
-        tcp, is_created = TestCasePlan.objects.get_or_create(
+        if sortkey is None:
+            lastcase = self.testcaseplan_set.order_by('-sortkey').first()
+            if lastcase and lastcase.sortkey is not None:
+                sortkey = lastcase.sortkey + 10
+            else:
+                sortkey = 0
+
+        return TestCasePlan.objects.get_or_create(
             plan=self,
             case=case,
-        )
-        if is_created:
-            tcp.sortkey = sortkey
-            tcp.save()
+            defaults={
+                'sortkey': sortkey
+            }
+        )[0]
 
     def add_tag(self, tag):
         return TestPlanTag.objects.get_or_create(

--- a/tcms/testplans/tests/tests.py
+++ b/tcms/testplans/tests/tests.py
@@ -135,6 +135,27 @@ class TestPlanModel(test.TestCase):
         self.assertEqual(1, cases_left.count())
         self.assertEqual(self.testcase_2.pk, cases_left[0].case.pk)
 
+    def test_add_cases_sortkey_autoincrement(self):
+        """
+        When you add new cases, each new case should get a sortkey of the
+        highest sortkey in the database + 10.
+
+        The first case should get sortkey 0. The offset between the sortkeys is
+        to leave space to insert cases in between without having to update all
+        cases.
+        """
+
+        plan = TestPlanFactory()
+
+        for sequence_no in range(3):
+            case_plan = plan.add_case(TestCaseFactory())
+            self.assertEqual(sequence_no * 10, case_plan.sortkey)
+
+        # Check if you can still specify a sortkey manually to insert a case in
+        # between the other cases.
+        case_plan = plan.add_case(TestCaseFactory(), sortkey=15)
+        self.assertEqual(15, case_plan.sortkey)
+
 
 class TestDeleteCasesFromPlan(BasePlanCase):
     """Test case for deleting cases from a plan"""


### PR DESCRIPTION
I was a bit annoyed with new cases showing up at the top of my cases list instead of the bottom. This change will ensure a test cases will get a `sortkey` of the highest `sortkey` in the plan + 10. You can still create a case with a custom `sortkey`. The first case in the plan will get `0` as a `sortkey`.