### PR TITLE
WIP [helpers] email_case_deletion() format error fixed

### DIFF
--- a/tcms/locale/de_DE/LC_MESSAGES/django.po
+++ b/tcms/locale/de_DE/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: kiwitcms\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-23 23:31+0000\n"
+"POT-Creation-Date: 2019-03-29 09:09+0000\n"
 "PO-Revision-Date: 2019-03-13 13:42\n"
 "Last-Translator: atodorov <atodorov@otb.bg>\n"
 "Language-Team: German\n"
@@ -49,6 +49,21 @@ msgstr "URL"
 msgid "Comment"
 msgstr "Bemerkung"
 
+#: tcms/core/contrib/linkreference/tests.py:84
+msgid "Enter a valid URL."
+msgstr ""
+
+#: tcms/core/contrib/linkreference/tests.py:101
+#, python-format
+msgid ""
+"Ensure this value has at most %(limit_value)d character (it has "
+"%(show_value)d)."
+msgid_plural ""
+"Ensure this value has at most %(limit_value)d characters (it has "
+"%(show_value)d)."
+msgstr[0] ""
+msgstr[1] ""
+
 #: tcms/core/history.py:41
 #, python-format
 msgid "UPDATE: %(model_name)s #%(pk)d - %(title)s"
@@ -89,114 +104,144 @@ msgstr "Berechtigungen"
 msgid "A user with that email already exists."
 msgstr "Ein Benutzer mit dieser E-Mail-Adresse ist bereits vorhanden."
 
-#: tcms/kiwi_auth/forms.py:60
+#: tcms/kiwi_auth/forms.py:60 tcms/kiwi_auth/tests.py:176
 #, python-format
 msgid "Your new %s account confirmation"
 msgstr ""
 
-#: tcms/kiwi_auth/views.py:50
+#: tcms/kiwi_auth/test_admin.py:59 tcms/management/tests/tests.py:76
+msgid "Yes, I'm sure"
+msgstr ""
+
+#: tcms/kiwi_auth/tests.py:97 tcms/templates/navbar.html:59
+#: tcms/templates/registration/registration_form.html:47
+msgid "Register"
+msgstr "Registrieren"
+
+#: tcms/kiwi_auth/tests.py:141 tcms/signals.py:78
+msgid "New user awaiting approval"
+msgstr ""
+
+#: tcms/kiwi_auth/tests.py:146
+#: tcms/templates/email/user_registered/notify_admins.txt:2
+#, python-format
+msgid ""
+"Dear Administrator,\n"
+"somebody just registered an account with username %(username)s at your\n"
+"Kiwi TCMS instance and is awaiting your approval!\n"
+"\n"
+"Go to %(user_url)s to activate the account!\n"
+msgstr ""
+
+#: tcms/kiwi_auth/tests.py:162 tcms/kiwi_auth/views.py:50
 msgid ""
 "Your account has been created, please check your mailbox for confirmation"
 msgstr ""
 "Ihr Konto wurde erstellt, bitte überprüfen Sie Ihre Mailbox für die "
 "Bestätigung"
 
-#: tcms/kiwi_auth/views.py:56
+#: tcms/kiwi_auth/tests.py:177 tcms/templates/email/confirm_registration.txt:1
+#, python-format
+msgid ""
+"Welcome %(user)s,\n"
+"thank you for signing up for an %(site_domain)s account!\n"
+"\n"
+"To activate your account, click this link:\n"
+"%(confirm_url)s\n"
+msgstr ""
+
+#: tcms/kiwi_auth/tests.py:196 tcms/kiwi_auth/views.py:56
 msgid ""
 "Your account has been created, but you need an administrator to activate it"
 msgstr ""
 "Ihr Konto wurde erstellt, wenden Sie sich an einen Administrator um es zu "
 "aktivieren"
 
+#: tcms/kiwi_auth/tests.py:222 tcms/kiwi_auth/views.py:103
+msgid "This activation key no longer exists in the database"
+msgstr ""
+
+#: tcms/kiwi_auth/tests.py:240 tcms/kiwi_auth/views.py:108
+msgid "This activation key has expired"
+msgstr "Diese Aktivierungs-Code ist abgelaufen"
+
+#: tcms/kiwi_auth/tests.py:259 tcms/kiwi_auth/views.py:120
+msgid "Your account has been activated successfully"
+msgstr "Dein Konto wurde erfolgreich aktiviert"
+
 #: tcms/kiwi_auth/views.py:61
 msgid "Following is the administrator list"
 msgstr ""
 
-#: tcms/kiwi_auth/views.py:103
-msgid "This activation key no longer exists in the database"
-msgstr ""
-
-#: tcms/kiwi_auth/views.py:108
-msgid "This activation key has expired"
-msgstr "Diese Aktivierungs-Code ist abgelaufen"
-
-#: tcms/kiwi_auth/views.py:120
-msgid "Your account has been activated successfully"
-msgstr "Dein Konto wurde erfolgreich aktiviert"
-
-#: tcms/settings/common.py:87
+#: tcms/settings/common.py:90
 msgid "DASHBOARD"
 msgstr "DASHBOARD"
 
-#: tcms/settings/common.py:88
+#: tcms/settings/common.py:91
 msgid "TESTING"
 msgstr "TESTEN"
 
-#: tcms/settings/common.py:89
+#: tcms/settings/common.py:92
 msgid "New Test Plan"
 msgstr "Neuer Testplan"
 
-#: tcms/settings/common.py:91
+#: tcms/settings/common.py:94
 msgid "New Test Case"
 msgstr "Neuer Testfall"
 
-#: tcms/settings/common.py:93
+#: tcms/settings/common.py:96
 msgid "SEARCH"
 msgstr "SUCHEN"
 
-#: tcms/settings/common.py:94
+#: tcms/settings/common.py:97
 msgid "Search Test Plans"
 msgstr "Suche Testplan"
 
-#: tcms/settings/common.py:95
+#: tcms/settings/common.py:98
 msgid "Search Test Runs"
 msgstr "Suche Testlauf"
 
-#: tcms/settings/common.py:96
+#: tcms/settings/common.py:99
 msgid "Search Test Cases"
 msgstr "Suche Testfall"
 
-#: tcms/settings/common.py:98
+#: tcms/settings/common.py:101 tcms/telemetry/tests/test_plugin_discovery.py:52
 msgid "TELEMETRY"
 msgstr ""
 
-#: tcms/settings/common.py:103
+#: tcms/settings/common.py:115
 msgid "ADMIN"
 msgstr "ADMIN"
 
-#: tcms/settings/common.py:104
+#: tcms/settings/common.py:116
 msgid "Users and groups"
 msgstr "Benutzer und Gruppen"
 
-#: tcms/settings/common.py:106
+#: tcms/settings/common.py:118
 msgid "Everything else"
 msgstr "Alles andere"
 
-#: tcms/settings/common.py:112
+#: tcms/settings/common.py:124
 msgid "Report an Issue"
 msgstr "Einen Fehler melden"
 
-#: tcms/settings/common.py:113
+#: tcms/settings/common.py:125
 msgid "Ask for help on StackOverflow"
 msgstr "Bitten Sie um Hilfe auf StackOverflow"
 
-#: tcms/settings/common.py:114
+#: tcms/settings/common.py:126
 msgid "User Guide"
 msgstr "Benutzerhandbuch"
 
-#: tcms/settings/common.py:115
+#: tcms/settings/common.py:127
 msgid "Administration Guide"
 msgstr "Administratorhandbuch"
 
-#: tcms/settings/common.py:116
+#: tcms/settings/common.py:128
 msgid "API Help"
 msgstr "API-Hilfe"
 
-#: tcms/signals.py:78
-msgid "New user awaiting approval"
-msgstr ""
-
-#: tcms/signals.py:153
+#: tcms/signals.py:153 tcms/testruns/tests/test_models.py:42
 #, python-format
 msgid "NEW: TestRun #%(pk)d - %(summary)s"
 msgstr "Neu: Testlauf #%(pk)d - %(summary)s"
@@ -255,7 +300,7 @@ msgstr ""
 msgid "Select Plan"
 msgstr ""
 
-#: tcms/templates/case/clone.html:32
+#: tcms/templates/case/clone.html:32 tcms/testcases/tests/test_views.py:346
 msgid "Use the same Plan"
 msgstr ""
 
@@ -574,21 +619,14 @@ msgstr ""
 msgid "There are no TestPlan(s) that belong to you"
 msgstr ""
 
-#: tcms/templates/email/confirm_registration.txt:1
-#, python-format
-msgid ""
-"Welcome %(user)s,\n"
-"thank you for signing up for an %(site_domain)s account!\n"
-"\n"
-"To activate your account, click this link:\n"
-"%(confirm_url)s\n"
-msgstr ""
-
 #: tcms/templates/email/post_case_delete/email.txt:2
-#, python-format
+#, fuzzy, python-format
+#| msgid ""
+#| "\n"
+#| "TestCase has been updated by %(username)s!\n"
 msgid ""
 "\n"
-"TestCase has been updated by %(username)s!\n"
+"TestCase has been deleted by %(username)s!\n"
 msgstr ""
 "\n"
 "Testfall wurde von %(username)s aktualisiert!\n"
@@ -617,16 +655,6 @@ msgid ""
 "%(notes)s\n"
 msgstr ""
 
-#: tcms/templates/email/user_registered/notify_admins.txt:2
-#, python-format
-msgid ""
-"Dear Administrator,\n"
-"somebody just registered an account with username %(username)s at your\n"
-"Kiwi TCMS instance and is awaiting your approval!\n"
-"\n"
-"Go to %(user_url)s to activate the account!\n"
-msgstr ""
-
 #: tcms/templates/management/get_tag.html:7
 msgid "Plans"
 msgstr ""
@@ -646,10 +674,14 @@ msgstr ""
 #: tcms/templates/plan/get_cases.html:32 tcms/templates/plan/get_cases.html:34
 #: tcms/templates/run/get_case_runs.html:24
 #: tcms/templates/run/get_case_runs.html:46
+#: tcms/testcases/tests/test_tags.py:42 tcms/testcases/tests/test_tags.py:58
+#: tcms/testplans/tests/test_views.py:43 tcms/testplans/tests/test_views.py:58
 msgid "Remove"
 msgstr ""
 
 #: tcms/templates/management/get_tag.html:35
+#: tcms/testcases/tests/test_tags.py:39 tcms/testcases/tests/test_tags.py:56
+#: tcms/testplans/tests/test_views.py:40
 msgid "Add Tag"
 msgstr ""
 
@@ -685,11 +717,6 @@ msgstr ""
 #: tcms/templates/navbar.html:53
 msgid "Login"
 msgstr ""
-
-#: tcms/templates/navbar.html:59
-#: tcms/templates/registration/registration_form.html:47
-msgid "Register"
-msgstr "Registrieren"
 
 #: tcms/templates/pagination.html:7
 msgid "First page"
@@ -727,7 +754,7 @@ msgstr ""
 msgid "Clone TestPlan"
 msgstr ""
 
-#: tcms/templates/plan/clone.html:29
+#: tcms/templates/plan/clone.html:29 tcms/testplans/tests/tests.py:443
 msgid "New Plan Name"
 msgstr ""
 
@@ -816,6 +843,7 @@ msgstr ""
 #: tcms/templates/run/get.html:91 tcms/templates/run/get_case_runs.html:122
 #: tcms/testcases/templates/testcases/get.html:330
 #: tcms/testcases/templates/testcases/search.html:141
+#: tcms/testcases/tests/test_views.py:411
 #: tcms/testplans/templates/testplans/search.html:115
 #: tcms/testruns/templates/testruns/search.html:98
 msgid "Tags"
@@ -1414,9 +1442,9 @@ msgid ""
 msgstr ""
 
 #: tcms/testcases/helpers/email.py:22
-#, python-brace-format
-msgid "DELETED: TestCase #%{pk}d - %{summary}s"
-msgstr "GELÖSCHT: Testfall #%{pk}d - %{summary}s"
+#, python-format
+msgid "DELETED: TestCase #%(pk)d - %(summary)s"
+msgstr "GELÖSCHT: Testfall #%(pk)d - %(summary)s"
 
 #: tcms/testcases/templates/testcases/get.html:98
 #: tcms/testcases/templates/testcases/mutable.html:107
@@ -1565,6 +1593,12 @@ msgstr "Suche"
 msgid "Created on"
 msgstr ""
 
+#: tcms/testcases/tests/test_views.py:334 tcms/testcases/views.py:761
+#: tcms/testruns/tests/test_views.py:212 tcms/testruns/views.py:422
+#: tcms/testruns/views.py:500
+msgid "At least one TestCase is required"
+msgstr "Mindestens ein Testfall ist erforderlich"
+
 #: tcms/testcases/views.py:399
 msgid "TestPlan not specified or does not exist"
 msgstr ""
@@ -1576,11 +1610,6 @@ msgstr ""
 #: tcms/testcases/views.py:588
 msgid "Delete"
 msgstr ""
-
-#: tcms/testcases/views.py:761 tcms/testruns/views.py:422
-#: tcms/testruns/views.py:500
-msgid "At least one TestCase is required"
-msgstr "Mindestens ein Testfall ist erforderlich"
 
 #: tcms/testcases/views.py:898
 msgid "TestCase cloning was successful"
@@ -1639,13 +1668,13 @@ msgstr ""
 msgid "Test plan"
 msgstr ""
 
-#: tcms/testplans/views.py:344
-msgid "TestPlan is required"
-msgstr "Testplan ist erforderlich"
-
-#: tcms/testplans/views.py:565
+#: tcms/testplans/tests/tests.py:91 tcms/testplans/views.py:565
 msgid "At least one test plan is required for print"
 msgstr ""
+
+#: tcms/testplans/tests/tests.py:424 tcms/testplans/views.py:344
+msgid "TestPlan is required"
+msgstr "Testplan ist erforderlich"
 
 #: tcms/testplans/views.py:573
 #, python-format
@@ -1716,28 +1745,28 @@ msgstr ""
 msgid "TestPlan ID"
 msgstr "Testplan ID"
 
+#: tcms/testruns/tests/test_views.py:108 tcms/testruns/views.py:60
+msgid "Creating a TestRun requires at least one TestCase"
+msgstr "Das Erstellen eines Testlaufs erfordert mindestens einen Testfall"
+
+#: tcms/testruns/tests/test_views.py:182 tcms/testruns/views.py:426
+msgid "Clone of "
+msgstr "Klon von "
+
+#: tcms/testruns/tests/test_views.py:462 tcms/testruns/views.py:637
+#, python-format
+msgid "%d CaseRun(s) updated:"
+msgstr "%d einzelne Tests aktualisiert:"
+
 #: tcms/testruns/views.py:50
 msgid "Creating a TestRun requires a TestPlan, select one"
 msgstr ""
 "Das Erstellen eines Testlaufs erfordert einen Testplan, bitte wählen Sie "
 "einen aus"
 
-#: tcms/testruns/views.py:60
-msgid "Creating a TestRun requires at least one TestCase"
-msgstr "Das Erstellen eines Testlaufs erfordert mindestens einen Testfall"
-
-#: tcms/testruns/views.py:426
-msgid "Clone of "
-msgstr "Klon von "
-
 #: tcms/testruns/views.py:509
 msgid "TestCase ID is not a valid integer"
 msgstr "Testfall-ID ist keine gültige Ganzzahl"
-
-#: tcms/testruns/views.py:637
-#, python-format
-msgid "%d CaseRun(s) updated:"
-msgstr "%d einzelne Tests aktualisiert:"
 
 #: tcms/xmlrpc/api/bug.py:85
 msgid ""
@@ -1755,49 +1784,49 @@ msgid "Model %s has no primary key. You have to specify such field manually."
 msgstr ""
 
 #: vinaigrette-deleteme.py:2
-msgid "IDLE"
-msgstr "INAKTIV"
-
-#: vinaigrette-deleteme.py:3
-msgid "RUNNING"
-msgstr "AM LAUFEN"
-
-#: vinaigrette-deleteme.py:4
-msgid "PAUSED"
-msgstr "PAUSIERT"
-
-#: vinaigrette-deleteme.py:5
-msgid "PASSED"
-msgstr "BESTANDEN"
-
-#: vinaigrette-deleteme.py:6
-msgid "FAILED"
-msgstr "FEHLGESCHLAGEN"
-
-#: vinaigrette-deleteme.py:7
-msgid "BLOCKED"
-msgstr "BLOCKIERT"
-
-#: vinaigrette-deleteme.py:8
-msgid "ERROR"
-msgstr "FEHLER"
-
-#: vinaigrette-deleteme.py:9
-msgid "WAIVED"
-msgstr "ÜBERSPRUNGEN"
-
-#: vinaigrette-deleteme.py:10
 msgid "PROPOSED"
 msgstr "VORGESCHLAGEN"
 
