### PR TITLE
[db] populate missing TestCase.text history

### DIFF
--- a/tcms/testcases/migrations/0006_merge_text_field_into_testcase_model.py
+++ b/tcms/testcases/migrations/0006_merge_text_field_into_testcase_model.py
@@ -28,6 +28,10 @@ def forward_copy_data(apps, schema_editor):
         if latest_text:
             test_case.case_text = convert_test_case_text(latest_text)
             test_case.save()
+            # b/c the above will not generate history
+            history = test_case.history.latest()
+            history.case_text = test_case.case_text
+            history.save()
 
 
 class Migration(migrations.Migration):

--- a/tcms/testcases/migrations/0009_populate_missing_text_history.py
+++ b/tcms/testcases/migrations/0009_populate_missing_text_history.py
@@ -1,0 +1,29 @@
+from django.db import migrations
+
+
+def forward_copy_data(apps, schema_editor):
+    TestCase = apps.get_model('testcases', 'TestCase')
+
+    for test_case in TestCase.objects.all():
+        history = test_case.history.latest()
+
+        # In 0006_merge_text_field_into_testcase_model we may have
+        # failed to save the text into the history record leaving
+        # historical records with text == None.
+        # If the TC was not modified since then we try to fix the last
+        # historical record
+        if test_case.text and not history.text:
+            history.text = test_case.text
+            history.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('testcases', '0008_notifications_default_true'),
+    ]
+
+    operations = [
+        # copy the data from the related model
+        migrations.RunPython(forward_copy_data),
+    ]


### PR DESCRIPTION
in version 6.5 the TestCase model was updated to store the text
into a single field called `text` instead of 4 separate fields.
During that migration historical records were updated to have
the new `text` field but values were not properly assigned.

The "effect" of this is that in TestCaseRun records you were not
able to see the actual text b/c it was None.

This commit ammends 0006_merge_text_field_into_testcase_model for
installations which have not yet migrated to 6.5 or later. We also
provide the data-only migration 0009_populate_missing_text_history
which will inspect the current state of the DB and copy the text
to historical records.