### PR TITLE
Upgrade pip and setuptools inside Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,9 @@ RUN virtualenv /venv
 ENV VIRTUAL_ENV /venv
 ENV PATH /venv/bin:$PATH
 
+# because we get some errors from other packages which need newer versions
+RUN pip install --upgrade pip setuptools
+
 # replace standard mod_wsgi with one compiled for Python 3
 RUN pip install --no-cache-dir --upgrade pip mod_wsgi && \
     ln -fs /venv/lib64/python3.6/site-packages/mod_wsgi/server/mod_wsgi-py36.cpython-36m-x86_64-linux-gnu.so \


### PR DESCRIPTION
because that may lead to errors from other packages which sometimes
are not easy to see (e.g. if pip falls back to an older version).

Right now we have:
ERROR: markdown 3.1 has requirement setuptools>=36, but you'll
       have setuptools 28.8.0 which is incompatible.

which despite being reported as error doesn't seem to break anything.