-#: vinaigrette-deleteme.py:11
+#: vinaigrette-deleteme.py:3
 msgid "CONFIRMED"
 msgstr "BESTÄTIGT"
 
-#: vinaigrette-deleteme.py:12
+#: vinaigrette-deleteme.py:4
 msgid "DISABLED"
 msgstr "DEAKTIVIERT"
 
-#: vinaigrette-deleteme.py:13
+#: vinaigrette-deleteme.py:5
 msgid "NEED_UPDATE"
 msgstr "MUSS_AKTUALISIERT_WERDEN"
+
+#: vinaigrette-deleteme.py:6
+msgid "IDLE"
+msgstr "INAKTIV"
+
+#: vinaigrette-deleteme.py:7
+msgid "RUNNING"
+msgstr "AM LAUFEN"
+
+#: vinaigrette-deleteme.py:8
+msgid "PAUSED"
+msgstr "PAUSIERT"
+
+#: vinaigrette-deleteme.py:9
+msgid "PASSED"
+msgstr "BESTANDEN"
+
+#: vinaigrette-deleteme.py:10
+msgid "FAILED"
+msgstr "FEHLGESCHLAGEN"
+
+#: vinaigrette-deleteme.py:11
+msgid "BLOCKED"
+msgstr "BLOCKIERT"
+
+#: vinaigrette-deleteme.py:12
+msgid "ERROR"
+msgstr "FEHLER"
+
+#: vinaigrette-deleteme.py:13
+msgid "WAIVED"
+msgstr "ÜBERSPRUNGEN"

--- a/tcms/locale/en/LC_MESSAGES/django.po
+++ b/tcms/locale/en/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-23 23:31+0000\n"
+"POT-Creation-Date: 2019-03-29 09:09+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -50,6 +50,21 @@ msgstr ""
 msgid "Comment"
 msgstr ""
 
+#: tcms/core/contrib/linkreference/tests.py:84
+msgid "Enter a valid URL."
+msgstr ""
+
+#: tcms/core/contrib/linkreference/tests.py:101
+#, python-format
+msgid ""
+"Ensure this value has at most %(limit_value)d character (it has "
+"%(show_value)d)."
+msgid_plural ""
+"Ensure this value has at most %(limit_value)d characters (it has "
+"%(show_value)d)."
+msgstr[0] ""
+msgstr[1] ""
+
 #: tcms/core/history.py:41
 #, python-format
 msgid "UPDATE: %(model_name)s #%(pk)d - %(title)s"
@@ -90,110 +105,140 @@ msgstr ""
 msgid "A user with that email already exists."
 msgstr ""
 
-#: tcms/kiwi_auth/forms.py:60
+#: tcms/kiwi_auth/forms.py:60 tcms/kiwi_auth/tests.py:176
 #, python-format
 msgid "Your new %s account confirmation"
 msgstr ""
 
-#: tcms/kiwi_auth/views.py:50
+#: tcms/kiwi_auth/test_admin.py:59 tcms/management/tests/tests.py:76
+msgid "Yes, I'm sure"
+msgstr ""
+
+#: tcms/kiwi_auth/tests.py:97 tcms/templates/navbar.html:59
+#: tcms/templates/registration/registration_form.html:47
+msgid "Register"
+msgstr ""
+
+#: tcms/kiwi_auth/tests.py:141 tcms/signals.py:78
+msgid "New user awaiting approval"
+msgstr ""
+
+#: tcms/kiwi_auth/tests.py:146
+#: tcms/templates/email/user_registered/notify_admins.txt:2
+#, python-format
+msgid ""
+"Dear Administrator,\n"
+"somebody just registered an account with username %(username)s at your\n"
+"Kiwi TCMS instance and is awaiting your approval!\n"
+"\n"
+"Go to %(user_url)s to activate the account!\n"
+msgstr ""
+
+#: tcms/kiwi_auth/tests.py:162 tcms/kiwi_auth/views.py:50
 msgid ""
 "Your account has been created, please check your mailbox for confirmation"
 msgstr ""
 
-#: tcms/kiwi_auth/views.py:56
+#: tcms/kiwi_auth/tests.py:177 tcms/templates/email/confirm_registration.txt:1
+#, python-format
+msgid ""
+"Welcome %(user)s,\n"
+"thank you for signing up for an %(site_domain)s account!\n"
+"\n"
+"To activate your account, click this link:\n"
+"%(confirm_url)s\n"
+msgstr ""
+
+#: tcms/kiwi_auth/tests.py:196 tcms/kiwi_auth/views.py:56
 msgid ""
 "Your account has been created, but you need an administrator to activate it"
+msgstr ""
+
+#: tcms/kiwi_auth/tests.py:222 tcms/kiwi_auth/views.py:103
+msgid "This activation key no longer exists in the database"
+msgstr ""
+
+#: tcms/kiwi_auth/tests.py:240 tcms/kiwi_auth/views.py:108
+msgid "This activation key has expired"
+msgstr ""
+
+#: tcms/kiwi_auth/tests.py:259 tcms/kiwi_auth/views.py:120
+msgid "Your account has been activated successfully"
 msgstr ""
 
 #: tcms/kiwi_auth/views.py:61
 msgid "Following is the administrator list"
 msgstr ""
 
-#: tcms/kiwi_auth/views.py:103
-msgid "This activation key no longer exists in the database"
-msgstr ""
-
-#: tcms/kiwi_auth/views.py:108
-msgid "This activation key has expired"
-msgstr ""
-
-#: tcms/kiwi_auth/views.py:120
-msgid "Your account has been activated successfully"
-msgstr ""
-
-#: tcms/settings/common.py:87
+#: tcms/settings/common.py:90
 msgid "DASHBOARD"
 msgstr ""
 
-#: tcms/settings/common.py:88
+#: tcms/settings/common.py:91
 msgid "TESTING"
 msgstr ""
 
-#: tcms/settings/common.py:89
+#: tcms/settings/common.py:92
 msgid "New Test Plan"
 msgstr ""
 
-#: tcms/settings/common.py:91
+#: tcms/settings/common.py:94
 msgid "New Test Case"
 msgstr ""
 
-#: tcms/settings/common.py:93
+#: tcms/settings/common.py:96
 msgid "SEARCH"
 msgstr ""
 
-#: tcms/settings/common.py:94
+#: tcms/settings/common.py:97
 msgid "Search Test Plans"
 msgstr ""
 
-#: tcms/settings/common.py:95
+#: tcms/settings/common.py:98
 msgid "Search Test Runs"
 msgstr ""
 
-#: tcms/settings/common.py:96
+#: tcms/settings/common.py:99
 msgid "Search Test Cases"
 msgstr ""
 
-#: tcms/settings/common.py:98
+#: tcms/settings/common.py:101 tcms/telemetry/tests/test_plugin_discovery.py:52
 msgid "TELEMETRY"
 msgstr ""
 
-#: tcms/settings/common.py:103
+#: tcms/settings/common.py:115
 msgid "ADMIN"
 msgstr ""
 
-#: tcms/settings/common.py:104
+#: tcms/settings/common.py:116
 msgid "Users and groups"
 msgstr ""
 
-#: tcms/settings/common.py:106
+#: tcms/settings/common.py:118
 msgid "Everything else"
 msgstr ""
 
-#: tcms/settings/common.py:112
+#: tcms/settings/common.py:124
 msgid "Report an Issue"
 msgstr ""
 
-#: tcms/settings/common.py:113
+#: tcms/settings/common.py:125
 msgid "Ask for help on StackOverflow"
 msgstr ""
 
-#: tcms/settings/common.py:114
+#: tcms/settings/common.py:126
 msgid "User Guide"
 msgstr ""
 
-#: tcms/settings/common.py:115
+#: tcms/settings/common.py:127
 msgid "Administration Guide"
 msgstr ""
 
-#: tcms/settings/common.py:116
+#: tcms/settings/common.py:128
 msgid "API Help"
 msgstr ""
 
-#: tcms/signals.py:78
-msgid "New user awaiting approval"
-msgstr ""
-
-#: tcms/signals.py:153
+#: tcms/signals.py:153 tcms/testruns/tests/test_models.py:42
 #, python-format
 msgid "NEW: TestRun #%(pk)d - %(summary)s"
 msgstr ""
@@ -252,7 +297,7 @@ msgstr ""
 msgid "Select Plan"
 msgstr ""
 
-#: tcms/templates/case/clone.html:32
+#: tcms/templates/case/clone.html:32 tcms/testcases/tests/test_views.py:346
 msgid "Use the same Plan"
 msgstr ""
 
@@ -562,21 +607,11 @@ msgstr ""
 msgid "There are no TestPlan(s) that belong to you"
 msgstr ""
 
-#: tcms/templates/email/confirm_registration.txt:1
-#, python-format
-msgid ""
-"Welcome %(user)s,\n"
-"thank you for signing up for an %(site_domain)s account!\n"
-"\n"
-"To activate your account, click this link:\n"
-"%(confirm_url)s\n"
-msgstr ""
-
 #: tcms/templates/email/post_case_delete/email.txt:2
 #, python-format
 msgid ""
 "\n"
-"TestCase has been updated by %(username)s!\n"
+"TestCase has been deleted by %(username)s!\n"
 msgstr ""
 
 #: tcms/templates/email/post_run_save/email.txt:2
@@ -603,16 +638,6 @@ msgid ""
 "%(notes)s\n"
 msgstr ""
 
-#: tcms/templates/email/user_registered/notify_admins.txt:2
-#, python-format
-msgid ""
-"Dear Administrator,\n"
-"somebody just registered an account with username %(username)s at your\n"
-"Kiwi TCMS instance and is awaiting your approval!\n"
-"\n"
-"Go to %(user_url)s to activate the account!\n"
-msgstr ""
-
 #: tcms/templates/management/get_tag.html:7
 msgid "Plans"
 msgstr ""
@@ -632,10 +657,14 @@ msgstr ""
 #: tcms/templates/plan/get_cases.html:32 tcms/templates/plan/get_cases.html:34
 #: tcms/templates/run/get_case_runs.html:24
 #: tcms/templates/run/get_case_runs.html:46
+#: tcms/testcases/tests/test_tags.py:42 tcms/testcases/tests/test_tags.py:58
+#: tcms/testplans/tests/test_views.py:43 tcms/testplans/tests/test_views.py:58
 msgid "Remove"
 msgstr ""
 
 #: tcms/templates/management/get_tag.html:35
+#: tcms/testcases/tests/test_tags.py:39 tcms/testcases/tests/test_tags.py:56
+#: tcms/testplans/tests/test_views.py:40
 msgid "Add Tag"
 msgstr ""
 
@@ -670,11 +699,6 @@ msgstr ""
 
 #: tcms/templates/navbar.html:53
 msgid "Login"
-msgstr ""
-
-#: tcms/templates/navbar.html:59
-#: tcms/templates/registration/registration_form.html:47
-msgid "Register"
 msgstr ""
 
 #: tcms/templates/pagination.html:7
@@ -713,7 +737,7 @@ msgstr ""
 msgid "Clone TestPlan"
 msgstr ""
 
-#: tcms/templates/plan/clone.html:29
+#: tcms/templates/plan/clone.html:29 tcms/testplans/tests/tests.py:443
 msgid "New Plan Name"
 msgstr ""
 
@@ -802,6 +826,7 @@ msgstr ""
 #: tcms/templates/run/get.html:91 tcms/templates/run/get_case_runs.html:122
 #: tcms/testcases/templates/testcases/get.html:330
 #: tcms/testcases/templates/testcases/search.html:141
+#: tcms/testcases/tests/test_views.py:411
 #: tcms/testplans/templates/testplans/search.html:115
 #: tcms/testruns/templates/testruns/search.html:98
 msgid "Tags"
@@ -1396,8 +1421,8 @@ msgid ""
 msgstr ""
 
 #: tcms/testcases/helpers/email.py:22
-#, python-brace-format
-msgid "DELETED: TestCase #%{pk}d - %{summary}s"
+#, python-format
+msgid "DELETED: TestCase #%(pk)d - %(summary)s"
 msgstr ""
 
 #: tcms/testcases/templates/testcases/get.html:98
@@ -1547,6 +1572,12 @@ msgstr ""
 msgid "Created on"
 msgstr ""
 
+#: tcms/testcases/tests/test_views.py:334 tcms/testcases/views.py:761
+#: tcms/testruns/tests/test_views.py:212 tcms/testruns/views.py:422
+#: tcms/testruns/views.py:500
+msgid "At least one TestCase is required"
+msgstr ""
+
 #: tcms/testcases/views.py:399
 msgid "TestPlan not specified or does not exist"
 msgstr ""
@@ -1557,11 +1588,6 @@ msgstr ""
 
 #: tcms/testcases/views.py:588
 msgid "Delete"
-msgstr ""
-
-#: tcms/testcases/views.py:761 tcms/testruns/views.py:422
-#: tcms/testruns/views.py:500
-msgid "At least one TestCase is required"
 msgstr ""
 
 #: tcms/testcases/views.py:898
@@ -1621,12 +1647,12 @@ msgstr ""
 msgid "Test plan"
 msgstr ""
 
-#: tcms/testplans/views.py:344
-msgid "TestPlan is required"
+#: tcms/testplans/tests/tests.py:91 tcms/testplans/views.py:565
+msgid "At least one test plan is required for print"
 msgstr ""
 
-#: tcms/testplans/views.py:565
-msgid "At least one test plan is required for print"
+#: tcms/testplans/tests/tests.py:424 tcms/testplans/views.py:344
+msgid "TestPlan is required"
 msgstr ""
 
 #: tcms/testplans/views.py:573
@@ -1698,25 +1724,25 @@ msgstr ""
 msgid "TestPlan ID"
 msgstr ""
 
+#: tcms/testruns/tests/test_views.py:108 tcms/testruns/views.py:60
+msgid "Creating a TestRun requires at least one TestCase"
+msgstr ""
+
+#: tcms/testruns/tests/test_views.py:182 tcms/testruns/views.py:426
+msgid "Clone of "
+msgstr ""
+
+#: tcms/testruns/tests/test_views.py:462 tcms/testruns/views.py:637
+#, python-format
+msgid "%d CaseRun(s) updated:"
+msgstr ""
+
 #: tcms/testruns/views.py:50
 msgid "Creating a TestRun requires a TestPlan, select one"
 msgstr ""
 
-#: tcms/testruns/views.py:60
-msgid "Creating a TestRun requires at least one TestCase"
-msgstr ""
-
-#: tcms/testruns/views.py:426
-msgid "Clone of "
-msgstr ""
-
 #: tcms/testruns/views.py:509
 msgid "TestCase ID is not a valid integer"
-msgstr ""
-
-#: tcms/testruns/views.py:637
-#, python-format
-msgid "%d CaseRun(s) updated:"
 msgstr ""
 
 #: tcms/xmlrpc/api/bug.py:85
@@ -1735,49 +1761,49 @@ msgid "Model %s has no primary key. You have to specify such field manually."
 msgstr ""
 
 #: vinaigrette-deleteme.py:2
-msgid "IDLE"
-msgstr ""
-
-#: vinaigrette-deleteme.py:3
-msgid "RUNNING"
-msgstr ""
-
-#: vinaigrette-deleteme.py:4
-msgid "PAUSED"
-msgstr ""
-
-#: vinaigrette-deleteme.py:5
-msgid "PASSED"
-msgstr ""
-
-#: vinaigrette-deleteme.py:6
-msgid "FAILED"
-msgstr ""
-
-#: vinaigrette-deleteme.py:7
-msgid "BLOCKED"
-msgstr ""
-
-#: vinaigrette-deleteme.py:8
-msgid "ERROR"
-msgstr ""
-
-#: vinaigrette-deleteme.py:9
-msgid "WAIVED"
-msgstr ""
-
-#: vinaigrette-deleteme.py:10
 msgid "PROPOSED"
 msgstr ""
 
-#: vinaigrette-deleteme.py:11
+#: vinaigrette-deleteme.py:3
 msgid "CONFIRMED"
 msgstr ""
 
