### PR TITLE
Use buildroot/runtime docker images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,4 @@
-*.in
 *.ini
 *.pyc
 docs/
 *.egg-info/
-setup.*

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,7 @@ FROM centos:centos7
 
 RUN rpm -Uhv https://dl.fedoraproject.org/pub/epel/7/x86_64/Packages/e/epel-release-7-11.noarch.rpm && \
     yum -y --setopt=tsflags=nodocs install centos-release-scl && \
-    yum -y --setopt=tsflags=nodocs install rh-python36 gcc mariadb-devel mariadb \
-    postgresql-devel httpd-devel mod_wsgi mod_ssl gettext && \
-    yum -y update --setopt=tsflags=nodocs && \
+    yum -y --setopt=tsflags=nodocs install rh-python36-python mariadb-libs postgresql httpd mod_wsgi mod_ssl && \
     yum clean all
 
 # Apache configuration for non-root users
@@ -23,36 +21,19 @@ RUN sed -i 's/Listen 80/Listen 8080/' /etc/httpd/conf/httpd.conf && \
 COPY ./etc/kiwi-httpd.conf /etc/httpd/conf.d/
 
 # make sure Python 3.6 is enabled by default
-ENV PATH /opt/rh/rh-python36/root/usr/bin${PATH:+:${PATH}}
-ENV LD_LIBRARY_PATH /opt/rh/rh-python36/root/usr/lib64${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
-ENV PKG_CONFIG_PATH /opt/rh/rh-python36/root/usr/lib64/pkgconfig${PKG_CONFIG_PATH:+:${PKG_CONFIG_PATH}}
-ENV XDG_DATA_DIRS "/opt/rh/rh-python36/root/usr/share:${XDG_DATA_DIRS:-/usr/local/share:/usr/share}"
+ENV PATH /venv/bin:/opt/rh/rh-python36/root/usr/bin${PATH:+:${PATH}} \
+    LD_LIBRARY_PATH /opt/rh/rh-python36/root/usr/lib64${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}} \
+    PKG_CONFIG_PATH /opt/rh/rh-python36/root/usr/lib64/pkgconfig${PKG_CONFIG_PATH:+:${PKG_CONFIG_PATH}} \
+    XDG_DATA_DIRS "/opt/rh/rh-python36/root/usr/share:${XDG_DATA_DIRS:-/usr/local/share:/usr/share}" \
+    VIRTUAL_ENV /venv
 
-# Create a virtualenv for the application dependencies
-RUN virtualenv /venv
-
-# Set virtualenv environment variables. This is equivalent to running
-# source /env/bin/activate. This ensures the application is executed within
-# the context of the virtualenv and will have access to its dependencies.
-ENV VIRTUAL_ENV /venv
-ENV PATH /venv/bin:$PATH
-
-# because we get some errors from other packages which need newer versions
-RUN pip install --upgrade pip setuptools
+# copy virtualenv dir which has been built inside the kiwitcms/buildroot container
+# this helps keep -devel dependencies outside of this image
+COPY ./dist/venv/ /venv
 
 # replace standard mod_wsgi with one compiled for Python 3
-RUN pip install --no-cache-dir --upgrade pip mod_wsgi && \
-    ln -fs /venv/lib64/python3.6/site-packages/mod_wsgi/server/mod_wsgi-py36.cpython-36m-x86_64-linux-gnu.so \
+RUN ln -fs /venv/lib64/python3.6/site-packages/mod_wsgi/server/mod_wsgi-py36.cpython-36m-x86_64-linux-gnu.so \
            /usr/lib64/httpd/modules/mod_wsgi.so
-
-# install the application
-COPY ./dist/kiwitcms-*.tar.gz /Kiwi/
-RUN pip install --no-cache-dir /Kiwi/kiwitcms-*.tar.gz
-
-# install DB requirements b/c the rest should already be installed
-COPY ./requirements/ /Kiwi/requirements/
-RUN pip install --no-cache-dir -r /Kiwi/requirements/mariadb.txt
-RUN pip install --no-cache-dir -r /Kiwi/requirements/postgres.txt
 
 COPY ./manage.py /Kiwi/
 COPY ./etc/kiwitcms/ssl/ /Kiwi/ssl/
@@ -60,9 +41,6 @@ RUN sed -i "s/tcms.settings.devel/tcms.settings.product/" /Kiwi/manage.py
 
 # create a mount directory so we can properly set ownership for it
 RUN mkdir /Kiwi/uploads
-
-# compile translations
-RUN /Kiwi/manage.py compilemessages
 
 # collect static files
 RUN /Kiwi/manage.py collectstatic --noinput

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN sed -i "s/tcms.settings.devel/tcms.settings.product/" /Kiwi/manage.py
 RUN mkdir /Kiwi/uploads
 
 # collect static files
