### PR TITLE
Disable pylint checks for several views, because those views are only selecting/reading data but not modifying it. Refs #171.

### DIFF
--- a/tcms/kiwi_auth/views.py
+++ b/tcms/kiwi_auth/views.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# pylint: disable=missing-permission-required
 
 from datetime import datetime
 
@@ -22,12 +23,12 @@ from tcms.kiwi_auth.models import UserActivationKey
 User = get_user_model()  # pylint: disable=invalid-name
 
 
-class LoginViewWithCustomTemplate(views.LoginView):  # pylint: disable=missing-permission-required
+class LoginViewWithCustomTemplate(views.LoginView):
     def get_template_names(self):
         return ['registration/custom_login.html', 'registration/login.html']
 
 
-class PasswordResetView(views.PasswordResetView):  # pylint: disable=missing-permission-required
+class PasswordResetView(views.PasswordResetView):
     form_class = forms.PasswordResetForm
 
 
@@ -93,7 +94,7 @@ def register(request):
 
 
 @require_GET
-def confirm(request, activation_key):  # pylint: disable=missing-permission-required
+def confirm(request, activation_key):
     """Confirm the user registration"""
 
     # Get the object
@@ -126,7 +127,7 @@ def confirm(request, activation_key):  # pylint: disable=missing-permission-requ
     return HttpResponseRedirect(request.GET.get('next', reverse('core-views-index')))
 
 
-def profile(request, username):  # pylint: disable=missing-permission-required
+def profile(request, username):
     """Show user profiles"""
     user = get_object_or_404(User, username=username)
     return HttpResponseRedirect(reverse('admin:auth_user_change', args=[user.pk]))

--- a/tcms/telemetry/views.py
+++ b/tcms/telemetry/views.py
@@ -1,12 +1,14 @@
+# pylint: disable=missing-permission-required
+
 from django.views.generic import TemplateView
 
 
-class TestingBreakdownView(TemplateView):  # pylint: disable=missing-permission-required
+class TestingBreakdownView(TemplateView):
 
     template_name = 'telemetry/testing/breakdown.html'
 
 
-class TestingStatusMatrixView(TemplateView):  # pylint: disable=missing-permission-required
+class TestingStatusMatrixView(TemplateView):
 
     template_name = 'telemetry/testing/status-matrix.html'
 

--- a/tcms/testcases/views.py
+++ b/tcms/testcases/views.py
@@ -43,7 +43,7 @@ TESTCASE_OPERATION_ACTIONS = (
 # helper functions
 
 
-def plan_from_request_or_none(request):
+def plan_from_request_or_none(request):  # pylint: disable=missing-permission-required
     """Get TestPlan from REQUEST
 
     This method relies on the existence of from_plan within REQUEST.
@@ -235,7 +235,7 @@ def build_cases_search_form(request, populate=None, plan=None):
     return search_form
 
 
-def paginate_testcases(request, testcases):
+def paginate_testcases(request, testcases):  # pylint: disable=missing-permission-required
     """Paginate queried TestCases
 
     Arguments:
@@ -256,7 +256,7 @@ def paginate_testcases(request, testcases):
     return testcases[offset:offset + page_size]
 
 
-def sort_queried_testcases(request, testcases):
+def sort_queried_testcases(request, testcases):  # pylint: disable=missing-permission-required
     """Sort querid TestCases according to sort key
 
     Arguments:
@@ -281,7 +281,7 @@ def sort_queried_testcases(request, testcases):
     return tcs
 
 
-def query_testcases_from_request(request, plan=None):
+def query_testcases_from_request(request, plan=None):  # pylint: disable=missing-permission-required
     """Query TestCases according to criterias coming within REQUEST
 
     :param request: the REQUEST object.
@@ -316,7 +316,7 @@ def query_testcases_from_request(request, plan=None):
     return tcs, search_form
 
 
-def get_selected_testcases(request):
+def get_selected_testcases(request):  # pylint: disable=missing-permission-required
     """Get selected TestCases from client side
 
     TestCases are selected in two cases. One is user selects part of displayed
@@ -382,7 +382,7 @@ def get_tags_from_cases(case_ids, plan=None):
 
 
 @require_POST
-def list_all(request):
+def list_all(request):  # pylint: disable=missing-permission-required
     """
     Generate the TestCase list for the UI tabs in TestPlan page view.
     """
@@ -532,7 +532,7 @@ class TestCaseExecutionDetailPanelView(TemplateView):  # pylint: disable=missing
         return data
 
 
-def get(request, case_id):
+def get(request, case_id):  # pylint: disable=missing-permission-required
     """Get the case content"""
     # Get the case
     try:
@@ -579,7 +579,8 @@ def get(request, case_id):
 
 
 @require_POST
-def printable(request, template_name='case/printable.html'):
+def printable(request,  # pylint: disable=missing-permission-required
+              template_name='case/printable.html'):
     """
         Create the printable copy for plan/case.
         Only CONFIRMED TestCases are printed when printing a TestPlan!

--- a/tcms/testplans/views.py
+++ b/tcms/testplans/views.py
@@ -433,7 +433,7 @@ class LinkCasesView(View):  # pylint: disable=missing-permission-required
         return HttpResponseRedirect(reverse('test_plan_url', args=[plan_id, slugify(plan.name)]))
 
 
-class LinkCasesSearchView(View):
+class LinkCasesSearchView(View):  # pylint: disable=missing-permission-required
     """Search cases for linking to plan"""
 
     template_name = 'plan/search_case.html'
@@ -507,7 +507,7 @@ class DeleteCasesView(View):
 
 
 @require_POST
-def printable(request):
+def printable(request):  # pylint: disable=missing-permission-required
     """Create the printable copy for plan"""
     plan_pk = request.POST.get('plan', 0)
 

--- a/tcms/testruns/views.py
+++ b/tcms/testruns/views.py
@@ -133,7 +133,7 @@ def search(request):  # pylint: disable=missing-permission-required
     return render(request, 'testruns/search.html', context_data)
 
 
-def _open_run_get_executions(request, run):
+def _open_run_get_executions(request, run):  # pylint: disable=missing-permission-required
     """Prepare for executions list in a TestRun page
 
     This is an internal method. Do not call this directly.
@@ -317,7 +317,8 @@ def edit(request, run_id):
     return render(request, 'testruns/mutable.html', context_data)
 
 
-class TestRunReportView(TemplateView, TestExecutionDataMixin):
+class TestRunReportView(TemplateView,  # pylint: disable=missing-permission-required
+                        TestExecutionDataMixin):
     """Test Run report"""
 
     template_name = 'run/report.html'


### PR DESCRIPTION
 Disable pylint message for unnecessary checks. Refs #171 