### PR TITLE
Add Dummy issue tracker. Fixes #289

### DIFF
--- a/tcms/issuetracker/types.py
+++ b/tcms/issuetracker/types.py
@@ -378,3 +378,14 @@ class Gitlab(IssueTrackerType):
             url += '/'
 
         return url + '/issues/new?' + urlencode(args, True)
+
+
+class LinkOnly(IssueTrackerType):
+    """
+        LinkOnly Issue Tracker, for when your issue tracker is not one of the supported ones.
+
+        Because of this, no API related functionallities are available
+    """
+
+    def is_adding_testcase_to_issue_disabled(self):
+        return True


### PR DESCRIPTION
This adds a dummy implementation of an issue tracker. 

`is_adding_testcase_to_issue_disabled` returns `True` because adding a test case to issues is unavailable. This means that trying to do this through the UI will result in an error being shown in the screen. An alternative would be to put it to `True` and then it will try to call `add_testcase_to_issue`, which is empty, so nothing will happen and success will be returned