### PR TITLE
Check for permissions in HTML template. Closes #961

### DIFF
--- a/tcms/templates/case/get_details.html
+++ b/tcms/templates/case/get_details.html
@@ -84,7 +84,7 @@
 				{% endfor %}
 			</td>
 		</tr>
-                {% if review_mode %}
+                {% if review_mode and perms.django_comments.add_comment %}
 		<tr>
 			<td colspan="3" style='border:none;background:transparent'>
 				<form class="update_form" method="POST">


### PR DESCRIPTION
RPC methods which add comments only need 1 permission so should
HTML templates. Adding comments (reviewing a TC) is independent
action and in theory you could have a very limited User/Group
which is allowed to do only this.