### PR TITLE
Fetch additional bug details and display them in TestCase page

### DIFF
--- a/docs/source/modules/tcms.xmlrpc.api.rst
+++ b/docs/source/modules/tcms.xmlrpc.api.rst
@@ -36,4 +36,5 @@ Submodules
    tcms.xmlrpc.api.testplan
    tcms.xmlrpc.api.testrun
    tcms.xmlrpc.api.user
+   tcms.xmlrpc.api.utils
    tcms.xmlrpc.api.version

--- a/docs/source/modules/tcms.xmlrpc.api.utils.rst
+++ b/docs/source/modules/tcms.xmlrpc.api.utils.rst
@@ -1,0 +1,7 @@
+tcms.xmlrpc.api.utils module
+============================
+
+.. automodule:: tcms.xmlrpc.api.utils
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,3 +9,4 @@ django-simple-history==2.7.3
 jira==2.0.0
 Markdown==3.1.1
 python-redmine==2.2.1
+topicaxis-opengraph==0.5

--- a/tcms/issuetracker/types.py
+++ b/tcms/issuetracker/types.py
@@ -17,6 +17,7 @@ import gitlab
 import redminelib
 
 from django.conf import settings
+from opengraph.opengraph import OpenGraph
 
 from tcms.issuetracker import bugzilla_integration
 from tcms.issuetracker import jira_integration
@@ -62,6 +63,21 @@ class IssueTrackerType:
             characters at the end of a string!
         """
         return int(RE_ENDS_IN_INT.search(url.strip()).group(0))
+
+    def details(self, url):
+        """
+            Returns bug details to be used later. By default this method
+            returns OpenGraph metadata (dict) which is shown in the UI as tooltips.
+            You can override this method to provide different information.
+        """
+        result = OpenGraph(url, scrape=True)
+
+        # remove data which we don't need
+        for key in ['_url', 'url', 'scrape', 'type']:
+            if key in result:
+                del result[key]
+
+        return result
 
     def _report_comment(self, execution):  # pylint: disable=no-self-use
         """

--- a/tcms/settings/common.py
+++ b/tcms/settings/common.py
@@ -137,6 +137,18 @@ HELP_MENU_ITEMS = [
 ]
 
 
+# Configure a caching backend. ATM only used to cache bug details b/c
+# external issue trackers may be slow. If you want to override see:
+# https://docs.djangoproject.com/en/2.2/topics/cache/
+# https://docs.djangoproject.com/en/2.2/ref/settings/#std:setting-CACHES
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+        'LOCATION': 'kiwitcms',
+        'TIMEOUT': 3600,
+    }
+}
+
 # Absolute path to the directory static files should be collected to.
 # Don't put anything in this directory yourself; store your static files
 # in apps' "static/" subdirectories and in STATICFILES_DIRS.

--- a/tcms/settings/devel.py
+++ b/tcms/settings/devel.py
@@ -21,6 +21,12 @@ DATABASES = {
     }
 }
 
+
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.dummy.DummyCache',
+    }
+}
 # django-debug-toolbar settings
 
 MIDDLEWARE += ['debug_toolbar.middleware.DebugToolbarMiddleware']  # noqa: F405

--- a/tcms/templates/case/get_details_case_run.html
+++ b/tcms/templates/case/get_details_case_run.html
@@ -114,10 +114,12 @@
 										{% for link in execution.links %}
 										<li>
 											<a {% if link.is_defect %}class="have_bug"{% endif %} href="{{ link.url }}" target="_blank" title="{{ link.url }}">{{ link.name|escape|default:link.url }}</a>
-											<span class="grey">{{ link.created_on|date:"N d, Y" }}</span>
-											<a href="javascript:void(0);" class="js-remove-testlog" data-param="{{ link.pk }}">
-												<img title="Remove this log" src="{% static 'images/remove_small.png' %}" />
-											</a>
+											<span class="grey" style="float: right">
+                                                                                            {{ link.created_on|date:"N d, Y" }} |
+											    <a href="javascript:void(0);" class="js-remove-testlog" data-param="{{ link.pk }}">
+												    <img title="Remove this log" src="{% static 'images/remove_small.png' %}" />
+											    </a>
+                                                                                        </span>
 										</li>
 										{% endfor %}
 									</ul>