-#: vinaigrette-deleteme.py:12
+#: vinaigrette-deleteme.py:4
 msgid "DISABLED"
 msgstr ""
 
-#: vinaigrette-deleteme.py:13
+#: vinaigrette-deleteme.py:5
 msgid "NEED_UPDATE"
+msgstr ""
+
+#: vinaigrette-deleteme.py:6
+msgid "IDLE"
+msgstr ""
+
+#: vinaigrette-deleteme.py:7
+msgid "RUNNING"
+msgstr ""
+
+#: vinaigrette-deleteme.py:8
+msgid "PAUSED"
+msgstr ""
+
+#: vinaigrette-deleteme.py:9
+msgid "PASSED"
+msgstr ""
+
+#: vinaigrette-deleteme.py:10
+msgid "FAILED"
+msgstr ""
+
+#: vinaigrette-deleteme.py:11
+msgid "BLOCKED"
+msgstr ""
+
+#: vinaigrette-deleteme.py:12
+msgid "ERROR"
+msgstr ""
+
+#: vinaigrette-deleteme.py:13
+msgid "WAIVED"
 msgstr ""

--- a/tcms/locale/fr_FR/LC_MESSAGES/django.po
+++ b/tcms/locale/fr_FR/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: kiwitcms\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-23 23:31+0000\n"
+"POT-Creation-Date: 2019-03-29 09:09+0000\n"
 "PO-Revision-Date: 2019-03-13 13:42\n"
 "Last-Translator: atodorov <atodorov@otb.bg>\n"
 "Language-Team: French\n"
@@ -48,6 +48,21 @@ msgstr "URL"
 #: tcms/templates/run/get_case_runs.html:50
 msgid "Comment"
 msgstr "Commentaire"
+
+#: tcms/core/contrib/linkreference/tests.py:84
+msgid "Enter a valid URL."
+msgstr ""
+
+#: tcms/core/contrib/linkreference/tests.py:101
+#, python-format
+msgid ""
+"Ensure this value has at most %(limit_value)d character (it has "
+"%(show_value)d)."
+msgid_plural ""
+"Ensure this value has at most %(limit_value)d characters (it has "
+"%(show_value)d)."
+msgstr[0] ""
+msgstr[1] ""
 
 #: tcms/core/history.py:41
 #, python-format
@@ -98,114 +113,155 @@ msgstr "Droits"
 msgid "A user with that email already exists."
 msgstr "Un utilisateur avec cette adresse mail existe déjà."
 
-#: tcms/kiwi_auth/forms.py:60
+#: tcms/kiwi_auth/forms.py:60 tcms/kiwi_auth/tests.py:176
 #, python-format
 msgid "Your new %s account confirmation"
 msgstr "Votre confirmation du nouveau compte %s"
 
-#: tcms/kiwi_auth/views.py:50
+#: tcms/kiwi_auth/test_admin.py:59 tcms/management/tests/tests.py:76
+msgid "Yes, I'm sure"
+msgstr ""
+
+#: tcms/kiwi_auth/tests.py:97 tcms/templates/navbar.html:59
+#: tcms/templates/registration/registration_form.html:47
+msgid "Register"
+msgstr "Inscription"
+
+#: tcms/kiwi_auth/tests.py:141 tcms/signals.py:78
+msgid "New user awaiting approval"
+msgstr "Nouvel utilisateur en attente d’approbation"
+
+#: tcms/kiwi_auth/tests.py:146
+#: tcms/templates/email/user_registered/notify_admins.txt:2
+#, python-format
+msgid ""
+"Dear Administrator,\n"
+"somebody just registered an account with username %(username)s at your\n"
+"Kiwi TCMS instance and is awaiting your approval!\n"
+"\n"
+"Go to %(user_url)s to activate the account!\n"
+msgstr ""
+"Chèr(e) Administra(teur/trice),\n"
+"une personne s'est enregistré un compte avec le nom %(username)s sur votre "
+"instance\n"
+"Kiwi TCMS et attend votre approbation!\n"
+"\n"
+"Aller à l'adresse %(user_url)s pour activer ce compte!\n"
+
+#: tcms/kiwi_auth/tests.py:162 tcms/kiwi_auth/views.py:50
 msgid ""
 "Your account has been created, please check your mailbox for confirmation"
 msgstr ""
 "Votre compte a été créé. Veuillez Vérifier votre boite de courriel pour le "
 "lien de confirmation"
 
-#: tcms/kiwi_auth/views.py:56
+#: tcms/kiwi_auth/tests.py:177 tcms/templates/email/confirm_registration.txt:1
+#, python-format
+msgid ""
+"Welcome %(user)s,\n"
+"thank you for signing up for an %(site_domain)s account!\n"
+"\n"
+"To activate your account, click this link:\n"
+"%(confirm_url)s\n"
+msgstr ""
+"Bienvenu %(user)s,\n"
+"Merci pour votre inscription sur %(site_domain)s!\n"
+"\n"
+"Pour activer votre compte cliquer sur le lien suivant:\n"
+"%(confirm_url)s\n"
+
+#: tcms/kiwi_auth/tests.py:196 tcms/kiwi_auth/views.py:56
 msgid ""
 "Your account has been created, but you need an administrator to activate it"
 msgstr ""
 "Votre compte a été créé, mais vous avez besoin d’un administrateur pour "
 "l’activer"
 
+#: tcms/kiwi_auth/tests.py:222 tcms/kiwi_auth/views.py:103
+msgid "This activation key no longer exists in the database"
+msgstr "Cette clé d'activation n'existe plus dans la base de données"
+
+#: tcms/kiwi_auth/tests.py:240 tcms/kiwi_auth/views.py:108
+msgid "This activation key has expired"
+msgstr "Cette clé d'activation a expiré"
+
+#: tcms/kiwi_auth/tests.py:259 tcms/kiwi_auth/views.py:120
+msgid "Your account has been activated successfully"
+msgstr "Votre compte a été activé avec succès"
+
 #: tcms/kiwi_auth/views.py:61
 msgid "Following is the administrator list"
 msgstr "Ci-dessous la liste des administrateurs"
 
-#: tcms/kiwi_auth/views.py:103
-msgid "This activation key no longer exists in the database"
-msgstr "Cette clé d'activation n'existe plus dans la base de données"
-
-#: tcms/kiwi_auth/views.py:108
-msgid "This activation key has expired"
-msgstr "Cette clé d'activation a expiré"
-
-#: tcms/kiwi_auth/views.py:120
-msgid "Your account has been activated successfully"
-msgstr "Votre compte a été activé avec succès"
-
-#: tcms/settings/common.py:87
+#: tcms/settings/common.py:90
 msgid "DASHBOARD"
 msgstr "TABLEAU DE BORD"
 
-#: tcms/settings/common.py:88
+#: tcms/settings/common.py:91
 msgid "TESTING"
 msgstr "EN_TEST"
 
-#: tcms/settings/common.py:89
+#: tcms/settings/common.py:92
 msgid "New Test Plan"
 msgstr "Nouveau plan de test"
 
-#: tcms/settings/common.py:91
+#: tcms/settings/common.py:94
 msgid "New Test Case"
 msgstr "Nouveau scénario de test"
 
-#: tcms/settings/common.py:93
+#: tcms/settings/common.py:96
 msgid "SEARCH"
 msgstr "RECHERCHER"
 
-#: tcms/settings/common.py:94
+#: tcms/settings/common.py:97
 msgid "Search Test Plans"
 msgstr "Rechercher des plans de test"
 
-#: tcms/settings/common.py:95
+#: tcms/settings/common.py:98
 msgid "Search Test Runs"
 msgstr "Rechercher des essais réalisés"
 
-#: tcms/settings/common.py:96
+#: tcms/settings/common.py:99
 msgid "Search Test Cases"
 msgstr "Rechercher des scénarios de tests"
 
-#: tcms/settings/common.py:98
+#: tcms/settings/common.py:101 tcms/telemetry/tests/test_plugin_discovery.py:52
 msgid "TELEMETRY"
 msgstr ""
 
-#: tcms/settings/common.py:103
+#: tcms/settings/common.py:115
 msgid "ADMIN"
 msgstr "ADMINISTRATEUR"
 
-#: tcms/settings/common.py:104
+#: tcms/settings/common.py:116
 msgid "Users and groups"
 msgstr "Utilisateurs et groupes"
 
-#: tcms/settings/common.py:106
+#: tcms/settings/common.py:118
 msgid "Everything else"
 msgstr "Tout le reste"
 
-#: tcms/settings/common.py:112
+#: tcms/settings/common.py:124
 msgid "Report an Issue"
 msgstr "Signaler un problème"
 
-#: tcms/settings/common.py:113
+#: tcms/settings/common.py:125
 msgid "Ask for help on StackOverflow"
 msgstr "Demander de l’aide sur StackOverflow"
 
-#: tcms/settings/common.py:114
+#: tcms/settings/common.py:126
 msgid "User Guide"
 msgstr "Guide de l'utilisateur"
 
-#: tcms/settings/common.py:115
+#: tcms/settings/common.py:127
 msgid "Administration Guide"
 msgstr "Guide de l'administrateur"
 
-#: tcms/settings/common.py:116
+#: tcms/settings/common.py:128
 msgid "API Help"
 msgstr "Aide sur l’API"
 
-#: tcms/signals.py:78
-msgid "New user awaiting approval"
-msgstr "Nouvel utilisateur en attente d’approbation"
-
-#: tcms/signals.py:153
+#: tcms/signals.py:153 tcms/testruns/tests/test_models.py:42
 #, python-format
 msgid "NEW: TestRun #%(pk)d - %(summary)s"
 msgstr "NOUVEAU: Essai #%(pk)d - %(summary)s"
@@ -264,7 +320,7 @@ msgstr "Cloner le(s) scénario(s) de test(s)"
 msgid "Select Plan"
 msgstr "Choisissez un plan"
 
-#: tcms/templates/case/clone.html:32
+#: tcms/templates/case/clone.html:32 tcms/testcases/tests/test_views.py:346
 msgid "Use the same Plan"
 msgstr "Utiliser le même plan"
 
@@ -584,26 +640,14 @@ msgstr ""
 msgid "There are no TestPlan(s) that belong to you"
 msgstr "Il n’y a aucun plan(s) de test qui vous est assigné"
 
-#: tcms/templates/email/confirm_registration.txt:1
-#, python-format
-msgid ""
-"Welcome %(user)s,\n"
-"thank you for signing up for an %(site_domain)s account!\n"
-"\n"
-"To activate your account, click this link:\n"
-"%(confirm_url)s\n"
-msgstr ""
-"Bienvenu %(user)s,\n"
-"Merci pour votre inscription sur %(site_domain)s!\n"
-"\n"
-"Pour activer votre compte cliquer sur le lien suivant:\n"
-"%(confirm_url)s\n"
-
 #: tcms/templates/email/post_case_delete/email.txt:2
-#, python-format
+#, fuzzy, python-format
+#| msgid ""
+#| "\n"
+#| "TestCase has been updated by %(username)s!\n"
 msgid ""
 "\n"
-"TestCase has been updated by %(username)s!\n"
+"TestCase has been deleted by %(username)s!\n"
 msgstr ""
 "\n"
 "Le scénario de test a été mis à jour par %(username)s!\n"
@@ -651,22 +695,6 @@ msgstr ""
 "Récapitulatif:\n"
 "%(notes)s\n"
 
-#: tcms/templates/email/user_registered/notify_admins.txt:2
-#, python-format
-msgid ""
-"Dear Administrator,\n"
-"somebody just registered an account with username %(username)s at your\n"
-"Kiwi TCMS instance and is awaiting your approval!\n"
-"\n"
-"Go to %(user_url)s to activate the account!\n"
-msgstr ""
-"Chèr(e) Administra(teur/trice),\n"
-"une personne s'est enregistré un compte avec le nom %(username)s sur votre "
-"instance\n"
-"Kiwi TCMS et attend votre approbation!\n"
-"\n"
-"Aller à l'adresse %(user_url)s pour activer ce compte!\n"
-
 #: tcms/templates/management/get_tag.html:7
 msgid "Plans"
 msgstr "Plans"
@@ -686,10 +714,14 @@ msgstr "Exécutions"
 #: tcms/templates/plan/get_cases.html:32 tcms/templates/plan/get_cases.html:34
 #: tcms/templates/run/get_case_runs.html:24
 #: tcms/templates/run/get_case_runs.html:46
+#: tcms/testcases/tests/test_tags.py:42 tcms/testcases/tests/test_tags.py:58
+#: tcms/testplans/tests/test_views.py:43 tcms/testplans/tests/test_views.py:58
 msgid "Remove"
 msgstr "Supprimer"
 
 #: tcms/templates/management/get_tag.html:35
+#: tcms/testcases/tests/test_tags.py:39 tcms/testcases/tests/test_tags.py:56
+#: tcms/testplans/tests/test_views.py:40
 msgid "Add Tag"
 msgstr "Ajouter une étiquette"
 
@@ -725,11 +757,6 @@ msgstr "Déconnexion"
 #: tcms/templates/navbar.html:53
 msgid "Login"
 msgstr "Se connecter"
-
-#: tcms/templates/navbar.html:59
-#: tcms/templates/registration/registration_form.html:47
-msgid "Register"
-msgstr "Inscription"
 
 #: tcms/templates/pagination.html:7
 msgid "First page"
@@ -767,7 +794,7 @@ msgstr "Dupliquer un plan"
 msgid "Clone TestPlan"
 msgstr "Dupliquer un plan de test"
 
-#: tcms/templates/plan/clone.html:29
+#: tcms/templates/plan/clone.html:29 tcms/testplans/tests/tests.py:443
 msgid "New Plan Name"
 msgstr "Nouveau nom de plan"
 
@@ -856,6 +883,7 @@ msgstr "Pièces jointes"
 #: tcms/templates/run/get.html:91 tcms/templates/run/get_case_runs.html:122
 #: tcms/testcases/templates/testcases/get.html:330
 #: tcms/testcases/templates/testcases/search.html:141
+#: tcms/testcases/tests/test_views.py:411
 #: tcms/testplans/templates/testplans/search.html:115
 #: tcms/testruns/templates/testruns/search.html:98
 msgid "Tags"
@@ -1479,9 +1507,9 @@ msgstr ""
 "3. élement\n"
 
 #: tcms/testcases/helpers/email.py:22
-#, python-brace-format
-msgid "DELETED: TestCase #%{pk}d - %{summary}s"
-msgstr "SUPPRIMÉ: scénario de test #%{pk}d - %{summary}s"
+#, python-format
+msgid "DELETED: TestCase #%(pk)d - %(summary)s"
+msgstr "SUPPRIMÉ: scénario de test #%(pk)d - %(summary)s"
 
 #: tcms/testcases/templates/testcases/get.html:98
 #: tcms/testcases/templates/testcases/mutable.html:107
@@ -1632,6 +1660,12 @@ msgstr "Recherche"
 msgid "Created on"
 msgstr "Créé le"
 
+#: tcms/testcases/tests/test_views.py:334 tcms/testcases/views.py:761
+#: tcms/testruns/tests/test_views.py:212 tcms/testruns/views.py:422
+#: tcms/testruns/views.py:500
+msgid "At least one TestCase is required"
+msgstr "Au moins un scénario de test est requis"
+
 #: tcms/testcases/views.py:399
 msgid "TestPlan not specified or does not exist"
 msgstr "Plan de test non spécifié ou n'existe pas"
@@ -1643,11 +1677,6 @@ msgstr "Historique"
 #: tcms/testcases/views.py:588
 msgid "Delete"
 msgstr "Supprimer"
-
-#: tcms/testcases/views.py:761 tcms/testruns/views.py:422
-#: tcms/testruns/views.py:500
-msgid "At least one TestCase is required"
-msgstr "Au moins un scénario de test est requis"
 
 #: tcms/testcases/views.py:898
 msgid "TestCase cloning was successful"
@@ -1706,13 +1735,13 @@ msgstr "Nom du plan de test"
 msgid "Test plan"
 msgstr "Plan de test"
 
-#: tcms/testplans/views.py:344
-msgid "TestPlan is required"
-msgstr "Le plan de test est requis"
-
-#: tcms/testplans/views.py:565
+#: tcms/testplans/tests/tests.py:91 tcms/testplans/views.py:565
 msgid "At least one test plan is required for print"
 msgstr "Au moins un plan de test est requis pur l'impression"
