### PR TITLE
Add Telemetry TestCase Breakdown view

### DIFF
--- a/docs/source/modules/tcms.telemetry.api.rst
+++ b/docs/source/modules/tcms.telemetry.api.rst
@@ -1,0 +1,7 @@
+tcms.telemetry.api module
+=========================
+
+.. automodule:: tcms.telemetry.api
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/modules/tcms.telemetry.rst
+++ b/docs/source/modules/tcms.telemetry.rst
@@ -6,3 +6,11 @@ tcms.telemetry package
     :undoc-members:
     :show-inheritance:
 
+Submodules
+----------
+
+.. toctree::
+
+   tcms.telemetry.api
+   tcms.telemetry.views
+

--- a/docs/source/modules/tcms.telemetry.views.rst
+++ b/docs/source/modules/tcms.telemetry.views.rst
@@ -1,0 +1,7 @@
+tcms.telemetry.views module
+===========================
+
+.. automodule:: tcms.telemetry.views
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/tcms/settings/common.py
+++ b/tcms/settings/common.py
@@ -103,9 +103,11 @@ MENU_ITEMS = [
         (_('Search Test Cases'), reverse_lazy('testcases-search')),
     ]),
     (_('TELEMETRY'), [
-        ('Coming soon',
+        (_('Testing'), [
+            (_('Breakdown'), reverse_lazy('testing-breakdown'))
+        ]),
+        ('More coming soon',
          'http://kiwitcms.org/blog/kiwi-tcms-team/2019/03/03/legacy-reports-become-telemetry/'),
-        ('-', '-'),
     ]),
 ]
 
@@ -294,6 +296,7 @@ INSTALLED_APPS = [
     'tcms.testcases.apps.AppConfig',
     'tcms.testplans.apps.AppConfig',
     'tcms.testruns.apps.AppConfig',
+    'tcms.telemetry',
     'tcms.xmlrpc',
 ]
 
@@ -334,6 +337,7 @@ MODERNRPC_METHODS_MODULES = [
     'tcms.xmlrpc.api.testrun',
     'tcms.xmlrpc.api.user',
     'tcms.xmlrpc.api.version',
+    'tcms.telemetry.api'
 ]
 
 # Enable the administrator delete permission

--- a/tcms/telemetry/api.py
+++ b/tcms/telemetry/api.py
@@ -1,0 +1,45 @@
+from django.db.models import Count
+from modernrpc.core import rpc_method
+
+from tcms.testcases.models import TestCase
+
+
+@rpc_method(name='Testing.breakdown')
+def breakdown(query=None):
+    """
+    .. function:: XML-RPC Testing.breakdown(query)
+
+        Perform a search and return the statistics for the selected test cases
+
+        :param query: Field lookups for :class:`tcms.testcases.models.TestCase`
+        :type query: dict
+        :return: Object, containing the statistics for the selected test cases
+        :rtype: dict
+    """
+
+    if query is None:
+        query = {}
+
+    test_cases = TestCase.objects.filter(**query).filter()
+
+    manual_count = test_cases.filter(is_automated=False).count()
+    automated_count = test_cases.filter(is_automated=True).count()
+    count = {
+        'manual': manual_count,
+        'automated': automated_count,
+        'all': manual_count + automated_count
+    }
+
+    priorities = _get_field_count_map(test_cases, 'priority', 'priority__value')
+    categories = _get_field_count_map(test_cases, 'category', 'category__name')
+
+    return {
+        'count': count,
+        'priorities': priorities,
+        'categories': categories,
+    }
+
+
+def _get_field_count_map(test_cases, expression, field):
+    query_set = test_cases.values(field).annotate(count=Count(expression))
+    return [[entry[field], entry['count']] for entry in query_set]

