### PR TITLE
Fix telemetry queries 

### DIFF
--- a/tcms/telemetry/static/telemetry/js/testing/execution-trends.js
+++ b/tcms/telemetry/static/telemetry/js/testing/execution-trends.js
@@ -25,12 +25,12 @@ function drawChart() {
 
     const productId = $('#id_product').val();
     if (productId) {
-        query['case__plan__product'] = productId;
+        query['run__plan__product'] = productId;
     }
 
     const versionId = $('#id_version').val();
     if (versionId) {
-        query['case__plan__product_version'] = versionId;
+        query['run__plan__product_version'] = versionId;
     }
 
     const buildId = $('#id_build').val();
@@ -40,7 +40,7 @@ function drawChart() {
 
     const testPlanId = $('#id_test_plan').val();
     if (testPlanId) {
-        query['case__plan__plan_id'] = testPlanId;
+        query['run__plan__plan_id'] = testPlanId;
     }
 
     const dateBefore = $('#id_before');

--- a/tcms/telemetry/static/telemetry/js/testing/status-matrix.js
+++ b/tcms/telemetry/static/telemetry/js/testing/status-matrix.js
@@ -46,12 +46,12 @@ function drawTable() {
 
     const productId = $('#id_product').val();
     if (productId) {
-        query['case__plan__product'] = productId;
+        query['run__plan__product'] = productId;
     }
 
     const versionId = $('#id_version').val();
     if (versionId) {
-        query['case__plan__product_version'] = versionId;
+        query['run__plan__product_version'] = versionId;
     }
 
     const buildId = $('#id_build').val();
@@ -61,7 +61,7 @@ function drawTable() {
 
     const testPlanId = $('#id_test_plan').val();
     if (testPlanId) {
-        query['case__plan__plan_id'] = testPlanId;
+        query['run__plan__plan_id'] = testPlanId;
     }
 
     const dateBefore = $('#id_before');


### PR DESCRIPTION
Change the query from case to run means one less join on the back-end
and also shows all data in the corner case, where the cases are deleted.