+
+#: tcms/testplans/tests/tests.py:424 tcms/testplans/views.py:344
+msgid "TestPlan is required"
+msgstr "Le plan de test est requis"
 
 #: tcms/testplans/views.py:573
 #, python-format
@@ -1788,27 +1817,27 @@ msgstr "ID du plan"
 msgid "TestPlan ID"
 msgstr "ID du plan de test"
 
+#: tcms/testruns/tests/test_views.py:108 tcms/testruns/views.py:60
+msgid "Creating a TestRun requires at least one TestCase"
+msgstr "Créé un scénario de test requiert au moins un cas de test"
+
+#: tcms/testruns/tests/test_views.py:182 tcms/testruns/views.py:426
+msgid "Clone of "
+msgstr "Clone de "
+
+#: tcms/testruns/tests/test_views.py:462 tcms/testruns/views.py:637
+#, python-format
+msgid "%d CaseRun(s) updated:"
+msgstr "Exécution du scénario %d mis à jour:"
+
 #: tcms/testruns/views.py:50
 msgid "Creating a TestRun requires a TestPlan, select one"
 msgstr ""
 "Créé un essai de test requiert un plan de test, veuillez en sélectionné un"
 
-#: tcms/testruns/views.py:60
-msgid "Creating a TestRun requires at least one TestCase"
-msgstr "Créé un scénario de test requiert au moins un cas de test"
-
-#: tcms/testruns/views.py:426
-msgid "Clone of "
-msgstr "Clone de "
-
 #: tcms/testruns/views.py:509
 msgid "TestCase ID is not a valid integer"
 msgstr "ID du scénario de test n'est plus un entier valide"
-
-#: tcms/testruns/views.py:637
-#, python-format
-msgid "%d CaseRun(s) updated:"
-msgstr "Exécution du scénario %d mis à jour:"
 
 #: tcms/xmlrpc/api/bug.py:85
 msgid ""
@@ -1832,49 +1861,49 @@ msgstr ""
 "manuellement."
 
 #: vinaigrette-deleteme.py:2
-msgid "IDLE"
-msgstr "EN VEILLE"
-
-#: vinaigrette-deleteme.py:3
-msgid "RUNNING"
-msgstr "EN COURS"
-
-#: vinaigrette-deleteme.py:4
-msgid "PAUSED"
-msgstr "MIS EN PAUSE"
-
-#: vinaigrette-deleteme.py:5
-msgid "PASSED"
-msgstr "PASSÉ"
-
-#: vinaigrette-deleteme.py:6
-msgid "FAILED"
-msgstr "EN ÉCHEC"
-
-#: vinaigrette-deleteme.py:7
-msgid "BLOCKED"
-msgstr "BLOQUÉ"
-
-#: vinaigrette-deleteme.py:8
-msgid "ERROR"
-msgstr "ERREUR"
-
-#: vinaigrette-deleteme.py:9
-msgid "WAIVED"
-msgstr "RENONCÉ À"
-
-#: vinaigrette-deleteme.py:10
 msgid "PROPOSED"
 msgstr "PROPOSÉ"
 
-#: vinaigrette-deleteme.py:11
+#: vinaigrette-deleteme.py:3
 msgid "CONFIRMED"
 msgstr "CONFIRMÉ"
 
-#: vinaigrette-deleteme.py:12
+#: vinaigrette-deleteme.py:4
 msgid "DISABLED"
 msgstr "DÉSACTIVÉ"
 
-#: vinaigrette-deleteme.py:13
+#: vinaigrette-deleteme.py:5
 msgid "NEED_UPDATE"
 msgstr "DOIT_ÊTRE_MAJ"
+
+#: vinaigrette-deleteme.py:6
+msgid "IDLE"
+msgstr "EN VEILLE"
+
+#: vinaigrette-deleteme.py:7
+msgid "RUNNING"
+msgstr "EN COURS"
+
+#: vinaigrette-deleteme.py:8
+msgid "PAUSED"
+msgstr "MIS EN PAUSE"
+
+#: vinaigrette-deleteme.py:9
+msgid "PASSED"
+msgstr "PASSÉ"
+
+#: vinaigrette-deleteme.py:10
+msgid "FAILED"
+msgstr "EN ÉCHEC"
+
+#: vinaigrette-deleteme.py:11
+msgid "BLOCKED"
+msgstr "BLOQUÉ"
+
+#: vinaigrette-deleteme.py:12
+msgid "ERROR"
+msgstr "ERREUR"
+
+#: vinaigrette-deleteme.py:13
+msgid "WAIVED"
+msgstr "RENONCÉ À"

--- a/tcms/locale/sl_SI/LC_MESSAGES/django.po
+++ b/tcms/locale/sl_SI/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: kiwitcms\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-23 23:31+0000\n"
+"POT-Creation-Date: 2019-03-29 09:09+0000\n"
 "PO-Revision-Date: 2019-03-26 09:57\n"
 "Last-Translator: atodorov <atodorov@otb.bg>\n"
 "Language-Team: Slovenian\n"
@@ -10,7 +10,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=4; plural=(n%100==1 ? 1 : n%100==2 ? 2 : n%100==3 || n%100==4 ? 3 : 0);\n"
+"Plural-Forms: nplurals=4; plural=(n%100==1 ? 1 : n%100==2 ? 2 : n%100==3 || n"
+"%100==4 ? 3 : 0);\n"
 "X-Generator: crowdin.com\n"
 "X-Crowdin-Project: kiwitcms\n"
 "X-Crowdin-Language: sl\n"
@@ -49,6 +50,23 @@ msgstr "URL naslov"
 msgid "Comment"
 msgstr "Komentar"
 
+#: tcms/core/contrib/linkreference/tests.py:84
+msgid "Enter a valid URL."
+msgstr ""
+
+#: tcms/core/contrib/linkreference/tests.py:101
+#, python-format
+msgid ""
+"Ensure this value has at most %(limit_value)d character (it has "
+"%(show_value)d)."
+msgid_plural ""
+"Ensure this value has at most %(limit_value)d characters (it has "
+"%(show_value)d)."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
+
 #: tcms/core/history.py:41
 #, python-format
 msgid "UPDATE: %(model_name)s #%(pk)d - %(title)s"
@@ -56,21 +74,31 @@ msgstr "POSODOBITEV: %(model_name)s #%(pk)d - %(title)s"
 
 #: tcms/core/history.py:47
 #, python-format
-msgid "Updated on %(history_date)s\n"
-"Updated by %(username)s\n\n"
-"%(diff)s\n\n"
+msgid ""
+"Updated on %(history_date)s\n"
+"Updated by %(username)s\n"
+"\n"
+"%(diff)s\n"
+"\n"
 "For more information:\n"
 "%(instance_url)s"
-msgstr "Čas posodobitve %(history_date)s\n"
-"Posodobil %(username)s\n\n"
-"%(diff)s\n\n"
+msgstr ""
+"Čas posodobitve %(history_date)s\n"
+"Posodobil %(username)s\n"
+"\n"
+"%(diff)s\n"
+"\n"
 "Dodatne informacije:\n"
 "%(instance_url)s"
 
 #: tcms/core/middleware.py:25
 #, python-format
-msgid "Base URL is not configured! See <a href=\"%(doc_url)s\">documentation</a> and <a href=\"%(admin_url)s\">change it</a>"
-msgstr "URL aplikacije ni nastavljen! <a href=\"%(doc_url)s\">Preverite dokumentacijo</a> in ga <a href=\"%(admin_url)s\">spremenite</a>"
+msgid ""
+"Base URL is not configured! See <a href=\"%(doc_url)s\">documentation</a> "
+"and <a href=\"%(admin_url)s\">change it</a>"
+msgstr ""
+"URL aplikacije ni nastavljen! <a href=\"%(doc_url)s\">Preverite "
+"dokumentacijo</a> in ga <a href=\"%(admin_url)s\">spremenite</a>"
 
 #: tcms/kiwi_auth/admin.py:28
 msgid "This email address is already in use"
@@ -88,108 +116,154 @@ msgstr "Dovoljenja"
 msgid "A user with that email already exists."
 msgstr "Uporabnik s tem e-mail naslovom že obstaja."
 
-#: tcms/kiwi_auth/forms.py:60
+#: tcms/kiwi_auth/forms.py:60 tcms/kiwi_auth/tests.py:176
 #, python-format
 msgid "Your new %s account confirmation"
 msgstr "Informacije o uporabniškem računu %s ."
 
-#: tcms/kiwi_auth/views.py:50
-msgid "Your account has been created, please check your mailbox for confirmation"
-msgstr "Uporabniški račun je bil uspešno kreiran, preverite vaš e-poštni nabiralnik za potrditveno povezavo preko katere ga aktivirate"
+#: tcms/kiwi_auth/test_admin.py:59 tcms/management/tests/tests.py:76
+msgid "Yes, I'm sure"
+msgstr ""
 
-#: tcms/kiwi_auth/views.py:56
-msgid "Your account has been created, but you need an administrator to activate it"
-msgstr "Uporabniški račun je bil ustvarjen. Pred uporabo ga mora potrditi še administrator"
+#: tcms/kiwi_auth/tests.py:97 tcms/templates/navbar.html:59
+#: tcms/templates/registration/registration_form.html:47
+msgid "Register"
+msgstr "Registracija"
+
+#: tcms/kiwi_auth/tests.py:141 tcms/signals.py:78
+msgid "New user awaiting approval"
+msgstr "Nov uporabnik - potrebna potrditev uporabniškega računa"
+
+#: tcms/kiwi_auth/tests.py:146
+#: tcms/templates/email/user_registered/notify_admins.txt:2
+#, python-format
+msgid ""
+"Dear Administrator,\n"
+"somebody just registered an account with username %(username)s at your\n"
+"Kiwi TCMS instance and is awaiting your approval!\n"
+"\n"
+"Go to %(user_url)s to activate the account!\n"
+msgstr ""
+"Spoštovani administrator,\n"
+"uporabnik %(username)s je kreiral nov uporabniški račun v sistemu Kiwi TCMS, "
+"kateri čaka na potrditev.\n"
+"\n"
+"Aktivacija računa je mogoča na sledeči povezavi %(user_url)s !\n"
+
+#: tcms/kiwi_auth/tests.py:162 tcms/kiwi_auth/views.py:50
+msgid ""
+"Your account has been created, please check your mailbox for confirmation"
+msgstr ""
+"Uporabniški račun je bil uspešno kreiran, preverite vaš e-poštni nabiralnik "
+"za potrditveno povezavo preko katere ga aktivirate"
+
+#: tcms/kiwi_auth/tests.py:177 tcms/templates/email/confirm_registration.txt:1
+#, python-format
+msgid ""
+"Welcome %(user)s,\n"
+"thank you for signing up for an %(site_domain)s account!\n"
+"\n"
+"To activate your account, click this link:\n"
+"%(confirm_url)s\n"
+msgstr ""
+"Pozdravljen-/a %(user)s,\n"
+"uspešno je bil kreiran uporabniški račun za domeno %(site_domain)s !\n"
+"\n"
+"Za aktivacijo računa kliknite na spodnjo povezavo\n"
+"%(confirm_url)s\n"
+
+#: tcms/kiwi_auth/tests.py:196 tcms/kiwi_auth/views.py:56
+msgid ""
+"Your account has been created, but you need an administrator to activate it"
+msgstr ""
+"Uporabniški račun je bil ustvarjen. Pred uporabo ga mora potrditi še "
+"administrator"
+
+#: tcms/kiwi_auth/tests.py:222 tcms/kiwi_auth/views.py:103
+msgid "This activation key no longer exists in the database"
+msgstr "Aktivacijska koda ne obstaja več v bazi"
+
+#: tcms/kiwi_auth/tests.py:240 tcms/kiwi_auth/views.py:108
+msgid "This activation key has expired"
+msgstr "Aktivacijska koda je potekla"
+
+#: tcms/kiwi_auth/tests.py:259 tcms/kiwi_auth/views.py:120
+msgid "Your account has been activated successfully"
+msgstr "Vaš račun je bil uspešno aktiviran"
 
 #: tcms/kiwi_auth/views.py:61
 msgid "Following is the administrator list"
 msgstr "Seznam administratorjev"
 
-#: tcms/kiwi_auth/views.py:103
-msgid "This activation key no longer exists in the database"
-msgstr "Aktivacijska koda ne obstaja več v bazi"
-
-#: tcms/kiwi_auth/views.py:108
-msgid "This activation key has expired"
-msgstr "Aktivacijska koda je potekla"
-
-#: tcms/kiwi_auth/views.py:120
-msgid "Your account has been activated successfully"
-msgstr "Vaš račun je bil uspešno aktiviran"
-
-#: tcms/settings/common.py:87
+#: tcms/settings/common.py:90
 msgid "DASHBOARD"
 msgstr "NADZORNA PLOŠČA"
 
-#: tcms/settings/common.py:88
+#: tcms/settings/common.py:91
 msgid "TESTING"
 msgstr "TESTIRANJE"
 
-#: tcms/settings/common.py:89
+#: tcms/settings/common.py:92
 msgid "New Test Plan"
 msgstr "Nova baza testnih scenarijev"
 
-#: tcms/settings/common.py:91
+#: tcms/settings/common.py:94
 msgid "New Test Case"
 msgstr "Nov testni scenarij"
 
-#: tcms/settings/common.py:93
+#: tcms/settings/common.py:96
 msgid "SEARCH"
 msgstr "ISKANJE"
 
-#: tcms/settings/common.py:94
+#: tcms/settings/common.py:97
 msgid "Search Test Plans"
 msgstr "Iskanje baz testnih scenarijev"
 
-#: tcms/settings/common.py:95
+#: tcms/settings/common.py:98
 msgid "Search Test Runs"
 msgstr "Iskanje testiranj"
 
-#: tcms/settings/common.py:96
+#: tcms/settings/common.py:99
 msgid "Search Test Cases"
 msgstr "Iskanje testnih scenarijev"
 
-#: tcms/settings/common.py:98
+#: tcms/settings/common.py:101 tcms/telemetry/tests/test_plugin_discovery.py:52
 msgid "TELEMETRY"
 msgstr "TELEMETRIJA"
 
-#: tcms/settings/common.py:103
+#: tcms/settings/common.py:115
 msgid "ADMIN"
 msgstr "ADMINISTRACIJA"
 
-#: tcms/settings/common.py:104
+#: tcms/settings/common.py:116
 msgid "Users and groups"
 msgstr "Uporabniki in skupine"
 
-#: tcms/settings/common.py:106
+#: tcms/settings/common.py:118
 msgid "Everything else"
 msgstr "Ostalo"
 
-#: tcms/settings/common.py:112
+#: tcms/settings/common.py:124
 msgid "Report an Issue"
 msgstr "Prijavi težavo"
 
-#: tcms/settings/common.py:113
+#: tcms/settings/common.py:125
 msgid "Ask for help on StackOverflow"
 msgstr "Postavite vprašanje glede uporabe KiwiTCMS na StackOverflow"
 
-#: tcms/settings/common.py:114
+#: tcms/settings/common.py:126
 msgid "User Guide"
 msgstr "Uporabniški vodnik"
 
-#: tcms/settings/common.py:115
+#: tcms/settings/common.py:127
 msgid "Administration Guide"
 msgstr "Administracijski vodnik"
 
-#: tcms/settings/common.py:116
+#: tcms/settings/common.py:128
 msgid "API Help"
 msgstr "Pomoč za API"
 
-#: tcms/signals.py:78
-msgid "New user awaiting approval"
-msgstr "Nov uporabnik - potrebna potrditev uporabniškega računa"
-
-#: tcms/signals.py:153
+#: tcms/signals.py:153 tcms/testruns/tests/test_models.py:42
 #, python-format
 msgid "NEW: TestRun #%(pk)d - %(summary)s"
 msgstr "NOVO: Testiranje #%(pk)d - %(summary)s"
@@ -248,7 +322,7 @@ msgstr "Kloniraj testne scenarije"
 msgid "Select Plan"
 msgstr "Izberi bazo testni scenarijev"
 
-#: tcms/templates/case/clone.html:32
+#: tcms/templates/case/clone.html:32 tcms/testcases/tests/test_views.py:346
 msgid "Use the same Plan"
 msgstr "Uporabi isto bazo testnih scenarijev"
 
@@ -507,12 +581,16 @@ msgstr "Začeto ob"
 
 #: tcms/templates/dashboard.html:26
 #, python-format