--- a/tcms/telemetry/static/telemetry/js/testing/breakdown.js
+++ b/tcms/telemetry/static/telemetry/js/testing/breakdown.js
@@ -1,0 +1,123 @@
+$(document).ready(() => {
+    $('.selectpicker').selectpicker();
+
+    loadInitialProduct();
+
+    document.getElementById('id_select_product').onchange = updateTestPlanSelect;
+    document.getElementById('id_select_test_plan').onchange = reloadCharts;
+});
+
+function loadInitialProduct() {
+    jsonRPC('Product.filter', {}, data => {
+        updateSelect(data, '#id_select_product', 'id', 'name');
+        reloadCharts();
+    });
+}
+
+function updateTestPlanSelect() {
+    const productId = $('#id_select_product').val();
+
+    if (!productId) {
+        updateSelect([], '#id_select_test_plan', 'plan_id', 'name');
+        reloadCharts();
+        return;
+    }
+    jsonRPC('TestPlan.filter', {'product_id': productId}, data => {
+        updateSelect(data, '#id_select_test_plan', 'plan_id', 'name');
+        reloadCharts();
+    })
+}
+
+function reloadCharts() {
+    const query = {};
+
+    const testPlanId = $('#id_select_test_plan').val();
+    const productId = $('#id_select_product').val();
+
+    if (testPlanId) {
+        query['plan'] = testPlanId;
+    } else if (productId) {
+        query['category__product_id'] = productId;
+    }
+    jsonRPC('Testing.breakdown', query, result => {
+        drawAutomatedBar(result.count);
+        drawPrioritiesChart(result.priorities);
+        drawCategoriesChart(result.categories);
+    }, true);
+}
+
+function drawAutomatedBar(count) {
+    d3.select('#total-count')
+        .style('font-weight', 'bold')
+        .style('font-size', '18px')
+        .text(count.all);
+
+    d3.selectAll('.progress-bar')
+        .attr('aria-valuemin', '0')
+        .attr('aria-valuemax', '100');
+
+    const automatedPercent = count.automated / count.all * 100;
+
+    d3.select('.automated-bar')
+        .attr('aria-valuenow', `${automatedPercent}`)
+        .attr('title', `${count.automated} Automated`)
+        .style('width', `${automatedPercent}%`);
+
+    $('.automated-bar').tooltip();
+
+    const manualPercent = count.manual / count.all * 100;
+
+    d3.select('.manual-bar')
+        .attr('aria-valuenow', `${manualPercent}`)
+        .attr('title', `${count.manual} Manual`)
+        .style('width', `${manualPercent}%`);
+
+    $('.manual-bar').tooltip();
+}
+
+function drawPrioritiesChart(priorities) {
+    drawChart(priorities, 'priority', '#priorities-chart');
+}
+
+function drawCategoriesChart(categories) {
+    drawChart(categories, 'category', '#categories-chart');
+}
+
+function drawChart(data, type, selector) {
+    const names = [];
+    const values = [[type]];
+    data.forEach(c => {
+        names.push(c[0]);
+        values[0].push(c[1]);
+    });
+
+    let chartConfig = $().c3ChartDefaults().getDefaultBarConfig(names);
+    chartConfig.bindto = selector;
+    chartConfig.axis = {
+        x: {
+            categories: names,
+            type: 'category',
+        },
+        y: {
+            tick: {
+                format: showOnlyRoundNumbers
+            }
+        }
+    };
+    chartConfig.data = {
+        type: 'bar',
+        columns: values,
+    };
+    chartConfig.grid = {
+        show: false
+    };
+
+    c3.generate(chartConfig);
+}
+
+function showOnlyRoundNumbers(number) {
+    if (number % 1 === 0) {
+        return number;
+    }
+    return '';
+}

