### PR TITLE
[db] Use query to update HistoricalTestCase in migrations

### DIFF
--- a/tcms/testcases/migrations/0006_merge_text_field_into_testcase_model.py
+++ b/tcms/testcases/migrations/0006_merge_text_field_into_testcase_model.py
@@ -22,6 +22,7 @@ def convert_test_case_text(test_case_text):
 def forward_copy_data(apps, schema_editor):
     TestCase = apps.get_model('testcases', 'TestCase')
     TestCaseText = apps.get_model('testcases', 'TestCaseText')
+    HistoricalTestCase = apps.get_model('testcases', 'HistoricalTestCase')
 
     for test_case in TestCase.objects.all():
         latest_text = TestCaseText.objects.filter(case=test_case.pk).order_by('-pk').first()
@@ -29,7 +30,9 @@ def forward_copy_data(apps, schema_editor):
             test_case.case_text = convert_test_case_text(latest_text)
             test_case.save()
             # b/c the above will not generate history
-            history = test_case.history.latest()
+            history = HistoricalTestCase.objects.filter(
+                        case_id=test_case.pk
+                      ).order_by('-history_id').first()
             history.case_text = test_case.case_text
             history.save()
 

--- a/tcms/testcases/migrations/0009_populate_missing_text_history.py
+++ b/tcms/testcases/migrations/0009_populate_missing_text_history.py
@@ -3,9 +3,12 @@ from django.db import migrations
 
 def forward_copy_data(apps, schema_editor):
     TestCase = apps.get_model('testcases', 'TestCase')
+    HistoricalTestCase = apps.get_model('testcases', 'HistoricalTestCase')
 
     for test_case in TestCase.objects.all():
-        history = test_case.history.latest()
+        history = HistoricalTestCase.objects.filter(
+                    case_id=test_case.pk
+                  ).order_by('-history_id').first()
 
         # In 0006_merge_text_field_into_testcase_model we may have
         # failed to save the text into the history record leaving


### PR DESCRIPTION
using test_case.history.latest() doesn't work b/c we don't have
the historical manager available during migrations so we need to
query the object directly.

The test suite doesn't catch this b/c initially there is no data
and the for loop isn't executed.