-msgid "\n"
-"                %(total_count)s TestRun(s) or TestCase(s) assigned to you need to be executed.\n"
+msgid ""
+"\n"
+"                %(total_count)s TestRun(s) or TestCase(s) assigned to you "
+"need to be executed.\n"
 "                Here are the latest %(count)s.\n"
 "                "
-msgstr "\n"
-"                %(total_count)s testiranj in/ali testov na katere ste dodeljeni scenarijev čaka na izvedbo.\n"
+msgstr ""
+"\n"
+"                %(total_count)s testiranj in/ali testov na katere ste "
+"dodeljeni scenarijev čaka na izvedbo.\n"
 "               Prikazanih je zadnjih %(count)s.\n"
 "                "
 
@@ -547,12 +625,16 @@ msgstr "Izvedbe"
 
 #: tcms/templates/dashboard.html:72
 #, python-format
-msgid "\n"
-"                You manage %(total_count)s TestPlan(s), %(disabled_count)s are disabled.\n"
+msgid ""
+"\n"
+"                You manage %(total_count)s TestPlan(s), %(disabled_count)s "
+"are disabled.\n"
 "                Here are the latest %(count)s.\n"
 "                "
-msgstr "\n"
-"                Imate %(total_count)s reopozitorijev testov, %(disabled_count)s je onemogočenih.\n"
+msgstr ""
+"\n"
+"                Imate %(total_count)s reopozitorijev testov, "
+"%(disabled_count)s je onemogočenih.\n"
 "                Tukaj so zadnji %(count)s.\n"
 "                "
 
@@ -560,64 +642,60 @@ msgstr "\n"
 msgid "There are no TestPlan(s) that belong to you"
 msgstr "Noben testni plan vam ni dodeljen"
 
-#: tcms/templates/email/confirm_registration.txt:1
-#, python-format
-msgid "Welcome %(user)s,\n"
-"thank you for signing up for an %(site_domain)s account!\n\n"
-"To activate your account, click this link:\n"
-"%(confirm_url)s\n"
-msgstr "Pozdravljen-/a %(user)s,\n"
-"uspešno je bil kreiran uporabniški račun za domeno %(site_domain)s !\n\n"
-"Za aktivacijo računa kliknite na spodnjo povezavo\n"
-"%(confirm_url)s\n"
-
 #: tcms/templates/email/post_case_delete/email.txt:2
-#, python-format
-msgid "\n"
-"TestCase has been updated by %(username)s!\n"
-msgstr "\n"
+#, fuzzy, python-format
+#| msgid ""
+#| "\n"
+#| "TestCase has been updated by %(username)s!\n"
+msgid ""
+"\n"
+"TestCase has been deleted by %(username)s!\n"
+msgstr ""
+"\n"
 "Testni scenarij je posodobil %(username)s!\n"
 
 #: tcms/templates/email/post_run_save/email.txt:2
 #, python-format
-msgid "\n"
-"Test run %(pk)s has been created or updated for you.\n\n"
+msgid ""
+"\n"
+"Test run %(pk)s has been created or updated for you.\n"
+"\n"
 "### Links ###\n"
 "Test run: %(run_url)s\n"
-"Test plan: %(plan_url)s\n\n"
+"Test plan: %(plan_url)s\n"
+"\n"
 "### Basic run information ###\n"
-"Summary: %(summary)s\n\n"
+"Summary: %(summary)s\n"
+"\n"
 "Managed: %(manager)s.\n"
-"Default tester: %(default_tester)s.\n\n"
+"Default tester: %(default_tester)s.\n"
+"\n"
 "Product: %(product)s\n"
 "Product version: %(version)s\n"
-"Build: %(build)s\n\n"
+"Build: %(build)s\n"
+"\n"
 "Notes:\n"
 "%(notes)s\n"
-msgstr "\n"
-"Testiranje %(pk)s je bilo ustvarjeno ali posobljeno.\n\n"
+msgstr ""
+"\n"
+"Testiranje %(pk)s je bilo ustvarjeno ali posobljeno.\n"
+"\n"
 "### Povezano ###\n"
 "Testiranje: %(run_url)s\n"
-"Baza testnih scenarijev: %(plan_url)s\n\n"
+"Baza testnih scenarijev: %(plan_url)s\n"
+"\n"
 "### Osnovne informacije o testiranju ###\n"
-"Povzetek: %(summary)s\n\n"
+"Povzetek: %(summary)s\n"
+"\n"
 "Vodja testiranja: %(manager)s.\n"
-"Zadolženi tester: %(default_tester)s.\n\n"
+"Zadolženi tester: %(default_tester)s.\n"
+"\n"
 "Produkt: %(product)s\n"
 "Verzija produkta: %(version)s\n"
-"Build: %(build)s\n\n"
+"Build: %(build)s\n"
+"\n"
 "Zapiski:\n"
 "%(notes)s\n"
-
-#: tcms/templates/email/user_registered/notify_admins.txt:2
-#, python-format
-msgid "Dear Administrator,\n"
-"somebody just registered an account with username %(username)s at your\n"
-"Kiwi TCMS instance and is awaiting your approval!\n\n"
-"Go to %(user_url)s to activate the account!\n"
-msgstr "Spoštovani administrator,\n"
-"uporabnik %(username)s je kreiral nov uporabniški račun v sistemu Kiwi TCMS, kateri čaka na potrditev.\n\n"
-"Aktivacija računa je mogoča na sledeči povezavi %(user_url)s !\n"
 
 #: tcms/templates/management/get_tag.html:7
 msgid "Plans"
@@ -638,10 +716,14 @@ msgstr "Testiranja"
 #: tcms/templates/plan/get_cases.html:32 tcms/templates/plan/get_cases.html:34
 #: tcms/templates/run/get_case_runs.html:24
 #: tcms/templates/run/get_case_runs.html:46
+#: tcms/testcases/tests/test_tags.py:42 tcms/testcases/tests/test_tags.py:58
+#: tcms/testplans/tests/test_views.py:43 tcms/testplans/tests/test_views.py:58
 msgid "Remove"
 msgstr "Odstrani"
 
 #: tcms/templates/management/get_tag.html:35
+#: tcms/testcases/tests/test_tags.py:39 tcms/testcases/tests/test_tags.py:56
+#: tcms/testplans/tests/test_views.py:40
 msgid "Add Tag"
 msgstr "Dodaj oznako"
 
@@ -677,11 +759,6 @@ msgstr "Odjava"
 #: tcms/templates/navbar.html:53
 msgid "Login"
 msgstr "Prijava"
-
-#: tcms/templates/navbar.html:59
-#: tcms/templates/registration/registration_form.html:47
-msgid "Register"
-msgstr "Registracija"
 
 #: tcms/templates/pagination.html:7
 msgid "First page"
@@ -719,7 +796,7 @@ msgstr "Kloniraj bazo testnih scenarijev"
 msgid "Clone TestPlan"
 msgstr "Kloniraj bazo testnih scenarijev"
 
-#: tcms/templates/plan/clone.html:29
+#: tcms/templates/plan/clone.html:29 tcms/testplans/tests/tests.py:443
 msgid "New Plan Name"
 msgstr "Naziv nove baze testnih scenarijev"
 
@@ -808,6 +885,7 @@ msgstr "Priloge"
 #: tcms/templates/run/get.html:91 tcms/templates/run/get_case_runs.html:122
 #: tcms/testcases/templates/testcases/get.html:330
 #: tcms/testcases/templates/testcases/search.html:141
+#: tcms/testcases/tests/test_views.py:411
 #: tcms/testplans/templates/testplans/search.html:115
 #: tcms/testruns/templates/testruns/search.html:98
 msgid "Tags"
@@ -918,8 +996,12 @@ msgid "Show filter options"
 msgstr "Prikaži filtre"
 
 #: tcms/templates/plan/get_cases.html:71
-msgid "Click me,then Drag and drop the rows to adjust the order,and click 'Done Sorting' link to submit your changes"
-msgstr "Kliknite na gumb, povlecite vrstice v želeni vrstni ter ter kliknite na gumb 'Razvrsti', da shranite spremembe prikaza vrstnega reda elementov"
+msgid ""
+"Click me,then Drag and drop the rows to adjust the order,and click 'Done "
+"Sorting' link to submit your changes"
+msgstr ""
+"Kliknite na gumb, povlecite vrstice v želeni vrstni ter ter kliknite na gumb "
+"'Razvrsti', da shranite spremembe prikaza vrstnega reda elementov"
 
 #: tcms/templates/plan/get_cases.html:71
 msgid "Re-order cases"
@@ -1109,7 +1191,9 @@ msgid "Confirm"
 msgstr "Potrdi"
 
 #: tcms/templates/registration/password_reset_confirm.html:43
-msgid "Please enter your new password twice so we can verify you typed it in correctly"
+msgid ""
+"Please enter your new password twice so we can verify you typed it in "
+"correctly"
 msgstr "Novo geslo vnesite dvakrat"
 
 #: tcms/templates/registration/password_reset_confirm.html:46
@@ -1176,11 +1260,16 @@ msgstr "Kako dodeliti testni scenarij?"
 
 #: tcms/templates/run/assign_case.html:59
 msgid "The table below list all the confirmed test cases of plan"
-msgstr "V spodnji tabeli se nahajajo vsi potrjeni testni scenariji iz izbrane baze testnih scenarijev"
+msgstr ""
+"V spodnji tabeli se nahajajo vsi potrjeni testni scenariji iz izbrane baze "
+"testnih scenarijev"
 
 #: tcms/templates/run/assign_case.html:59
-msgid "check the checkbox to add cases into test run. Remember to update at last"
-msgstr "označite polje da dodate scenarije v testiranje. Predlagamo, da spremenite vsaj"
+msgid ""
+"check the checkbox to add cases into test run. Remember to update at last"
+msgstr ""
+"označite polje da dodate scenarije v testiranje. Predlagamo, da spremenite "
+"vsaj"
 
 #: tcms/templates/run/assign_case.html:74
 msgid "Created Date"
@@ -1340,7 +1429,8 @@ msgstr "Prikaži vse v povezani aplikaciji"
 
 #: tcms/templates/run/report.html:134
 msgid "Only configured ITs which support multiple bugs are shown"
-msgstr "Samo pravilno nastavljene aplikacije, ki podpirajo več napak so prikazane"
+msgstr ""
+"Samo pravilno nastavljene aplikacije, ki podpirajo več napak so prikazane"
 
 #: tcms/templates/run/report.html:137
 msgid "Tracker"
@@ -1371,38 +1461,53 @@ msgid "No case run found"
 msgstr "Testiranje za ta iskalni niz ne obstaja"
 
 #: tcms/testcases/forms.py:21
-msgid "Please input valid case id(s). use comma to split more than one case id. e.g. \"111, 222\""
-msgstr "Prosimo vnesite veljavne Id-je testni scenarijev. Uporabite vejico za več primerov npr. \"111, 222\""
+msgid ""
+"Please input valid case id(s). use comma to split more than one case id. e."
+"g. \"111, 222\""
+msgstr ""
+"Prosimo vnesite veljavne Id-je testni scenarijev. Uporabite vejico za več "
+"primerov npr. \"111, 222\""
 
 #: tcms/testcases/forms.py:90
-msgid "**Scenario**: ... what behavior will be tested ...\n"
+msgid ""
+"**Scenario**: ... what behavior will be tested ...\n"
 "  **Given** ... conditions ...\n"
 "  **When** ... actions ...\n"
-"  **Then** ... expected results ...\n\n"
-"*Actions*:\n\n"
-"1. item\n"
-"2. item\n"
-"3. item\n\n"
-"*Expected results*:\n\n"
+"  **Then** ... expected results ...\n"
+"\n"
+"*Actions*:\n"
+"\n"
 "1. item\n"
 "2. item\n"
 "3. item\n"
-msgstr "**Scenarij**: ... kaj testiramo..\n"
+"\n"
+"*Expected results*:\n"
+"\n"
+"1. item\n"
+"2. item\n"
+"3. item\n"
+msgstr ""
+"**Scenarij**: ... kaj testiramo..\n"
 "  **Pogoj** ... pogoji potrebni za izvedbo testa ...\n"
 "  **Ko** ... koraki za izvedbo testa...\n"
-"  **Potem** ... pričakovani rezultati...\n\n"
-"*Ko*:\n\n"
+"  **Potem** ... pričakovani rezultati...\n"
+"\n"
+"*Ko*:\n"
+"\n"
 "1. korak\n"
 "2. korak\n"
-"3. korak\n\n"
-"*Potem*:\n\n"
+"3. korak\n"
+"\n"
+"*Potem*:\n"
+"\n"
 "1. rezultat\n"
 "2. rezultat\n"
 "3. rezultat\n"
 
 #: tcms/testcases/helpers/email.py:22
-#, python-brace-format
-msgid "DELETED: TestCase #%{pk}d - %{summary}s"
+#, fuzzy, python-format
+#| msgid "DELETED: TestCase #%{pk}d - %{summary}s"
+msgid "DELETED: TestCase #%(pk)d - %(summary)s"
 msgstr "Izbrisan: Testni scenarij #%{pk}d - %{summary}s"
 
 #: tcms/testcases/templates/testcases/get.html:98
@@ -1500,8 +1605,12 @@ msgid "CC to"
 msgstr "KP v"
 
 #: tcms/testcases/templates/testcases/mutable.html:211
-msgid "Email addresses separated by comma. A notification email will be sent to each Email address within CC list."
-msgstr "E-poštni naslovi naj bodo ločeni z vejico. E-poštno spoorčilo bo poslano na vse email naslove v polju KP."
+msgid ""
+"Email addresses separated by comma. A notification email will be sent to "
+"each Email address within CC list."
+msgstr ""
+"E-poštni naslovi naj bodo ločeni z vejico. E-poštno spoorčilo bo poslano na "
+"vse email naslove v polju KP."
 
 #: tcms/testcases/templates/testcases/mutable.html:214
 #: tcms/testplans/templates/testplans/mutable.html:145
@@ -1550,6 +1659,12 @@ msgstr "Iskanje"
 msgid "Created on"
 msgstr "Ustvarjeno dne"
 
+#: tcms/testcases/tests/test_views.py:334 tcms/testcases/views.py:761
+#: tcms/testruns/tests/test_views.py:212 tcms/testruns/views.py:422
+#: tcms/testruns/views.py:500
+msgid "At least one TestCase is required"
+msgstr "Vsaj en testni scenarij je zahtevan"
+
 #: tcms/testcases/views.py:399
 msgid "TestPlan not specified or does not exist"
 msgstr "Baza testnih scenarijev ni izbrana ali ne obstaja"
@@ -1561,11 +1676,6 @@ msgstr "Zgodovina"
 #: tcms/testcases/views.py:588
 msgid "Delete"
 msgstr "Izbriši"
-
-#: tcms/testcases/views.py:761 tcms/testruns/views.py:422
-#: tcms/testruns/views.py:500
-msgid "At least one TestCase is required"
-msgstr "Vsaj en testni scenarij je zahtevan"
 
 #: tcms/testcases/views.py:898
 msgid "TestCase cloning was successful"
@@ -1624,13 +1734,13 @@ msgstr "Naziv baze testni scenarijev"
 msgid "Test plan"
 msgstr "Baza testni scenarijev"
 
-#: tcms/testplans/views.py:344
-msgid "TestPlan is required"
-msgstr "Testni repozitorij je obvezen"
-
-#: tcms/testplans/views.py:565
+#: tcms/testplans/tests/tests.py:91 tcms/testplans/views.py:565
 msgid "At least one test plan is required for print"
 msgstr "Za tiskanje je potrebno izbrati vsaj eno bazo testnih scenarijev"
+
+#: tcms/testplans/tests/tests.py:424 tcms/testplans/views.py:344
+msgid "TestPlan is required"
+msgstr "Testni repozitorij je obvezen"
 
 #: tcms/testplans/views.py:573
 #, python-format
@@ -1677,12 +1787,16 @@ msgstr "Izbrani testni scenariji(s):"
 
 #: tcms/testruns/templates/testruns/mutable.html:82
 #, python-format
-msgid "\n"
-"                    %(count)s of the pre-selected test cases is not CONFIRMED and will not be cloned!\n"
+msgid ""
+"\n"
+"                    %(count)s of the pre-selected test cases is not "
+"CONFIRMED and will not be cloned!\n"
 "                    See test plan for more details!\n"
 "                    "
