### PR TITLE
Override PermissionTestCase.__call__(), not run()

### DIFF
--- a/tcms/tests/__init__.py
+++ b/tcms/tests/__init__.py
@@ -250,11 +250,11 @@ class PermissionsTestCase(LoggedInTestCase):
             return
         super().tearDownClass()
 
-    def run(self, result=None):
+    def __call__(self, result=None):
         if self.__class__.__name__ == "PermissionsTestCase":
             return None
 
-        return super().run()
+        return super().__call__(result)
     # end skip running
 
     @classmethod


### PR DESCRIPTION
to skip this class appropriately. Otherwise we get
Run 0 tests and not see the errors when they exist

this makes the errors in #1190 visible.