### PR TITLE
[db] Apply linkreference permissions to Tester group. Fixes #881

### DIFF
--- a/docs/source/admin.rst
+++ b/docs/source/admin.rst
@@ -68,8 +68,8 @@ created
 
 * Administrator - has all available permissions;
 * Tester - has ``add``, ``change`` and ``delete`` permissions from the
-  ``attachments``, ``django_comments``, ``management``, ``testcases``,
-  ``testruns`` and ``testplans`` applications.
+  ``attachments``, ``django_comments``, ``management``, ``linkreference``,
+  ``testcases``, ``testplans`` and ``testruns`` applications.
 
 
 Adding a group

--- a/tcms/core/migrations/0001_squashed.py
+++ b/tcms/core/migrations/0001_squashed.py
@@ -32,7 +32,8 @@ def forwards_add_default_perms(apps, schema_editor):
 
     tester = Group.objects.get(name='Tester')
     # apply all permissions for test case & product management
-    for app_name in ['django_comments', 'management', 'testcases', 'testplans', 'testruns']:
+    for app_name in ['django_comments', 'management', 'linkreference',
+                     'testcases', 'testplans', 'testruns']:
         app_perms = Permission.objects.filter(content_type__app_label__contains=app_name)
         tester.permissions.add(*app_perms)
 

--- a/tcms/utils/permissions.py
+++ b/tcms/utils/permissions.py
@@ -16,7 +16,8 @@ def assign_default_group_permissions():
     tester = Group.objects.get(name='Tester')
     if tester.permissions.count() == 0:
         # apply all permissions for test case & product management
-        for app_name in ['django_comments', 'management', 'testcases', 'testplans', 'testruns']:
+        for app_name in ['django_comments', 'linkreference', 'management',
+                         'testcases', 'testplans', 'testruns']:
             app_perms = Permission.objects.filter(content_type__app_label__contains=app_name)
             tester.permissions.add(*app_perms)
 


### PR DESCRIPTION
NOTE: administrators of existing applications will need to
apply these permissions by hand via the Admin section of the
application.