-msgstr "\n"
-"                    %(count)s testni scenarijev ni v statusu potrjen in se ne bodo prenesli.\n"
+msgstr ""
+"\n"
+"                    %(count)s testni scenarijev ni v statusu potrjen in se "
+"ne bodo prenesli.\n"
 "                    Več podrobnosti je na voljo v informacijah testiranja!\n"
 "                    "
 
@@ -1702,30 +1816,38 @@ msgstr "ID načrta"
 msgid "TestPlan ID"
 msgstr "ID repozitorija testov"
 
-#: tcms/testruns/views.py:50
-msgid "Creating a TestRun requires a TestPlan, select one"
-msgstr "V kolikor želite kreirati novo testiranje morate imeti ustvarjen testni repozitorij"
-
-#: tcms/testruns/views.py:60
+#: tcms/testruns/tests/test_views.py:108 tcms/testruns/views.py:60
 msgid "Creating a TestRun requires at least one TestCase"
-msgstr "V kolikor želite kreirati novo testiranje morate dodati najmanj en testni scenarij"
+msgstr ""
+"V kolikor želite kreirati novo testiranje morate dodati najmanj en testni "
+"scenarij"
 
-#: tcms/testruns/views.py:426
+#: tcms/testruns/tests/test_views.py:182 tcms/testruns/views.py:426
 msgid "Clone of "
 msgstr "Klon "
+
+#: tcms/testruns/tests/test_views.py:462 tcms/testruns/views.py:637
+#, python-format
+msgid "%d CaseRun(s) updated:"
+msgstr "%d testiranje posodobljeno:"
+
+#: tcms/testruns/views.py:50
+msgid "Creating a TestRun requires a TestPlan, select one"
+msgstr ""
+"V kolikor želite kreirati novo testiranje morate imeti ustvarjen testni "
+"repozitorij"
 
 #: tcms/testruns/views.py:509
 msgid "TestCase ID is not a valid integer"
 msgstr "ID testnega scenarija ni celo število"
 
-#: tcms/testruns/views.py:637
-#, python-format
-msgid "%d CaseRun(s) updated:"
-msgstr "%d testiranje posodobljeno:"
-
 #: tcms/xmlrpc/api/bug.py:85
-msgid "Enable linking test cases by configuring API parameters for this Issue Tracker!"
-msgstr "Potrebno je nastaviti podatke za povezavo preko API-ja za integracijo v sistem za beleženje napak!"
+msgid ""
+"Enable linking test cases by configuring API parameters for this Issue "
+"Tracker!"
+msgstr ""
+"Potrebno je nastaviti podatke za povezavo preko API-ja za integracijo v "
+"sistem za beleženje napak!"
 
 #: tcms/xmlrpc/api/bug.py:138
 msgid "Enable reporting to this Issue Tracker by configuring its base_url!"
@@ -1737,50 +1859,49 @@ msgid "Model %s has no primary key. You have to specify such field manually."
 msgstr "Model %s nima primarnega ključa. Polje bo potrebno ročno dodati."
 
 #: vinaigrette-deleteme.py:2
-msgid "IDLE"
-msgstr "NESTESTIRANO"
-
-#: vinaigrette-deleteme.py:3
-msgid "RUNNING"
-msgstr "V TEKU"
-
-#: vinaigrette-deleteme.py:4
-msgid "PAUSED"
-msgstr "ZAČASNO ZAUSTAVLJENO"
-
-#: vinaigrette-deleteme.py:5
-msgid "PASSED"
-msgstr "OK"
-
-#: vinaigrette-deleteme.py:6
-msgid "FAILED"
-msgstr "NEUSPEŠEN TEST"
-
-#: vinaigrette-deleteme.py:7
-msgid "BLOCKED"
-msgstr "BLOKIRAN"
-
-#: vinaigrette-deleteme.py:8
-msgid "ERROR"
-msgstr "NAPAKA"
-
-#: vinaigrette-deleteme.py:9
-msgid "WAIVED"
-msgstr "IZPUŠČEN"
-
-#: vinaigrette-deleteme.py:10
 msgid "PROPOSED"
 msgstr "PREDLOG"
 
-#: vinaigrette-deleteme.py:11
+#: vinaigrette-deleteme.py:3
 msgid "CONFIRMED"
 msgstr "POTRJEN"
 
-#: vinaigrette-deleteme.py:12
+#: vinaigrette-deleteme.py:4
 msgid "DISABLED"
 msgstr "ONEMOGOČEN"
 
-#: vinaigrette-deleteme.py:13
+#: vinaigrette-deleteme.py:5
 msgid "NEED_UPDATE"
 msgstr "ZA POPRAVITI"
 
+#: vinaigrette-deleteme.py:6
+msgid "IDLE"
+msgstr "NESTESTIRANO"
+
+#: vinaigrette-deleteme.py:7
+msgid "RUNNING"
+msgstr "V TEKU"
+
+#: vinaigrette-deleteme.py:8
+msgid "PAUSED"
+msgstr "ZAČASNO ZAUSTAVLJENO"
+
+#: vinaigrette-deleteme.py:9
+msgid "PASSED"
+msgstr "OK"
+
+#: vinaigrette-deleteme.py:10
+msgid "FAILED"
+msgstr "NEUSPEŠEN TEST"
+
+#: vinaigrette-deleteme.py:11
+msgid "BLOCKED"
+msgstr "BLOKIRAN"
+
+#: vinaigrette-deleteme.py:12
+msgid "ERROR"
+msgstr "NAPAKA"
+
+#: vinaigrette-deleteme.py:13
+msgid "WAIVED"
+msgstr "IZPUŠČEN"

--- a/tcms/locale/zh_CN/LC_MESSAGES/django.po
+++ b/tcms/locale/zh_CN/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: kiwitcms\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-23 23:31+0000\n"
+"POT-Creation-Date: 2019-03-29 09:09+0000\n"
 "PO-Revision-Date: 2019-03-07 10:04\n"
 "Last-Translator: atodorov <atodorov@otb.bg>\n"
 "Language-Team: Chinese Simplified\n"
@@ -48,6 +48,20 @@ msgstr "网址"
 #: tcms/templates/run/get_case_runs.html:50
 msgid "Comment"
 msgstr "评论"
+
+#: tcms/core/contrib/linkreference/tests.py:84
+msgid "Enter a valid URL."
+msgstr ""
+
+#: tcms/core/contrib/linkreference/tests.py:101
+#, python-format
+msgid ""
+"Ensure this value has at most %(limit_value)d character (it has "
+"%(show_value)d)."
+msgid_plural ""
+"Ensure this value has at most %(limit_value)d characters (it has "
+"%(show_value)d)."
+msgstr[0] ""
 
 #: tcms/core/history.py:41
 #, python-format
@@ -98,110 +112,150 @@ msgstr "权限"
 msgid "A user with that email already exists."
 msgstr "已存在使用相同电子邮件的地址的用户。"
 
-#: tcms/kiwi_auth/forms.py:60
+#: tcms/kiwi_auth/forms.py:60 tcms/kiwi_auth/tests.py:176
 #, python-format
 msgid "Your new %s account confirmation"
 msgstr "你的新帐户  %s  确认"
 
-#: tcms/kiwi_auth/views.py:50
+#: tcms/kiwi_auth/test_admin.py:59 tcms/management/tests/tests.py:76
+msgid "Yes, I'm sure"
+msgstr ""
+
+#: tcms/kiwi_auth/tests.py:97 tcms/templates/navbar.html:59
+#: tcms/templates/registration/registration_form.html:47
+msgid "Register"
+msgstr "注册"
+
+#: tcms/kiwi_auth/tests.py:141 tcms/signals.py:78
+msgid "New user awaiting approval"
+msgstr "等待审批通过的新用户"
+
+#: tcms/kiwi_auth/tests.py:146
+#: tcms/templates/email/user_registered/notify_admins.txt:2
+#, python-format
+msgid ""
+"Dear Administrator,\n"
+"somebody just registered an account with username %(username)s at your\n"
+"Kiwi TCMS instance and is awaiting your approval!\n"
+"\n"
+"Go to %(user_url)s to activate the account!\n"
+msgstr ""
+"亲爱的管理员,\n"
+"有人刚刚在您的 Kiwi TCMS 实例上注册了以 %(username)s 为名的用户并等待您的审批"
+"通过！\n"
+"\n"
+"请前往 %(user_url)s 激活账户！\n"
+
+#: tcms/kiwi_auth/tests.py:162 tcms/kiwi_auth/views.py:50
 msgid ""
 "Your account has been created, please check your mailbox for confirmation"
 msgstr "您的账户已创建，请检查您的收件箱进行确认"
 
-#: tcms/kiwi_auth/views.py:56
+#: tcms/kiwi_auth/tests.py:177 tcms/templates/email/confirm_registration.txt:1
+#, python-format
+msgid ""
+"Welcome %(user)s,\n"
+"thank you for signing up for an %(site_domain)s account!\n"
+"\n"
+"To activate your account, click this link:\n"
+"%(confirm_url)s\n"
+msgstr ""
+"欢迎你， %(user)s，\n"
+"感谢你注册为 %(site_domain)s 账户！\n"
+"\n"
+"点击这个链接激活你的账户：\n"
+"%(confirm_url)s\n"
+
+#: tcms/kiwi_auth/tests.py:196 tcms/kiwi_auth/views.py:56
 msgid ""
 "Your account has been created, but you need an administrator to activate it"
 msgstr "您的账户已创建，但您需要管理员来激活它"
+
+#: tcms/kiwi_auth/tests.py:222 tcms/kiwi_auth/views.py:103
+msgid "This activation key no longer exists in the database"
+msgstr "此激活密钥不再存于数据库中"
+
+#: tcms/kiwi_auth/tests.py:240 tcms/kiwi_auth/views.py:108
+msgid "This activation key has expired"
+msgstr "此激活密钥已过期"
+
+#: tcms/kiwi_auth/tests.py:259 tcms/kiwi_auth/views.py:120
+msgid "Your account has been activated successfully"
+msgstr "您的账户已被成功激活"
 
 #: tcms/kiwi_auth/views.py:61
 msgid "Following is the administrator list"
 msgstr "以下是管理员列表"
 
-#: tcms/kiwi_auth/views.py:103
-msgid "This activation key no longer exists in the database"
-msgstr "此激活密钥不再存于数据库中"
-
-#: tcms/kiwi_auth/views.py:108
-msgid "This activation key has expired"
-msgstr "此激活密钥已过期"
-
-#: tcms/kiwi_auth/views.py:120
-msgid "Your account has been activated successfully"
-msgstr "您的账户已被成功激活"
-
-#: tcms/settings/common.py:87
+#: tcms/settings/common.py:90
 msgid "DASHBOARD"
 msgstr "仪表 板"
 
-#: tcms/settings/common.py:88
+#: tcms/settings/common.py:91
 msgid "TESTING"
 msgstr "测试"
 
-#: tcms/settings/common.py:89
+#: tcms/settings/common.py:92
 msgid "New Test Plan"
 msgstr "新的测试计划"
 
-#: tcms/settings/common.py:91
+#: tcms/settings/common.py:94
 msgid "New Test Case"
 msgstr "新的测试用例"
 
-#: tcms/settings/common.py:93
+#: tcms/settings/common.py:96
 msgid "SEARCH"
 msgstr "搜索"
 
-#: tcms/settings/common.py:94
+#: tcms/settings/common.py:97
 msgid "Search Test Plans"
 msgstr "搜索测试计划"
 
-#: tcms/settings/common.py:95
+#: tcms/settings/common.py:98
 msgid "Search Test Runs"
 msgstr "搜索测试执行"
 
-#: tcms/settings/common.py:96
+#: tcms/settings/common.py:99
 msgid "Search Test Cases"
 msgstr "搜索测试用例"
 
-#: tcms/settings/common.py:98
+#: tcms/settings/common.py:101 tcms/telemetry/tests/test_plugin_discovery.py:52
 msgid "TELEMETRY"
 msgstr ""
 
-#: tcms/settings/common.py:103
+#: tcms/settings/common.py:115
 msgid "ADMIN"
 msgstr "管理员"
 
-#: tcms/settings/common.py:104
+#: tcms/settings/common.py:116
 msgid "Users and groups"
 msgstr "用户和用户组"
 
-#: tcms/settings/common.py:106
+#: tcms/settings/common.py:118
 msgid "Everything else"
 msgstr "管理其他事项"
 
-#: tcms/settings/common.py:112
+#: tcms/settings/common.py:124
 msgid "Report an Issue"
 msgstr "反馈问题"
 
-#: tcms/settings/common.py:113
+#: tcms/settings/common.py:125
 msgid "Ask for help on StackOverflow"
 msgstr "在StackOflow上寻求帮助"
 
-#: tcms/settings/common.py:114
+#: tcms/settings/common.py:126
 msgid "User Guide"
 msgstr "用户指南"
 
-#: tcms/settings/common.py:115
+#: tcms/settings/common.py:127
 msgid "Administration Guide"
 msgstr "管理员指南"
 
-#: tcms/settings/common.py:116
+#: tcms/settings/common.py:128
 msgid "API Help"
 msgstr "API 参考"
 
-#: tcms/signals.py:78
-msgid "New user awaiting approval"
-msgstr "等待审批通过的新用户"
-
-#: tcms/signals.py:153
+#: tcms/signals.py:153 tcms/testruns/tests/test_models.py:42
 #, python-format
 msgid "NEW: TestRun #%(pk)d - %(summary)s"
 msgstr "NEW: 测试执行 #%(pk)d - - %(summary)s"
@@ -260,7 +314,7 @@ msgstr "克隆测试用例"
 msgid "Select Plan"
 msgstr "选择计划"
 
-#: tcms/templates/case/clone.html:32
+#: tcms/templates/case/clone.html:32 tcms/testcases/tests/test_views.py:346
 msgid "Use the same Plan"
 msgstr "使用相同的计划"
 
@@ -576,26 +630,14 @@ msgstr ""
 msgid "There are no TestPlan(s) that belong to you"
 msgstr "没有属于你的测试计划"
 
-#: tcms/templates/email/confirm_registration.txt:1
-#, python-format
-msgid ""
-"Welcome %(user)s,\n"
-"thank you for signing up for an %(site_domain)s account!\n"
-"\n"
-"To activate your account, click this link:\n"
-"%(confirm_url)s\n"
-msgstr ""
-"欢迎你， %(user)s，\n"
-"感谢你注册为 %(site_domain)s 账户！\n"
-"\n"
-"点击这个链接激活你的账户：\n"
-"%(confirm_url)s\n"
-
 #: tcms/templates/email/post_case_delete/email.txt:2
-#, python-format
+#, fuzzy, python-format
+#| msgid ""
+#| "\n"
+#| "TestCase has been updated by %(username)s!\n"
 msgid ""
 "\n"
-"TestCase has been updated by %(username)s!\n"
+"TestCase has been deleted by %(username)s!\n"
 msgstr ""
 "\n"
 "测试用例已被 %(username)s 更新！\n"
@@ -643,21 +685,6 @@ msgstr ""
 "备注:\n"
 "%(notes)s\n"
 
-#: tcms/templates/email/user_registered/notify_admins.txt:2
-#, python-format
-msgid ""
-"Dear Administrator,\n"
-"somebody just registered an account with username %(username)s at your\n"
-"Kiwi TCMS instance and is awaiting your approval!\n"
-"\n"
-"Go to %(user_url)s to activate the account!\n"
-msgstr ""
-"亲爱的管理员,\n"
-"有人刚刚在您的 Kiwi TCMS 实例上注册了以 %(username)s 为名的用户并等待您的审批"
-"通过！\n"
-"\n"
-"请前往 %(user_url)s 激活账户！\n"
-
 #: tcms/templates/management/get_tag.html:7
 msgid "Plans"
 msgstr "计划"
@@ -677,10 +704,14 @@ msgstr "执行"
 #: tcms/templates/plan/get_cases.html:32 tcms/templates/plan/get_cases.html:34
 #: tcms/templates/run/get_case_runs.html:24
 #: tcms/templates/run/get_case_runs.html:46
+#: tcms/testcases/tests/test_tags.py:42 tcms/testcases/tests/test_tags.py:58
+#: tcms/testplans/tests/test_views.py:43 tcms/testplans/tests/test_views.py:58
 msgid "Remove"
 msgstr "删除"
 
 #: tcms/templates/management/get_tag.html:35