-RUN /Kiwi/manage.py collectstatic --noinput
+RUN /Kiwi/manage.py collectstatic --noinput --link
 
 # from now on execute as non-root
 RUN chown -R 1001 /Kiwi/ /venv/ \

--- a/Dockerfile.buildroot
+++ b/Dockerfile.buildroot
@@ -1,0 +1,38 @@
+FROM centos:centos7
+
+RUN rpm -Uhv https://dl.fedoraproject.org/pub/epel/7/x86_64/Packages/e/epel-release-7-11.noarch.rpm && \
+    yum -y --setopt=tsflags=nodocs install centos-release-scl && \
+    yum -y --setopt=tsflags=nodocs install rh-python36 gcc mariadb-devel \
+    postgresql-devel httpd-devel gettext npm which unzip libffi-devel && \
+    yum clean all
+
+
+# make sure Python 3.6 is enabled by default
+ENV PATH /venv/bin:/opt/rh/rh-python36/root/usr/bin${PATH:+:${PATH}} \
+    LD_LIBRARY_PATH /opt/rh/rh-python36/root/usr/lib64${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}} \
+    PKG_CONFIG_PATH /opt/rh/rh-python36/root/usr/lib64/pkgconfig${PKG_CONFIG_PATH:+:${PKG_CONFIG_PATH}} \
+    XDG_DATA_DIRS "/opt/rh/rh-python36/root/usr/share:${XDG_DATA_DIRS:-/usr/local/share:/usr/share}" \
+    VIRTUAL_ENV /venv
+
+# Create a virtualenv for the application dependencies
+RUN virtualenv /venv
+
+# because we get some errors from other packages which need newer versions
+RUN pip install --upgrade pip setuptools
+
+# replace standard mod_wsgi with one compiled for Python 3
+RUN pip install --no-cache-dir --upgrade mod_wsgi
+
+# build and install the application
+COPY . /Kiwi/
+WORKDIR /Kiwi
+RUN sed -i "s/tcms.settings.devel/tcms.settings.product/" manage.py && \
+    ./tests/check-build && \
+    pip install --no-cache-dir dist/kiwitcms-*.tar.gz
+
+# install DB requirements b/c the rest should already be installed
+RUN pip install --no-cache-dir -r requirements/mariadb.txt
+RUN pip install --no-cache-dir -r requirements/postgres.txt
+
+# compile gettext translations
+RUN ./manage.py compilemessages

--- a/Makefile
+++ b/Makefile
@@ -71,8 +71,14 @@ bandit_site_packages:
 
 .PHONY: docker-image
 docker-image:
-	find -name "*.pyc" -delete
-	./tests/check-build
+	sudo rm -rf dist/
+	docker build -t kiwitcms/buildroot -f Dockerfile.buildroot .
+	docker run --rm --security-opt label=disable \
+	            -v `pwd`:/host --entrypoint /bin/cp kiwitcms/buildroot \
+	            -r /Kiwi/dist/ /host/
+	docker run --rm --security-opt label=disable \
+	            -v `pwd`:/host --entrypoint /bin/cp kiwitcms/buildroot \
+	            -r /venv /host/dist/
 	docker build -t kiwitcms/kiwi:latest .
 
 .PHONY: test-docker-image

--- a/tests/check-build
+++ b/tests/check-build
@@ -30,9 +30,13 @@ $(which python) setup.py sdist >/dev/null
 $(which python) setup.py bdist_wheel >/dev/null
 set +e
 
-# check rst formatting of README before building the package
-echo "..... Check rst formatting for PyPI"
-twine check dist/* || exit 1
+# we avoid installing twine inside buildroot b/c we're building
+# for release then. However twine is available locally and inside Travis CI
+if [ -n "$(which twine)" ]; then
+    # check rst formatting of README before building the package
+    echo "..... Check rst formatting for PyPI"
+    twine check dist/* || exit 1
+fi
 
 # then run some sanity tests
 for PKG_NAME in kiwitcms; do


### PR DESCRIPTION
- build Kiwi TCMS PyPI tarballs inside buildroot
- build Python dependencies inside buildroot
- compile translations inside buildroot
- copy /venv/ to the outside and then inside runtime image

- reduces overall image size from 1.01 GB to 699 MB

- simulates a multi-stage build but doesn't depend on it explicitly
  because there are version requirements which we don't want to force
  onto people, see:
  https://docs.docker.com/develop/develop-images/multistage-build/

- works in our own build infrastructure which is RHEL based and
  docker (especially the binaries coming from Docker, Inc.) are not
  first class citizens


cc @clee