### PR TITLE
Test Case Health Telemetry API

### DIFF
--- a/tcms/testruns/models.py
+++ b/tcms/testruns/models.py
@@ -18,7 +18,6 @@ from tcms.xmlrpc.serializer import TestExecutionXMLRPCSerializer
 from tcms.xmlrpc.serializer import TestRunXMLRPCSerializer
 from tcms.xmlrpc.utils import distinct_filter
 
-
 TestExecutionStatusSubtotal = namedtuple('TestExecutionStatusSubtotal', [
     'StatusSubtotal',
     'CaseRunsTotalCount',
@@ -239,6 +238,7 @@ class TestExecutionStatus(TCMSActionModel):
     BLOCKED = 'BLOCKED'
     PASSED = 'PASSED'
     IDLE = 'IDLE'
+    WAIVED = 'WAIVED'
 
     _icons = {
         'IDLE': 'fa fa-question-circle-o',
@@ -248,7 +248,7 @@ class TestExecutionStatus(TCMSActionModel):
         FAILED: 'fa fa-times-circle-o',
         BLOCKED: 'fa fa-stop-circle-o',
         'ERROR': 'fa fa-minus-circle',
-        'WAIVED': 'fa fa-commenting-o',
+        WAIVED: 'fa fa-commenting-o',
     }
 
     _css_classes = {
@@ -265,8 +265,9 @@ class TestExecutionStatus(TCMSActionModel):
         'FAIL': '#cc0000'
     }
 
-    complete_status_names = (PASSED, 'ERROR', FAILED, 'WAIVED')
-    failure_status_names = ('ERROR', FAILED)
+    complete_status_names = (PASSED, 'ERROR', FAILED, WAIVED)
+    failure_status_names = ('ERROR', FAILED, BLOCKED)
+    passed_status_names = (PASSED, WAIVED)
     idle_status_names = (IDLE,)
     chart_status_names = ('pass', 'fail', 'idle', 'other')
 


### PR DESCRIPTION
This aims to define the API that is going to be used for the Test Case Health Telemetry feature.

From the blog post is seems that this will be all the information we are going to need in order to draw the corresponding tables.

Sample response:
```json
[
        {
            "case_id": 1,
            "case_summary": "Test login with non-existing username",
            "count": {
                "fail": 1,
                "pass": 11
            }
        },
        {
            "case_id": 2,
            "case_summary": "Test login with existing username and wrong password",
            "count": {
                "fail": 0,
                "pass": 12
            }
        },
        {
            "case_id": 3,
            "case_summary": "Test login with existing username and right password",
            "count": {
                "fail": 1,
                "pass": 11
            }
        }
]
```