--- a/tcms/telemetry/templates/telemetry/testing/breakdown.html
+++ b/tcms/telemetry/templates/telemetry/testing/breakdown.html
@@ -1,0 +1,77 @@
+{% extends "base.html" %}
+{% load i18n %}
+{% load static %}
+
+{% block title %}{% trans "Testing Breakdown" %}{% endblock %}
+
+{% block contents %}
+
+    <div class="container-fluid container-cards-pf">
+
+        <form class="form-horizontal">
+            <div class="form-group">
+                <label for="id_select_product" class="col-md-1 col-lg-1">
+                    {% trans "Product" %}:
+                </label>
+                <div class="col-md-3">
+                    <select name="product" id="id_select_product" class="form-control selectpicker">
+                        <option value="">----------</option>
+                    </select>
+                </div>
+
+                <label for="id_select_test_plan" class="col-md-1 col-lg-1">
+                    {% trans "Test Plan" %}:
+                </label>
+                <div class="col-md-3">
+                    <select name="test_plan" id="id_select_test_plan" class="form-control selectpicker">
+                        <option value="">----------</option>
+                    </select>
+                </div>
+            </div>
+        </form>
+
+        <div class="col-md-3" style="text-align: center">
+            <div id="total-count"></div>
+            <label> {% trans "Total" %} </label>
+
+            <div class="progress automated-manual-bar">
+                <div class="progress-bar automated-bar" role="progressbar" data-toggle="tooltip"></div>
+                <div class="progress-bar progress-bar-warning manual-bar" role="progressbar" data-toggle="tooltip"></div>
+            </div>
+
+            <div class="bar-legend">
+                <div class="bar-legend" style="display: flex; justify-content: space-around">
+                    <div style="align-items: center; display: flex;">
+                        <div class="progress-bar" style="width: 20px; height: 20px;"></div>
+                        <div style="padding-left: 5px">{% trans "Automated" %}</div>
+                    </div>
+                    <div style="align-items: center; display: flex;">
+                        <div class="progress-bar-warning" style="width: 20px; height: 20px;"></div>
+                        <div style="padding-left: 5px">{% trans "Manual" %}</div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="col-md-4" style="text-align: center">
+            <div style="text-align: center; font-weight: bold">{% trans "Priorities" %}</div>
+            <div id="priorities-chart"></div>
+        </div>
+
+        <div class="col-md-4" style="text-align: center">
+            <div style="text-align: center; font-weight: bold">{% trans "Categories" %}</div>
+            <div id="categories-chart"></div>
+        </div>
+    </div>
+
+    <script src="{% static 'bootstrap-select/dist/js/bootstrap-select.min.js' %}"></script>
+    <script src="{% static 'bootstrap-switch/dist/js/bootstrap-switch.min.js' %}"></script>
+    <script src="{% static 'c3/c3.min.js' %}"></script>
+    <script src="{% static 'd3/d3.min.js' %}"></script>
+
+    <script src="{% static 'js/utils.js' %}"></script>
+    <script src="{% static 'js/jsonrpc.js' %}"></script>
+
+    <script src="{% static 'telemetry/js/testing/breakdown.js' %}"></script>
+
+{% endblock %}

--- a/tcms/telemetry/urls.py
+++ b/tcms/telemetry/urls.py
@@ -1,0 +1,7 @@
+from django.conf.urls import url
+
+from tcms.telemetry.views import TestingBreakdownView
+
+urlpatterns = [
+    url(r'^testing/breakdown/$', TestingBreakdownView.as_view(), name='testing-breakdown')
+]

--- a/tcms/telemetry/views.py
+++ b/tcms/telemetry/views.py
@@ -1,0 +1,6 @@
+from django.views.generic import TemplateView
+
+
+class TestingBreakdownView(TemplateView):
+
+    template_name = 'telemetry/testing/breakdown.html'

--- a/tcms/urls.py
+++ b/tcms/urls.py
@@ -22,6 +22,7 @@ from tcms.testplans import urls as testplans_urls
 from tcms.testcases import urls as testcases_urls
 from tcms.kiwi_auth import urls as auth_urls
 from tcms.testruns import urls as testruns_urls
+from tcms.telemetry import urls as telemetry_urls
 
 
 urlpatterns = [
@@ -57,6 +58,8 @@ urlpatterns = [
 
     # Testruns zone
     url(r'^runs/', include(testruns_urls)),
+
+    url(r'^telemetry/', include(telemetry_urls)),
 
     url(r'^caserun/comment-many/', ajax.comment_case_runs, name='ajax-comment_case_runs'),
     url(r'^caserun/update-bugs-for-many/', ajax.update_bugs_to_caseruns),


### PR DESCRIPTION
Initial touches on Test Case Breakdown View.

This PR contains working Test Case Breakdown page showing some data. 

The purpose of this PR is to lay the foundations of the page. There are few questions:
1. Is this the preferred approach? - all the data is fetched via the API and the charts are drawn on the client-side, with the view returning an almost empty template that serves as a placeholder
2. Is the validation in the RPC method done right?
3. Are those the right tools to draw the charts? Patternfly wrapper of D3.js, and also some pure D3.js

The visualisation is a bit ugly now, and the colors are not right, but that can be changed easily if the other things are done right. 

Please review the draft PR and comment on what the MVP of the page is, so that I know what to focus on in the following few days.
