### PR TITLE
[bug-fix] Remove and compile .po files in check-build

### DIFF
--- a/Dockerfile.buildroot
+++ b/Dockerfile.buildroot
@@ -18,7 +18,7 @@ ENV PATH /venv/bin:/opt/rh/rh-python36/root/usr/bin${PATH:+:${PATH}} \
 RUN virtualenv /venv
 
 # because we get some errors from other packages which need newer versions
-RUN pip install --upgrade pip setuptools
+RUN pip install --no-cache-dir --upgrade pip setuptools twine
 
 # replace standard mod_wsgi with one compiled for Python 3
 RUN pip install --no-cache-dir --upgrade mod_wsgi
@@ -26,13 +26,11 @@ RUN pip install --no-cache-dir --upgrade mod_wsgi
 # build and install the application
 COPY . /Kiwi/
 WORKDIR /Kiwi
-RUN sed -i "s/tcms.settings.devel/tcms.settings.product/" manage.py && \
-    ./tests/check-build && \
-    pip install --no-cache-dir dist/kiwitcms-*.tar.gz
 
-# install DB requirements b/c the rest should already be installed
+# install app dependencies so we can build the app later
 RUN pip install --no-cache-dir -r requirements/mariadb.txt
 RUN pip install --no-cache-dir -r requirements/postgres.txt
 
-# compile gettext translations
-RUN ./manage.py compilemessages
+RUN sed -i "s/tcms.settings.devel/tcms.settings.product/" manage.py
+RUN ./tests/check-build
+RUN pip install --no-cache-dir dist/kiwitcms-*.tar.gz

--- a/tests/check-build
+++ b/tests/check-build
@@ -8,10 +8,19 @@
 # first clean up the local environment
 echo "..... Clean up first"
 find . -type f -name '*.pyc' -delete
-find . -type d -name __pycache__ -delete
+find . -type d -name __pycache__ | xargs rm -rf
 find . -type d -name '*.egg-info' | xargs rm -rf
 rm -rf build/ .cache/ dist/ .eggs/ .tox/ .venv/
 rm -rf tcms/node_modules/
+
+# ensure fresh translations are compiled in
+find tcms/locale/ -name "*.mo" -delete
+./manage.py compilemessages
+
+if [ -z $(find -type f -name "*.mo") ]; then
+    echo "ERROR: .mo files not found"
+    exit 1
+fi
 
 echo "..... Installing npm dependencies"
 pushd tcms/


### PR DESCRIPTION
this will ensure that we always ship the latest possible
translations in binary form, ready for use by gettext.

Note: in version 7.0 we may have shipped stale .mo files b/c
some strings for Bulgarian have definitely been translated but
they didn't appear even after rebuilding the image.