+#: tcms/testcases/tests/test_tags.py:39 tcms/testcases/tests/test_tags.py:56
+#: tcms/testplans/tests/test_views.py:40
 msgid "Add Tag"
 msgstr "添加标签"
 
@@ -716,11 +747,6 @@ msgstr "登出"
 #: tcms/templates/navbar.html:53
 msgid "Login"
 msgstr "登录"
-
-#: tcms/templates/navbar.html:59
-#: tcms/templates/registration/registration_form.html:47
-msgid "Register"
-msgstr "注册"
 
 #: tcms/templates/pagination.html:7
 msgid "First page"
@@ -758,7 +784,7 @@ msgstr "克隆计划"
 msgid "Clone TestPlan"
 msgstr "克隆测试计划"
 
-#: tcms/templates/plan/clone.html:29
+#: tcms/templates/plan/clone.html:29 tcms/testplans/tests/tests.py:443
 msgid "New Plan Name"
 msgstr "新计划名称"
 
@@ -847,6 +873,7 @@ msgstr "附件"
 #: tcms/templates/run/get.html:91 tcms/templates/run/get_case_runs.html:122
 #: tcms/testcases/templates/testcases/get.html:330
 #: tcms/testcases/templates/testcases/search.html:141
+#: tcms/testcases/tests/test_views.py:411
 #: tcms/testplans/templates/testplans/search.html:115
 #: tcms/testruns/templates/testruns/search.html:98
 msgid "Tags"
@@ -1457,9 +1484,9 @@ msgstr ""
 "3. 第三个\n"
 
 #: tcms/testcases/helpers/email.py:22
-#, python-brace-format
-msgid "DELETED: TestCase #%{pk}d - %{summary}s"
-msgstr "已删除: 测试用例 #%{pk}d - %{summary}s"
+#, python-format
+msgid "DELETED: TestCase #%(pk)d - %(summary)s"
+msgstr "已删除: 测试用例 #%(pk)d - %(summary)s"
 
 #: tcms/testcases/templates/testcases/get.html:98
 #: tcms/testcases/templates/testcases/mutable.html:107
@@ -1609,6 +1636,12 @@ msgstr "搜索"
 msgid "Created on"
 msgstr "创建于"
 
+#: tcms/testcases/tests/test_views.py:334 tcms/testcases/views.py:761
+#: tcms/testruns/tests/test_views.py:212 tcms/testruns/views.py:422
+#: tcms/testruns/views.py:500
+msgid "At least one TestCase is required"
+msgstr "需要至少一个测试实例"
+
 #: tcms/testcases/views.py:399
 msgid "TestPlan not specified or does not exist"
 msgstr "测试计划未指定或不存在"
@@ -1620,11 +1653,6 @@ msgstr "历史"
 #: tcms/testcases/views.py:588
 msgid "Delete"
 msgstr "删除"
-
-#: tcms/testcases/views.py:761 tcms/testruns/views.py:422
-#: tcms/testruns/views.py:500
-msgid "At least one TestCase is required"
-msgstr "需要至少一个测试实例"
 
 #: tcms/testcases/views.py:898
 msgid "TestCase cloning was successful"
@@ -1683,13 +1711,13 @@ msgstr "测试计划名"
 msgid "Test plan"
 msgstr "测试计划"
 
-#: tcms/testplans/views.py:344
-msgid "TestPlan is required"
-msgstr "需要测试计划"
-
-#: tcms/testplans/views.py:565
+#: tcms/testplans/tests/tests.py:91 tcms/testplans/views.py:565
 msgid "At least one test plan is required for print"
 msgstr "需要至少一个测试计划进行打印"
+
+#: tcms/testplans/tests/tests.py:424 tcms/testplans/views.py:344
+msgid "TestPlan is required"
+msgstr "需要测试计划"
 
 #: tcms/testplans/views.py:573
 #, python-format
@@ -1763,26 +1791,26 @@ msgstr "计划 ID"
 msgid "TestPlan ID"
 msgstr "测试计划 ID"
 
+#: tcms/testruns/tests/test_views.py:108 tcms/testruns/views.py:60
+msgid "Creating a TestRun requires at least one TestCase"
+msgstr "新建测试计划至少需要一个测试实例"
+
+#: tcms/testruns/tests/test_views.py:182 tcms/testruns/views.py:426
+msgid "Clone of "
+msgstr "克隆来自 "
+
+#: tcms/testruns/tests/test_views.py:462 tcms/testruns/views.py:637
+#, python-format
+msgid "%d CaseRun(s) updated:"
+msgstr "已更新 %d 个测试运行:"
+
 #: tcms/testruns/views.py:50
 msgid "Creating a TestRun requires a TestPlan, select one"
 msgstr "创建一个测试执行需要一个测试计划，请选择一个"
 
-#: tcms/testruns/views.py:60
-msgid "Creating a TestRun requires at least one TestCase"
-msgstr "新建测试计划至少需要一个测试实例"
-
-#: tcms/testruns/views.py:426
-msgid "Clone of "
-msgstr "克隆来自 "
-
 #: tcms/testruns/views.py:509
 msgid "TestCase ID is not a valid integer"
 msgstr "测试实例编号不是有效的整数"
-
-#: tcms/testruns/views.py:637
-#, python-format
-msgid "%d CaseRun(s) updated:"
-msgstr "已更新 %d 个测试运行:"
 
 #: tcms/xmlrpc/api/bug.py:85
 msgid ""
@@ -1800,49 +1828,49 @@ msgid "Model %s has no primary key. You have to specify such field manually."
 msgstr "%s 没有主键。你必须手动指定此类字段。"
 
 #: vinaigrette-deleteme.py:2
-msgid "IDLE"
-msgstr "空闲"
-
-#: vinaigrette-deleteme.py:3
-msgid "RUNNING"
-msgstr "运行中"
-
-#: vinaigrette-deleteme.py:4
-msgid "PAUSED"
-msgstr "已暂停"
-
-#: vinaigrette-deleteme.py:5
-msgid "PASSED"
-msgstr "已通过"
-
-#: vinaigrette-deleteme.py:6
-msgid "FAILED"
-msgstr "失败"
-
-#: vinaigrette-deleteme.py:7
-msgid "BLOCKED"
-msgstr "已屏蔽"
-
-#: vinaigrette-deleteme.py:8
-msgid "ERROR"
-msgstr "错误"
-
-#: vinaigrette-deleteme.py:9
-msgid "WAIVED"
-msgstr "已放弃"
-
-#: vinaigrette-deleteme.py:10
 msgid "PROPOSED"
 msgstr "已建议"
 
-#: vinaigrette-deleteme.py:11
+#: vinaigrette-deleteme.py:3
 msgid "CONFIRMED"
 msgstr "已确认"
 
-#: vinaigrette-deleteme.py:12
+#: vinaigrette-deleteme.py:4
 msgid "DISABLED"
 msgstr "已禁用"
 
-#: vinaigrette-deleteme.py:13
+#: vinaigrette-deleteme.py:5
 msgid "NEED_UPDATE"
 msgstr "需要更新"
+
+#: vinaigrette-deleteme.py:6
+msgid "IDLE"
+msgstr "空闲"
+
+#: vinaigrette-deleteme.py:7
+msgid "RUNNING"
+msgstr "运行中"
+
+#: vinaigrette-deleteme.py:8
+msgid "PAUSED"
+msgstr "已暂停"
+
+#: vinaigrette-deleteme.py:9
+msgid "PASSED"
+msgstr "已通过"
+
+#: vinaigrette-deleteme.py:10
+msgid "FAILED"
+msgstr "失败"
+
+#: vinaigrette-deleteme.py:11
+msgid "BLOCKED"
+msgstr "已屏蔽"
+
+#: vinaigrette-deleteme.py:12
+msgid "ERROR"
+msgstr "错误"
+
+#: vinaigrette-deleteme.py:13
+msgid "WAIVED"
+msgstr "已放弃"

--- a/tcms/locale/zh_TW/LC_MESSAGES/django.po
+++ b/tcms/locale/zh_TW/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: kiwitcms\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-23 23:31+0000\n"
+"POT-Creation-Date: 2019-03-29 09:09+0000\n"
 "PO-Revision-Date: 2019-03-13 13:42\n"
 "Last-Translator: atodorov <atodorov@otb.bg>\n"
 "Language-Team: Chinese Traditional\n"
@@ -49,6 +49,20 @@ msgstr "網址"
 msgid "Comment"
 msgstr "附註"
 
+#: tcms/core/contrib/linkreference/tests.py:84
+msgid "Enter a valid URL."
+msgstr ""
+
+#: tcms/core/contrib/linkreference/tests.py:101
+#, python-format
+msgid ""
+"Ensure this value has at most %(limit_value)d character (it has "
+"%(show_value)d)."
+msgid_plural ""
+"Ensure this value has at most %(limit_value)d characters (it has "
+"%(show_value)d)."
+msgstr[0] ""
+
 #: tcms/core/history.py:41
 #, python-format
 msgid "UPDATE: %(model_name)s #%(pk)d - %(title)s"
@@ -89,110 +103,145 @@ msgstr ""
 msgid "A user with that email already exists."
 msgstr "使用此電子郵件的用戶已經存在"
 
-#: tcms/kiwi_auth/forms.py:60
+#: tcms/kiwi_auth/forms.py:60 tcms/kiwi_auth/tests.py:176
 #, python-format
 msgid "Your new %s account confirmation"
 msgstr "您的新帳戶 %s 確認"
 
-#: tcms/kiwi_auth/views.py:50
+#: tcms/kiwi_auth/test_admin.py:59 tcms/management/tests/tests.py:76
+msgid "Yes, I'm sure"
+msgstr ""
+
+#: tcms/kiwi_auth/tests.py:97 tcms/templates/navbar.html:59
+#: tcms/templates/registration/registration_form.html:47
+msgid "Register"
+msgstr ""
+
+#: tcms/kiwi_auth/tests.py:141 tcms/signals.py:78
+msgid "New user awaiting approval"
+msgstr "等待審批的新使用者"
+
+#: tcms/kiwi_auth/tests.py:146
+#: tcms/templates/email/user_registered/notify_admins.txt:2
+#, python-format
+msgid ""
+"Dear Administrator,\n"
+"somebody just registered an account with username %(username)s at your\n"
+"Kiwi TCMS instance and is awaiting your approval!\n"
+"\n"
+"Go to %(user_url)s to activate the account!\n"
+msgstr ""
+"親愛的管理員, 有人剛剛在您的Kiwi TCMS 註冊了一個帳戶與使用者名 %(username)s, "
+"並等待您的批准! 至 %(user_url)s 以啟動帳戶!\n"
+
+#: tcms/kiwi_auth/tests.py:162 tcms/kiwi_auth/views.py:50
 msgid ""
 "Your account has been created, please check your mailbox for confirmation"
 msgstr "您的帳戶已經新增完畢，請確認您的 E-mail 是否有啟動連結的信件。"
 
-#: tcms/kiwi_auth/views.py:56
+#: tcms/kiwi_auth/tests.py:177 tcms/templates/email/confirm_registration.txt:1
+#, python-format
+msgid ""
+"Welcome %(user)s,\n"
+"thank you for signing up for an %(site_domain)s account!\n"
+"\n"
+"To activate your account, click this link:\n"
+"%(confirm_url)s\n"
+msgstr ""
+"歡迎 %(user)s, 感謝您註冊了 %(site_domain)s 帳戶! 要啟動您的帳戶, 請按一下此"
+"連結:\n"
+"%(confirm_url)s\n"
+
+#: tcms/kiwi_auth/tests.py:196 tcms/kiwi_auth/views.py:56
 msgid ""
 "Your account has been created, but you need an administrator to activate it"
 msgstr "您的帳戶已創建, 但您需要管理員來啟用它"
+
+#: tcms/kiwi_auth/tests.py:222 tcms/kiwi_auth/views.py:103
+msgid "This activation key no longer exists in the database"
+msgstr "此啟用金鑰不存在於資料庫中"
+
+#: tcms/kiwi_auth/tests.py:240 tcms/kiwi_auth/views.py:108
+msgid "This activation key has expired"
+msgstr "此啟用金鑰已過期"
+
+#: tcms/kiwi_auth/tests.py:259 tcms/kiwi_auth/views.py:120
+msgid "Your account has been activated successfully"
+msgstr "您的帳戶已成功啟用"
 
 #: tcms/kiwi_auth/views.py:61
 msgid "Following is the administrator list"
 msgstr "以下是管理員清單"
 
-#: tcms/kiwi_auth/views.py:103
-msgid "This activation key no longer exists in the database"
-msgstr "此啟用金鑰不存在於資料庫中"
-
-#: tcms/kiwi_auth/views.py:108
-msgid "This activation key has expired"
-msgstr "此啟用金鑰已過期"
-
-#: tcms/kiwi_auth/views.py:120
-msgid "Your account has been activated successfully"
-msgstr "您的帳戶已成功啟用"
-
-#: tcms/settings/common.py:87
+#: tcms/settings/common.py:90
 msgid "DASHBOARD"
 msgstr ""
 
-#: tcms/settings/common.py:88
+#: tcms/settings/common.py:91
 msgid "TESTING"
 msgstr ""
 
-#: tcms/settings/common.py:89
+#: tcms/settings/common.py:92
 msgid "New Test Plan"
 msgstr ""
 
-#: tcms/settings/common.py:91
+#: tcms/settings/common.py:94
 msgid "New Test Case"
 msgstr ""
 
-#: tcms/settings/common.py:93
+#: tcms/settings/common.py:96
 msgid "SEARCH"
 msgstr ""
 
-#: tcms/settings/common.py:94
+#: tcms/settings/common.py:97
 msgid "Search Test Plans"
 msgstr ""
 
-#: tcms/settings/common.py:95
+#: tcms/settings/common.py:98
 msgid "Search Test Runs"
 msgstr ""
 
-#: tcms/settings/common.py:96
+#: tcms/settings/common.py:99
 msgid "Search Test Cases"
 msgstr ""
 
-#: tcms/settings/common.py:98
+#: tcms/settings/common.py:101 tcms/telemetry/tests/test_plugin_discovery.py:52
 msgid "TELEMETRY"
 msgstr ""
 
-#: tcms/settings/common.py:103
+#: tcms/settings/common.py:115
 msgid "ADMIN"
 msgstr ""
 
-#: tcms/settings/common.py:104
+#: tcms/settings/common.py:116
 msgid "Users and groups"
 msgstr ""
 
-#: tcms/settings/common.py:106
+#: tcms/settings/common.py:118
 msgid "Everything else"
 msgstr ""
 
-#: tcms/settings/common.py:112
+#: tcms/settings/common.py:124
 msgid "Report an Issue"
 msgstr ""
 
-#: tcms/settings/common.py:113
+#: tcms/settings/common.py:125
 msgid "Ask for help on StackOverflow"
 msgstr ""
 
-#: tcms/settings/common.py:114
+#: tcms/settings/common.py:126
 msgid "User Guide"
 msgstr ""
 
-#: tcms/settings/common.py:115
+#: tcms/settings/common.py:127
 msgid "Administration Guide"
 msgstr ""
 
-#: tcms/settings/common.py:116
+#: tcms/settings/common.py:128
 msgid "API Help"
 msgstr ""
 
-#: tcms/signals.py:78
-msgid "New user awaiting approval"
-msgstr "等待審批的新使用者"
-
-#: tcms/signals.py:153
+#: tcms/signals.py:153 tcms/testruns/tests/test_models.py:42
 #, python-format
 msgid "NEW: TestRun #%(pk)d - %(summary)s"
 msgstr ""
@@ -251,7 +300,7 @@ msgstr ""
 msgid "Select Plan"
 msgstr ""
 
-#: tcms/templates/case/clone.html:32
+#: tcms/templates/case/clone.html:32 tcms/testcases/tests/test_views.py:346
 msgid "Use the same Plan"
 msgstr ""
 
@@ -561,24 +610,11 @@ msgstr ""
 msgid "There are no TestPlan(s) that belong to you"
 msgstr ""
 
-#: tcms/templates/email/confirm_registration.txt:1
-#, python-format
-msgid ""
-"Welcome %(user)s,\n"
-"thank you for signing up for an %(site_domain)s account!\n"
-"\n"
-"To activate your account, click this link:\n"
-"%(confirm_url)s\n"
-msgstr ""
-"歡迎 %(user)s, 感謝您註冊了 %(site_domain)s 帳戶! 要啟動您的帳戶, 請按一下此"
-"連結:\n"
-"%(confirm_url)s\n"
-
 #: tcms/templates/email/post_case_delete/email.txt:2
 #, python-format
 msgid ""
 "\n"