--- a/tcms/testcases/static/testcases/js/get.js
+++ b/tcms/testcases/static/testcases/js/get.js
@@ -1,3 +1,6 @@
+const bug_details_cache = {}
+
+
 function addTag(module, object_id, tag_input, to_table) {
     var tag_name = tag_input.value;
 
@@ -215,7 +218,7 @@ $(document).ready(function() {
     });
 
     // bugs table
-    var bugs_table = $('#bugs').DataTable({
+    $('#bugs').DataTable({
         ajax: function(data, callback, settings) {
             dataTableJsonRPC('TestExecution.get_links',
                              {execution__case: case_id,
@@ -225,7 +228,16 @@ $(document).ready(function() {
             {
                 data: null,
                 render: function (data, type, full, meta) {
-                    return '<a href="' + data.url + '">' + data.url + '</a>';
+                    return '<a href="' + data.url + '" class="bug-url">' + data.url + '</a>';
+                }
+            },
+            {
+                data: null,
+                render: function (data, type, full, meta) {
+                    return '<a href="#bugs" data-toggle="popover" data-html="true" ' +
+                                'data-content="undefined" data-trigger="focus" data-placement="top">' +
+                                '<span class="fa fa-info-circle"></span>' +
+                           '</a>';
                 }
             },
         ],
@@ -238,6 +250,15 @@ $(document).ready(function() {
         order: [[ 0, 'asc' ]],
     });
 
+    $('#bugs').on('draw.dt', function () {
+        $('#bugs').find('[data-toggle=popover]')
+        .popovers()
+        .on('show.bs.popover', function(element) {
+            fetchBugDetails($(element.target).parents('tr').find('.bug-url')[0],
+                            element.target,
+                            bug_details_cache);
+        });
+    });
 
     // executions treeview
     // collapse all child rows
@@ -255,4 +276,31 @@ $(document).ready(function() {
       }
     });
 
+    $('[data-toggle=popover]')
+        .popovers()
+        .on('show.bs.popover', function(element) {
+            fetchBugDetails($(element.target).parents('.list-view-pf-body').find('.bug-url')[0],
+                            element.target,
+                            bug_details_cache);
+    });
 });
+
+
+function assignPopoverData(source, popover, data) {
+    source.title = data.title;
+    $(popover).attr('data-original-title', data.title);
+    $(popover).attr('data-content', data.description);
+}
+
+
+function fetchBugDetails(source, popover, cache) {
+    if (source.href in cache) {
+        assignPopoverData(source, popover, cache[source.href]);
+        return;
+    }
+
+    jsonRPC('Bug.details', [source.href], function(data) {
+        cache[source.href] = data;
+        assignPopoverData(source, popover, data);
+    }, true);
+}

--- a/tcms/testcases/templates/testcases/get.html
+++ b/tcms/testcases/templates/testcases/get.html
@@ -217,10 +217,20 @@
                                                     <div class="list-view-pf-body">
                                                         <div class="list-view-pf-description">
                                                             <div class="list-group-item-text">
-                                                                <a href="{{ bug.url }}">{{ bug.url }}</a>
+                                                                <a href="{{ bug.url }}" class="bug-url">{{ bug.url }}</a>
                                                             </div>
                                                         </div>
+
                                                         <div class="list-view-pf-additional-info">
+                                                            <div class="list-view-pf-additional-info-item">
+                                                                <a href="#"
+                                                                    data-toggle="popover" data-html="true"
+                                                                    data-content="undefined"
+                                                                    data-trigger="focus"
+                                                                    data-placement="top">
+                                                                    <span class="fa fa-info-circle"></span>
+                                                                </a>
+                                                            </div>
                                                         </div>
                                                     </div>
                                                 </div>
@@ -285,7 +295,7 @@
                     <table class="table" id="bugs">
                         <thead>
                             <tr>
-                                <th>{% trans 'Bug URL' %}</th>
+                                <th colspan="2">{% trans 'Bug URL' %}</th>
                             </tr>
                         </thead>
                     </table>

--- a/tcms/xmlrpc/api/bug.py
+++ b/tcms/xmlrpc/api/bug.py
@@ -6,11 +6,31 @@ from django.utils.translation import ugettext_lazy as _
 from tcms.testcases.models import BugSystem
 from tcms.testruns.models import TestExecution
 from tcms.issuetracker.types import IssueTrackerType
+from tcms.xmlrpc.api.utils import tracker_from_url
 
 
 __all__ = (
+    'details',
     'report',
 )
+
+
+@rpc_method(name='Bug.details')
+def details(url):
+    """
+    .. function:: XML-RPC Bug.details(url)
+
+        Returns details about bug at the given URL address. This method is
+        used when generating additional information which is shown in the UI.
+
+        :param url: URL address
+        :type url: str
+        :return: Detailed information about this URL. Depends on the underlying
+                 issue tracker.
+        :rtype: dict
+    """
+    tracker = tracker_from_url(url)
+    return tracker.details(url)
 
 
 @rpc_method(name='Bug.report')

--- a/tcms/xmlrpc/api/bug.py
+++ b/tcms/xmlrpc/api/bug.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from modernrpc.core import rpc_method
 
+from django.core.cache import cache
 from django.utils.translation import ugettext_lazy as _
 
 from tcms.testcases.models import BugSystem
@@ -29,8 +30,12 @@ def details(url):
                  issue tracker.
         :rtype: dict
     """
-    tracker = tracker_from_url(url)
-    return tracker.details(url)
+    result = cache.get(url)
+    if not result:
+        tracker = tracker_from_url(url)
+        result = tracker.details(url)
+
+    return result
 
 
 @rpc_method(name='Bug.report')

--- a/tcms/xmlrpc/api/testexecution.py
+++ b/tcms/xmlrpc/api/testexecution.py
@@ -8,11 +8,10 @@ from tcms.core.utils import form_errors_to_list
 from tcms.core.contrib.comments.forms import SimpleForm
 from tcms.core.contrib.comments import utils as comment_utils
 from tcms.core.contrib.linkreference.models import LinkReference
-from tcms.issuetracker.types import IssueTrackerType
-from tcms.testcases.models import BugSystem
 from tcms.testruns.models import TestExecution
 from tcms.xmlrpc.serializer import XMLRPCSerializer
 from tcms.xmlrpc.decorators import permissions_required
+from tcms.xmlrpc.api.utils import tracker_from_url
 
 __all__ = (
     'create',
@@ -25,19 +24,6 @@ __all__ = (
     'get_links',
     'remove_link',
 )
-
-
-def tracker_from_url(url):
-    """
-        Return the IssueTrackerType object for the system
-        where ``base_url`` is part of ``url``. Usually we pass
-        URLs to pre-existing defects to this method.
-    """
-    for bug_system in BugSystem.objects.all():
-        if url.startswith(bug_system.base_url):
-            return IssueTrackerType.from_name(bug_system.tracker_type)(bug_system)
-
-    return None
 
 
 @rpc_method(name='TestExecution.add_comment')

--- a/tcms/xmlrpc/api/utils.py
+++ b/tcms/xmlrpc/api/utils.py
@@ -1,0 +1,19 @@
+# Copyright (c) 2019 Alexander Todorov <atodorov@MrSenko.com>
+
+# Licensed under the GPL 2.0: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+
+from tcms.issuetracker.types import IssueTrackerType
+from tcms.testcases.models import BugSystem
+
+
+def tracker_from_url(url):
+    """
+        Return the IssueTrackerType object for the system
+        where ``base_url`` is part of ``url``. Usually we pass
+        URLs to pre-existing defects to this method.
+    """
+    for bug_system in BugSystem.objects.all():
+        if url.startswith(bug_system.base_url):
+            return IssueTrackerType.from_name(bug_system.tracker_type)(bug_system)
+
+    return None


### PR DESCRIPTION
there are still things which need to be done, especially around documenting how to override the existing behavior and caching backends. 

Also the feature is partially implemented b/c TR page needs refactoring to Patternfly before we can continue further. Will land together with the test of the bugtracker changes next month.