### PR TITLE
Don't auto-download FontAwesome for SimpleMDE. Fixes #905

### DIFF
--- a/tcms/core/widgets.py
+++ b/tcms/core/widgets.py
@@ -15,7 +15,10 @@ class SimpleMDE(forms.Textarea):
         rendered_string = super().render(name, value, attrs, renderer)
         rendered_string += """
 <script>
-var simplemde = new SimpleMDE({ element: document.getElementById("%s") });
+var simplemde = new SimpleMDE({
+    element: document.getElementById("%s"),
+    autoDownloadFontAwesome: false
+});
 </script>
 """ % attrs['id']
 


### PR DESCRIPTION
FontAwesome is loaded automatically by Patternfly and this
auto-download causes some sort of override/conflict/version mismatch
and some of the icons disappear.