### PR TITLE
[refactoring] Use default_tester instead assignee_tester variable

### DIFF
--- a/tcms/testruns/views.py
+++ b/tcms/testruns/views.py
@@ -89,8 +89,6 @@ class CreateTestRunView(View):
                     default_tester=default_tester,
                 )
 
-                assignee_tester = User.objects.filter(username=default_tester).first()
-
                 loop = 1
                 for case in form.cleaned_data['case']:
                     try:
@@ -100,7 +98,7 @@ class CreateTestRunView(View):
                         sortkey = loop * 10
 
                     test_run.add_case_run(case=case, sortkey=sortkey,
-                                          assignee=assignee_tester)
+                                          assignee=default_tester)
                     loop += 1
 
                 return HttpResponseRedirect(


### PR DESCRIPTION
because the underlying form resturns None or a User object and
there is no point in querying the DB again with the same value.

CC @RMadjev