### PR TITLE
Don't use Site.objects.get_current()

### DIFF
--- a/tcms/core/models/base.py
+++ b/tcms/core/models/base.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from django.conf import settings
 from django.contrib.sites.models import Site
 
 from tcms.core.utils import request_host_link
@@ -8,6 +9,6 @@ class UrlMixin:  # pylint: disable=too-few-public-methods
     """Mixin class for getting full URL"""
 
     def get_full_url(self):
-        site = Site.objects.get_current()
+        site = Site.objects.get(pk=settings.SITE_ID)
         host_link = request_host_link(None, site.domain)
         return '{}/{}'.format(host_link, self._get_absolute_url().strip('/'))

--- a/tcms/kiwi_auth/forms.py
+++ b/tcms/kiwi_auth/forms.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from django import forms
 from django.urls import reverse
+from django.conf import settings
 from django.contrib.sites.models import Site
 from django.contrib.auth import get_user_model
 from django.contrib.auth.forms import UserCreationForm
@@ -49,7 +50,7 @@ class RegistrationForm(UserCreationForm):
         return UserActivationKey.set_random_key_for_user(user=self.instance)
 
     def send_confirm_mail(self, request, activation_key):
-        current_site = Site.objects.get_current()
+        current_site = Site.objects.get(pk=settings.SITE_ID)
         confirm_url = '%s%s' % (
             request_host_link(request, current_site.domain),
             reverse('tcms-confirm',

--- a/tcms/kiwi_auth/tests.py
+++ b/tcms/kiwi_auth/tests.py
@@ -162,7 +162,7 @@ Go to %(user_url)s to activate the account!
             _('Your account has been created, please check your mailbox for confirmation')
         )
 
-        site = Site.objects.get_current()
+        site = Site.objects.get(pk=settings.SITE_ID)
         confirm_url = 'http://%s%s' % (site.domain, reverse('tcms-confirm',
                                                             args=[self.fake_activate_key]))
 


### PR DESCRIPTION
because it uses an internal cache and causes email notifications
from tenants/public to use the wrong URL.