### PR TITLE
Use bootstrap-switch version 3.3.4 Fixes #916

### DIFF
--- a/tcms/package.json
+++ b/tcms/package.json
@@ -2,6 +2,7 @@
   "dependencies": {
     "marked": "0.6.2",
     "patternfly": "3.59.1",
+    "bootstrap-switch": "3.3.4",
     "simplemde": "1.11.2",
     "typeahead.js": "0.11.1"
   }


### PR DESCRIPTION
There is a bug from version 3.3.5 onwards, which displays ON switches as OFF ones.
This change can be reverted once https://github.com/Bttstrp/bootstrap-switch/issues/683 is closed