### PR TITLE
Add TestingStatusMatrixView

### DIFF
--- a/tcms/settings/common.py
+++ b/tcms/settings/common.py
@@ -104,7 +104,8 @@ MENU_ITEMS = [
     ]),
     (_('TELEMETRY'), [
         (_('Testing'), [
-            (_('Breakdown'), reverse_lazy('testing-breakdown'))
+            (_('Breakdown'), reverse_lazy('testing-breakdown')),
+            (_('Status matrix'), reverse_lazy('testing-status-matrix'))
         ]),
         ('More coming soon',
          'http://kiwitcms.org/blog/kiwi-tcms-team/2019/03/03/legacy-reports-become-telemetry/'),

--- a/tcms/telemetry/static/telemetry/css/testing/status-matrix.css
+++ b/tcms/telemetry/static/telemetry/css/testing/status-matrix.css
@@ -1,0 +1,21 @@
+.table-with-horizontal-scroll {
+    display: block;
+    overflow-x: auto;
+    white-space: nowrap;
+}
+
+table > tbody > tr > .pass {
+    border-left: 5px solid #92d400; /* pf-green-400 */
+}
+
+table > tbody > tr > .fail {
+    border-left: 5px solid #cc0000; /* pf-red-100 */
+}
+
+table > tbody > tr > .idle {
+    border-left: 5px solid #72767b; /* pf-black-600 */
+}
+
+table > tbody > tr > .other {
+    border-left: 5px solid #ec7a08; /* pf-orange-400 */
+}

--- a/tcms/telemetry/static/telemetry/js/testing/status-matrix.js
+++ b/tcms/telemetry/static/telemetry/js/testing/status-matrix.js
@@ -1,0 +1,127 @@
+let table;
+let initial_column = {
+    data: null,
+    className: "table-view-pf-actions",
+    render: function (data, type, full, meta) {
+        const caseId = data.tc_id;
+
+        return `<span style="padding: 5px;">` +
+            `<a href="/case/${caseId}">TC-${caseId}: ${data.tc_summary}</a>` +
+            `</span>`;
+    }
+};
+
+$(document).ready(() => {
+    loadInitialProduct();
+    loadInitialTestPlans();
+
+    document.getElementById('id_product').onchange = () => {
+        update_version_select_from_product();
+        update_build_select_from_product(true);
+        updateTestPlanSelectFromProduct(drawTable);
+    };
+
+    document.getElementById('id_version').onchange = drawTable;
+    document.getElementById('id_build').onchange = drawTable;
+    document.getElementById('id_test_plan').onchange = drawTable;
+
+    $('#id_after').on('dp.change', drawTable);
+    $('#id_before').on('dp.change', drawTable);
+
+    drawTable();
+});
+
+
+function drawTable() {
+    if (table) {
+        table.destroy();
+
+        $('table > thead > tr > th:not(.header)').remove();
+        $('table > tbody > tr').remove();
+    }
+
+    const query = {};
+
+    const productId = $('#id_product').val();
+    if (productId) {
+        query['case__plan__product'] = productId;
+    }
+
+    const versionId = $('#id_version').val();
+    if (versionId) {
+        query['case__plan__product_version'] = versionId;
+    }
+
+    const buildId = $('#id_build').val();
+    if (buildId) {
+        query['build_id'] = buildId;
+    }
+
+    const testPlanId = $('#id_test_plan').val();
+    if (testPlanId) {
+        query['case__plan__plan_id'] = testPlanId;
+    }
+
+    const dateBefore = $('#id_before');
+    if (dateBefore.val()) {
+        query['close_date__lte'] = dateBefore.data('DateTimePicker').date().format('YYYY-MM-DD 23:59:59');
+    }
+
+    const dateAfter = $('#id_after');
+    if (dateAfter.val()) {
+        query['close_date__gte'] = dateAfter.data('DateTimePicker').date().format('YYYY-MM-DD 00:00:00');
+    }
+
+    jsonRPC('Testing.status_matrix', query, data => {
+
+        const table_columns = [initial_column];
+
+        Object.keys(data.columns).forEach(testRunId => {
+            const testRunSummary = data.columns[testRunId];
+            $('.table > thead > tr').append(`<th>TR-${testRunId} ${testRunSummary}</th>`);
+
+            table_columns.push({
+                data: null,
+                sortable: false,
+                render: renderData(testRunId)
+            });
+        });
+
+        table = $('#table').DataTable({
+            columns: table_columns,
+            data: data.data,
+            paging: false,
+            ordering: false,
+            dom: "t"
+        });
+
+        const cells = $('.table > tbody > tr > td:has(.execution-status)');
+        Object.entries(cells).forEach(applyStyleToCell);
+    });
+}
+
+function applyStyleToCell(cell) {
+    const cellElement = cell[1];
+    if (cellElement) {
+        const cellChildren = cellElement.children;
+        if (cellChildren) {
+            const el = cellChildren[0];
+            if (el && el.classList) {
+                const classListValue = el.classList.value;
+                $(cell).addClass(classListValue);
+            }
+        }
+    }
+}
+
+function renderData(testRunId) {
+    return (data, type, full, meta) => {
+        const execution = full.executions.find(e => e.run_id === Number(testRunId));
+        if (execution) {
+            return `<span class="execution-status ${execution.class}">`
+                + `<a href="/runs/${execution.run_id}/#caserun_${execution.pk}">TE-${execution.pk}</a>`
+                + `</span>`;
+        }
+        return '';
+    }
+}

--- a/tcms/telemetry/static/telemetry/js/testing/utils.js
+++ b/tcms/telemetry/static/telemetry/js/testing/utils.js
@@ -1,0 +1,24 @@
+function updateTestPlanSelectFromProduct(callback = () => {}) {
+    const updateCallback = (data = []) => {
+        updateSelect(data, '#id_test_plan', 'plan_id', 'name');
+        callback();
+    };
+
+    const productId = $('#id_product').val();
+    if (!productId) {
+        updateCallback();
+    } else {
+        jsonRPC('TestPlan.filter', {product: productId}, updateCallback);
+    }
+}
+
+function loadInitialProduct(callback = () => {}) {
+    jsonRPC('Product.filter', {}, data => {
+        updateSelect(data, '#id_product', 'id', 'name');
+        callback();
+    });
+}
+
+function loadInitialTestPlans() {
+    jsonRPC('TestPlan.filter', {}, data => updateSelect(data, '#id_test_plan', 'plan_id', 'name'));
+}

--- a/tcms/telemetry/templates/telemetry/testing/status-matrix.html
+++ b/tcms/telemetry/templates/telemetry/testing/status-matrix.html
@@ -1,0 +1,98 @@
+{% extends "base.html" %}
+{% load i18n %}
+{% load static %}
+
+{% block title %}{% trans "Testing Status Matrix" %}{% endblock %}
+
+{% block contents %}
+    <div class="container-fluid container-cards-pf">
+
+        <form class="form-horizontal">
+            <div class="form-group">
+                <label for="id_product" class="col-md-1 col-lg-1">
+                    {% trans "Product" %}
+                </label>
+                <div class="col-md-3">
+                    <select name="product" id="id_product" class="form-control selectpicker">
+                        <option value="">----------</option>
+                    </select>
+                </div>
+
+                <label for="id_version" class="col-md-1 col-lg-1">
+                    {% trans "Version" %}
+                </label>
+                <div class="col-md-3">
+                    <select name="version" id="id_version" class="form-control selectpicker">
+                        <option value="">----------</option>
+                    </select>
+                </div>
+
+                <label for="id_build" class="col-md-1 col-lg-1">
+                    {% trans "Build" %}
+                </label>
+                <div class="col-md-3">
+                    <select name="build" id="id_build" class="form-control selectpicker">
+                        <option value="">----------</option>
+                    </select>
+                </div>
+            </div>
+
+            <div class="form-group">
+                <label for="id_test_plan" class="col-md-1 col-lg-1">
+                    {% trans "Test Plan" %}
+                </label>
+                <div class="col-md-3">
+                    <select name="test_plan" id="id_test_plan" class="form-control selectpicker">
+                        <option value="">----------</option>
+                    </select>
+                </div>
+
+                <label class="col-md-1 col-lg-1" for="id_after">{% trans "After" %}</label>
+                <div class="col-md-3 col-lg-3">
+                    <div class="input-group date-time-picker-pf">
+                        <input type="text" class="form-control" id="id_after">
+                        <span class="input-group-addon">
+                            <span class="fa fa-calendar"></span>
+                        </span>
+                    </div>
+
+                    {% include "datetimepicker_script.html" with selector="#id_after" %}
+                </div>
+
+                <label class="col-md-1 col-lg-1" for="id_before">{% trans "Before" %}</label>
+                <div class="col-md-3 col-lg-3">
+                    <div class="input-group date-time-picker-pf">
+                        <input type="text" class="form-control" id="id_before">
+                        <span class="input-group-addon">
+                            <span class="fa fa-calendar"></span>
+                        </span>
+                    </div>
+
+                    {% include "datetimepicker_script.html" with selector="#id_before" %}
+                </div>
+            </div>
+        </form>
+
+        <table class="table table-bordered table-with-horizontal-scroll" id="table">
+            <thead>
+            <tr>
+                <th class="header"> {% trans "Test case"%} \ {% trans "Test run" %}</th>
+            </tr>
+            </thead>
+        </table>
+
+    </div>
+
+    <link rel="stylesheet" type="text/css" href="{% static 'telemetry/css/testing/status-matrix.css' %}"/>
+
+    <script src="{% static 'moment/min/moment-with-locales.min.js' %}"></script>
+    <script src="{% static 'eonasdan-bootstrap-datetimepicker/build/js/bootstrap-datetimepicker.min.js' %}"></script>
+    <script src="{% static 'bootstrap-select/dist/js/bootstrap-select.min.js' %}"></script>
+    <script src="{% static 'bootstrap-switch/dist/js/bootstrap-switch.min.js' %}"></script>
+
+    <script src="{% static 'js/utils.js' %}"></script>
+    <script src="{% static 'js/jsonrpc.js' %}"></script>
+
+    <script src="{% static 'telemetry/js/testing/utils.js' %}"></script>
+    <script src="{% static 'telemetry/js/testing/status-matrix.js' %}"></script>
+{% endblock %}

--- a/tcms/telemetry/urls.py
+++ b/tcms/telemetry/urls.py
@@ -1,7 +1,9 @@
 from django.conf.urls import url
 
-from tcms.telemetry.views import TestingBreakdownView
+from tcms.telemetry import views
 
 urlpatterns = [
-    url(r'^testing/breakdown/$', TestingBreakdownView.as_view(), name='testing-breakdown')
+    url(r'^testing/breakdown/$', views.TestingBreakdownView.as_view(), name='testing-breakdown'),
+    url(r'^testing/status-matrix/$', views.TestingStatusMatrixView.as_view(),
+        name='testing-status-matrix')
 ]

--- a/tcms/telemetry/views.py
+++ b/tcms/telemetry/views.py
@@ -4,3 +4,8 @@ from django.views.generic import TemplateView
 class TestingBreakdownView(TemplateView):
 
     template_name = 'telemetry/testing/breakdown.html'
+
+
+class TestingStatusMatrixView(TemplateView):
+
+    template_name = 'telemetry/testing/status-matrix.html'

--- a/tcms/testruns/models.py
+++ b/tcms/testruns/models.py
@@ -251,6 +251,12 @@ class TestExecutionStatus(TCMSActionModel):
         'WAIVED': 'fa fa-commenting-o',
     }
 
+    _css_classes = {
+        IDLE: 'idle',
+        FAILED: 'fail',
+        PASSED: 'pass',
+    }
+
     complete_status_names = (PASSED, 'ERROR', FAILED, 'WAIVED')
     failure_status_names = ('ERROR', FAILED)
     idle_status_names = (IDLE,)
@@ -273,7 +279,11 @@ class TestExecutionStatus(TCMSActionModel):
 
     def icon(self):
         with override('en'):
-            return self._icons[self.name]
+            return self._icons.get(self.name)
+
+    def color_code(self):
+        with override('en'):
+            return self._css_classes.get(self.name, 'other')
 
 
 # register model for DB translations


### PR DESCRIPTION
This is the outline for Testing/StatusMatrix.

What is left:
-latest comment in case of failure.
-Links to bugs will be shown in each cell with a summarized bug table below the charts.

Few takeaways:
- we have some duplicated logic in `utils.js` - `update_build_select_from_product`, `update_category_select_from_product`, `update_component_select_from_product` and the new `updateTestCaseSelectFromProduct` have a lot of similarities and a base method can be extracted to avoid code duplication. I can do that now or open an issue for later? Also, the method names should be change to camelCase as this is preffered in js.
- the way we serialize domain objects is not optimal. we use `Model.toxmlrpc(query)` which fetches the objects from the db, based on `query` and serializes them. However, in this case I need them `TestRun`s and `TestExecution`s once as `QuerySet` - to use them as filter for another object, once serialized to return from the api Therefore I had to query the db twice - this is not optimal:
```python
test_plans_qs = TestPlan.objects.filter(**query)
test_run_qs = TestRun.objects.filter(plan__in=test_plans_qs)
test_executions_qs = TestExecution.objects.filter(run__in=test_run_qs)

return {
    'test_runs': TestRun.to_xmlrpc({'plan__in': test_plans_qs}),
    'test_cases': TestCase.to_xmlrpc({'case_run__in': test_executions_qs}, distinct=True),
    'test_executions': TestExecution.to_xmlrpc({'run__in': test_run_qs}),
}
```
Also, the whole `to_xmlrpc` method is not functional enough, and I had to add an additional optional `distinct` parameter.
Ideally, we would have something like an instance method `Object::serialize` and then the code would look something like:
```python
test_plans_qs = TestPlan.objects.filter(**query)

test_run = TestRun.objects.filter(plan__in=test_plans_qs)
test_executions = TestExecution.objects.filter(run__in=test_run)
test_cases = TestCase.filter(case_run__in=test_executions_qs).distinct()

test_runs_serialized = [test_run.serialize() for test_run in test_runs]
test_executions_serialized = [test_execution.serialize() for test_execution in test_executions]
test_cases_serialized = [test_case.serialize() for test_case in test_cases]

return {
    'test_runs': test_runs_serialized,
    'test_cases': test_cases_serialized,
    'test_executions': test_executions_serialized,
}
```