-"TestCase has been updated by %(username)s!\n"
+"TestCase has been deleted by %(username)s!\n"
 msgstr ""
 
 #: tcms/templates/email/post_run_save/email.txt:2
@@ -617,18 +653,6 @@ msgstr ""
 "備註:\n"
 "%(notes)s\n"
 
-#: tcms/templates/email/user_registered/notify_admins.txt:2
-#, python-format
-msgid ""
-"Dear Administrator,\n"
-"somebody just registered an account with username %(username)s at your\n"
-"Kiwi TCMS instance and is awaiting your approval!\n"
-"\n"
-"Go to %(user_url)s to activate the account!\n"
-msgstr ""
-"親愛的管理員, 有人剛剛在您的Kiwi TCMS 註冊了一個帳戶與使用者名 %(username)s, "
-"並等待您的批准! 至 %(user_url)s 以啟動帳戶!\n"
-
 #: tcms/templates/management/get_tag.html:7
 msgid "Plans"
 msgstr ""
@@ -648,10 +672,14 @@ msgstr ""
 #: tcms/templates/plan/get_cases.html:32 tcms/templates/plan/get_cases.html:34
 #: tcms/templates/run/get_case_runs.html:24
 #: tcms/templates/run/get_case_runs.html:46
+#: tcms/testcases/tests/test_tags.py:42 tcms/testcases/tests/test_tags.py:58
+#: tcms/testplans/tests/test_views.py:43 tcms/testplans/tests/test_views.py:58
 msgid "Remove"
 msgstr ""
 
 #: tcms/templates/management/get_tag.html:35
+#: tcms/testcases/tests/test_tags.py:39 tcms/testcases/tests/test_tags.py:56
+#: tcms/testplans/tests/test_views.py:40
 msgid "Add Tag"
 msgstr ""
 
@@ -686,11 +714,6 @@ msgstr ""
 
 #: tcms/templates/navbar.html:53
 msgid "Login"
-msgstr ""
-
-#: tcms/templates/navbar.html:59
-#: tcms/templates/registration/registration_form.html:47
-msgid "Register"
 msgstr ""
 
 #: tcms/templates/pagination.html:7
@@ -729,7 +752,7 @@ msgstr ""
 msgid "Clone TestPlan"
 msgstr ""
 
-#: tcms/templates/plan/clone.html:29
+#: tcms/templates/plan/clone.html:29 tcms/testplans/tests/tests.py:443
 msgid "New Plan Name"
 msgstr ""
 
@@ -818,6 +841,7 @@ msgstr ""
 #: tcms/templates/run/get.html:91 tcms/templates/run/get_case_runs.html:122
 #: tcms/testcases/templates/testcases/get.html:330
 #: tcms/testcases/templates/testcases/search.html:141
+#: tcms/testcases/tests/test_views.py:411
 #: tcms/testplans/templates/testplans/search.html:115
 #: tcms/testruns/templates/testruns/search.html:98
 msgid "Tags"
@@ -1412,8 +1436,8 @@ msgid ""
 msgstr ""
 
 #: tcms/testcases/helpers/email.py:22
-#, python-brace-format
-msgid "DELETED: TestCase #%{pk}d - %{summary}s"
+#, python-format
+msgid "DELETED: TestCase #%(pk)d - %(summary)s"
 msgstr ""
 
 #: tcms/testcases/templates/testcases/get.html:98
@@ -1563,6 +1587,12 @@ msgstr ""
 msgid "Created on"
 msgstr ""
 
+#: tcms/testcases/tests/test_views.py:334 tcms/testcases/views.py:761
+#: tcms/testruns/tests/test_views.py:212 tcms/testruns/views.py:422
+#: tcms/testruns/views.py:500
+msgid "At least one TestCase is required"
+msgstr "至少需要一個 TestCase"
+
 #: tcms/testcases/views.py:399
 msgid "TestPlan not specified or does not exist"
 msgstr "TestPlan 未指定或不存在"
@@ -1574,11 +1604,6 @@ msgstr ""
 #: tcms/testcases/views.py:588
 msgid "Delete"
 msgstr ""
-
-#: tcms/testcases/views.py:761 tcms/testruns/views.py:422
-#: tcms/testruns/views.py:500
-msgid "At least one TestCase is required"
-msgstr "至少需要一個 TestCase"
 
 #: tcms/testcases/views.py:898
 msgid "TestCase cloning was successful"
@@ -1637,13 +1662,13 @@ msgstr ""
 msgid "Test plan"
 msgstr ""
 
-#: tcms/testplans/views.py:344
-msgid "TestPlan is required"
-msgstr ""
-
-#: tcms/testplans/views.py:565
+#: tcms/testplans/tests/tests.py:91 tcms/testplans/views.py:565
 msgid "At least one test plan is required for print"
 msgstr "列印時至少需要一個Test Plan"
+
+#: tcms/testplans/tests/tests.py:424 tcms/testplans/views.py:344
+msgid "TestPlan is required"
+msgstr ""
 
 #: tcms/testplans/views.py:573
 #, python-format
@@ -1714,26 +1739,26 @@ msgstr ""
 msgid "TestPlan ID"
 msgstr ""
 
-#: tcms/testruns/views.py:50
-msgid "Creating a TestRun requires a TestPlan, select one"
-msgstr ""
-
-#: tcms/testruns/views.py:60
+#: tcms/testruns/tests/test_views.py:108 tcms/testruns/views.py:60
 msgid "Creating a TestRun requires at least one TestCase"
 msgstr "創建 TestRun 至少需要一個 TestCase"
 
-#: tcms/testruns/views.py:426
+#: tcms/testruns/tests/test_views.py:182 tcms/testruns/views.py:426
 msgid "Clone of "
+msgstr ""
+
+#: tcms/testruns/tests/test_views.py:462 tcms/testruns/views.py:637
+#, python-format
+msgid "%d CaseRun(s) updated:"
+msgstr "%d CaseRun 已更新:"
+
+#: tcms/testruns/views.py:50
+msgid "Creating a TestRun requires a TestPlan, select one"
 msgstr ""
 
 #: tcms/testruns/views.py:509
 msgid "TestCase ID is not a valid integer"
 msgstr "TestCase ID 不是有效的整數"
-
-#: tcms/testruns/views.py:637
-#, python-format
-msgid "%d CaseRun(s) updated:"
-msgstr "%d CaseRun 已更新:"
 
 #: tcms/xmlrpc/api/bug.py:85
 msgid ""
@@ -1751,49 +1776,49 @@ msgid "Model %s has no primary key. You have to specify such field manually."
 msgstr ""
 
 #: vinaigrette-deleteme.py:2
-msgid "IDLE"
-msgstr "閒置"
-
-#: vinaigrette-deleteme.py:3
-msgid "RUNNING"
-msgstr "運行"
-
-#: vinaigrette-deleteme.py:4
-msgid "PAUSED"
-msgstr "暫停"
-
-#: vinaigrette-deleteme.py:5
-msgid "PASSED"
-msgstr "通過"
-
-#: vinaigrette-deleteme.py:6
-msgid "FAILED"
-msgstr "失敗"
-
-#: vinaigrette-deleteme.py:7
-msgid "BLOCKED"
-msgstr "封鎖"
-
-#: vinaigrette-deleteme.py:8
-msgid "ERROR"
-msgstr "錯誤"
-
-#: vinaigrette-deleteme.py:9
-msgid "WAIVED"
-msgstr "放棄"
-
-#: vinaigrette-deleteme.py:10
 msgid "PROPOSED"
 msgstr "提出"
 
-#: vinaigrette-deleteme.py:11
+#: vinaigrette-deleteme.py:3
 msgid "CONFIRMED"
 msgstr "已驗證"
 
-#: vinaigrette-deleteme.py:12
+#: vinaigrette-deleteme.py:4
 msgid "DISABLED"
 msgstr "禁用"
 
-#: vinaigrette-deleteme.py:13
+#: vinaigrette-deleteme.py:5
 msgid "NEED_UPDATE"
 msgstr "需要更新"
+
+#: vinaigrette-deleteme.py:6
+msgid "IDLE"
+msgstr "閒置"
+
+#: vinaigrette-deleteme.py:7
+msgid "RUNNING"
+msgstr "運行"
+
+#: vinaigrette-deleteme.py:8
+msgid "PAUSED"
+msgstr "暫停"
+
+#: vinaigrette-deleteme.py:9
+msgid "PASSED"
+msgstr "通過"
+
+#: vinaigrette-deleteme.py:10
+msgid "FAILED"
+msgstr "失敗"
+
+#: vinaigrette-deleteme.py:11
+msgid "BLOCKED"
+msgstr "封鎖"
+
+#: vinaigrette-deleteme.py:12
+msgid "ERROR"
+msgstr "錯誤"
+
+#: vinaigrette-deleteme.py:13
+msgid "WAIVED"
+msgstr "放棄"

--- a/tcms/templates/email/post_case_delete/email.txt
+++ b/tcms/templates/email/post_case_delete/email.txt
@@ -1,4 +1,4 @@
 {% load i18n %}
 {% blocktrans with username=case.history.latest().history_user.username %}
-TestCase has been updated by {{ username }}!
+TestCase has been deleted by {{ username }}!
 {% endblocktrans %}

--- a/tcms/testcases/helpers/email.py
+++ b/tcms/testcases/helpers/email.py
@@ -19,7 +19,7 @@ def email_case_deletion(case):
     cc_list = case.emailing.get_cc_list()
     if not recipients:
         return
-    subject = _('DELETED: TestCase #%{pk}d - %{summary}s') % {'pk': case.pk,
+    subject = _('DELETED: TestCase #%(pk)d - %(summary)s') % {'pk': case.pk,
                                                               'summary': case.summary}
     context = {'case': case}
     mailto('email/post_case_delete/email.txt', subject, recipients, context, cc=cc_list)

--- a/tcms/testcases/tests/test_models.py
+++ b/tcms/testcases/tests/test_models.py
@@ -4,6 +4,7 @@
 from mock import patch
 
 from django.conf import settings
+from django.template.loader import render_to_string
 
 from tcms.core.history import history_email_for
 from tcms.testcases.models import BugSystem
@@ -156,6 +157,38 @@ class TestSendMailOnCaseIsUpdated(BasePlanCase):
 
         expected_subject, expected_body = history_email_for(self.case, self.case.summary)
         recipients = get_case_notification_recipients(self.case)
+
+        # Verify notification mail
+        send_mail.assert_called_once_with(settings.EMAIL_SUBJECT_PREFIX + expected_subject,
+                                          expected_body,
+                                          settings.DEFAULT_FROM_EMAIL,
+                                          recipients,
+                                          fail_silently=False)
+
+
+class TestSendMailOnCaseIsDeleted(BasePlanCase):
+    """Test send mail on case post_delete signal is triggered"""
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+
+        cls.case.emailing.notify_on_case_delete = True
+        cls.case.emailing.auto_to_case_author = True
+        cls.case.emailing.save()
+
+    @patch('tcms.core.utils.mailto.send_mail')
+    def test_send_mail_to_case_author(self, send_mail):
+        expected_subject = (
+            'DELETED: TestCase #%(pk)d - %(summary)s' % {
+                'pk': self.case.pk,
+                'summary': self.case.summary
+            }
+        )
+        import pdb; pdb.set_trace()
+        expected_body = render_to_string('email/post_case_delete/email.txt', {'case': self.case})
+        recipients = get_case_notification_recipients(self.case)
+
+        self.case.delete()
 
         # Verify notification mail
         send_mail.assert_called_once_with(settings.EMAIL_SUBJECT_PREFIX + expected_subject,


### PR DESCRIPTION
**NOTE: This merge request is work in progress**

`email_case_deletion()` didn't work because of wrong string formatting, I fixed this

I also added a unit tests for this, but it doesn't work because I get an error in rendering the notification email template:

```
ERROR: test_send_mail_to_case_author (tcms.testcases.tests.test_models.TestSendMailOnCaseIsDeleted)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/rik/.local/share/virtualenvs/kiwi-_tsNZa2y/lib/python3.6/site-packages/mock/mock.py", line 1305, in patched                                                                                           
    return func(*args, **keywargs)
  File "/home/rik/dev/kiwi/tcms/testcases/tests/test_models.py", line 188, in test_send_mail_to_case_author                                                                                                         
    expected_body = render_to_string('email/post_case_delete/email.txt', {'case': self.case})
  File "/home/rik/.local/share/virtualenvs/kiwi-_tsNZa2y/lib/python3.6/site-packages/django/template/loader.py", line 61, in render_to_string                                                                       
    template = get_template(template_name, using=using)
  File "/home/rik/.local/share/virtualenvs/kiwi-_tsNZa2y/lib/python3.6/site-packages/django/template/loader.py", line 15, in get_template                                                                           
    return engine.get_template(template_name)
  File "/home/rik/.local/share/virtualenvs/kiwi-_tsNZa2y/lib/python3.6/site-packages/django/template/backends/django.py", line 34, in get_template                                                                  
    return Template(self.engine.get_template(template_name), self)
  File "/home/rik/.local/share/virtualenvs/kiwi-_tsNZa2y/lib/python3.6/site-packages/django/template/engine.py", line 144, in get_template                                                                          
    template, origin = self.find_template(template_name)
  File "/home/rik/.local/share/virtualenvs/kiwi-_tsNZa2y/lib/python3.6/site-packages/django/template/engine.py", line 126, in find_template                                                                         
    template = loader.get_template(name, skip=skip)
  File "/home/rik/.local/share/virtualenvs/kiwi-_tsNZa2y/lib/python3.6/site-packages/django/template/loaders/base.py", line 30, in get_template                                                                     
    contents, origin, origin.template_name, self.engine,
  File "/home/rik/.local/share/virtualenvs/kiwi-_tsNZa2y/lib/python3.6/site-packages/django/template/base.py", line 156, in __init__                                                                                
    self.nodelist = self.compile_nodelist()
  File "/home/rik/.local/share/virtualenvs/kiwi-_tsNZa2y/lib/python3.6/site-packages/django/template/base.py", line 194, in compile_nodelist                                                                        
    return parser.parse()
  File "/home/rik/.local/share/virtualenvs/kiwi-_tsNZa2y/lib/python3.6/site-packages/django/template/base.py", line 478, in parse                                                                                   
    raise self.error(token, e)
  File "/home/rik/.local/share/virtualenvs/kiwi-_tsNZa2y/lib/python3.6/site-packages/django/template/base.py", line 476, in parse                                                                                   
    compiled_result = compile_func(self, token)
  File "/home/rik/.local/share/virtualenvs/kiwi-_tsNZa2y/lib/python3.6/site-packages/django/templatetags/i18n.py", line 465, in do_block_translate                                                                  
    value = token_kwargs(remaining_bits, parser, support_legacy=True)
  File "/home/rik/.local/share/virtualenvs/kiwi-_tsNZa2y/lib/python3.6/site-packages/django/template/base.py", line 1039, in token_kwargs                                                                           
    kwargs[key] = parser.compile_filter(value)
  File "/home/rik/.local/share/virtualenvs/kiwi-_tsNZa2y/lib/python3.6/site-packages/django/template/base.py", line 563, in compile_filter                                                                          
    return FilterExpression(token, self)
  File "/home/rik/.local/share/virtualenvs/kiwi-_tsNZa2y/lib/python3.6/site-packages/django/template/base.py", line 663, in __init__                                                                                
    "from '%s'" % (token[upto:], token))
django.template.exceptions.TemplateSyntaxError: Could not parse the remainder: '().history_user.username' from 'case.history.latest().history_user.username'
```

It seems that `case.history.latest().history_user` is `None`. I looked at the `TestSendMailOnCaseIsUpdated` test and there the email is sent differently, it's not using a template and it has a fallback to an empty string:

https://github.com/kiwitcms/Kiwi/blob/master/tcms/core/history.py#L54

So I'm not sure what's best to do here. I think a template for such a simple message as:

https://github.com/kiwitcms/Kiwi/blob/master/tcms/templates/email/post_case_delete/email.txt

Is maybe a bit overdone, and it would make it easier to do it the same way like the update case email notification is done.

What do you guys think?