### PR TITLE
Leverage new Test case status icons

### DIFF
--- a/tcms/static/js/testrun_actions.js
+++ b/tcms/static/js/testrun_actions.js
@@ -273,16 +273,17 @@ var updateCaseRunStatus = function(e) {
   // Callback when
   var callback = function(t) {
     // Update the contents
-    if (parameters['value'] != '') {
+    const value = parameters['value']
+    if (value != '') {
       // Update the case run status icon
       var crs = Nitrate.TestRuns.CaseRunStatus;
-      title.find('.icon_status').each(function(index) {
+      title.find('.execution_status_icon').each(function(index) {
         for (i in crs) {
-          if (typeof crs[i] === 'string' && jQ(this).is('.btn_' + crs[i])) {
-            jQ(this).removeClass('btn_' + crs[i]);
-          }
+          jQ(this).removeClass(crs[i].icon);
         }
-        jQ(this).addClass('btn_' + Nitrate.TestRuns.CaseRunStatus[value - 1]);
+        const execution = Nitrate.TestRuns.CaseRunStatus.find(tcs => tcs.pk === value);
+        jQ(this).addClass(execution.icon);
+        jQ(this).css('color', execution.color)
       });
 
       // Update related people

--- a/tcms/static/style/base.css
+++ b/tcms/static/style/base.css
@@ -669,17 +669,8 @@ ul.data_content_title li{ display:inline-block; margin-left:3px;}
 
 .addBlue9{background:url("../images/operation_ico.png") no-repeat 3px 6px;}
 .removeBlue9{background:url("../images/operation_ico.png") no-repeat 3px -24px;}
-.reorderBlue9{background:url("../images/operation_ico.png") no-repeat 3px -54px;}
 .updateBlue9{background:url("../images/operation_ico.png") no-repeat 3px -144px;}
 .assigneeBlue9{background:url("../images/operation_ico.png") no-repeat 3px -114px;}
-.idleBlue9{background:url("../images/operation_ico.png") no-repeat 3px -174px;}
-.passedBlue9{background:url("../images/operation_ico.png") no-repeat 3px -264px;}
-.failedBlue9{background:url("../images/operation_ico.png") no-repeat 3px -294px;}
-.runningBlue9{background:url("../images/operation_ico.png") no-repeat 3px -204px;}
-.pausedBlue9{background:url("../images/operation_ico.png") no-repeat 3px -354px;}
-.blockedBlue9{background:url("../images/operation_ico.png") no-repeat 3px -234px;}
-.errorBlue9{background:url("../images/operation_ico.png") no-repeat 3px -324px;}
-.waivedBlue9{background:url("../images/operation_ico.png") no-repeat 3px -384px;}
 /* ico end */
 
  /********************************list: cases list /runs list ***********************/

--- a/tcms/templates/run/get.html
+++ b/tcms/templates/run/get.html
@@ -17,7 +17,11 @@
 {#　Define the status array for all of case run status　#}
 Nitrate.TestRuns.CaseRunStatus = new Array();
 {% for crs in test_status %}
-Nitrate.TestRuns.CaseRunStatus.push('{{ crs.name|lower }}');
+Nitrate.TestRuns.CaseRunStatus.push({
+  "pk": "{{crs.pk}}",
+  "icon": "{{crs.icon}}",
+  "color": "{{crs.color}}"
+});
 {% endfor %}
 Nitrate.Utils.after_page_load(Nitrate.TestRuns.Details.on_load);
 </script>

--- a/tcms/templates/run/get_case_runs.html
+++ b/tcms/templates/run/get_case_runs.html
@@ -34,8 +34,8 @@
                     <span>{% trans "Status" %}</span>
 			{% if perms.testruns.change_testexecution %}
 				<ul class="statusOptions">
-					{% for tcrs in test_status %}
-					<li><a value="{{ tcrs.pk }}" href="#" class="{{ tcrs|lower }}Blue9">{{ tcrs }}</a></li>
+					{% for execution_status in test_status %}
+					<li><a value="{{ execution_status.pk }}" href="#"><i class="{{execution_status.icon}}" style="color: {{execution_status.color}}"></i> {{ execution_status.name }}</a></li>
 					{% endfor %}
 				</ul>
 			{% endif %}

--- a/tcms/templates/run/table_executions.html
+++ b/tcms/templates/run/table_executions.html
@@ -26,7 +26,7 @@
 		</tr>
 	</thead>
 	<tbody>
-		{% for execution, tester, assignee, priority_value, status_name, comments_count, bugs_count in executions %}
+		{% for execution, tester, assignee, priority_value, comments_count, bugs_count in executions %}
 		<tr class="{% cycle 'odd' 'even' %} {% ifequal execution.assignee_id user.pk %} mine {% endifequal %}">
 			<td>
 				<input type="checkbox" name="case_run" value="{{ execution.pk }}" class="caserun_selector" data-case_id="{{ execution.case.pk }}" title="Select/Unselect" />
@@ -63,7 +63,7 @@
 			<td class="expandable">{{ priority_value }}</td>
 			<td class="expandable"><span id="{{ execution.pk }}_case_bug_count" {% if bugs_count %}class="have_bug"{% endif %}>{{ bugs_count }}</span></td>
 			<td class="expandable center">
-				<img border="0" alt="" class="icon_status btn_{{ status_name|lower }}" />
+				<i class="execution_status_icon {{ execution.status.icon }} fa-2x" aria-hidden="true" style="color: {{ execution.status.color }}"></i>
 			</td>
 			<td><div id="{{ execution.case_id }}_case_comment_count">{% if comments_count %}<img src="{% static 'images/comment.png' %}" style="vertical-align: middle;">{%endif %} <span id="{{ execution.case_id }}_comments_count">{{ comments_count }}</span></div></td>
 		</tr>

--- a/tcms/testruns/tests/test_views.py
+++ b/tcms/testruns/tests/test_views.py
@@ -626,10 +626,10 @@ class TestRunStatusMenu(BaseCaseRun):
         cls.url = reverse('testruns-get', args=[cls.test_run.pk])
         cls.status_menu_html = []
 
-        for tcrs in TestExecutionStatus.objects.all():
+        for execution_status in TestExecutionStatus.objects.all():
             cls.status_menu_html.append(
-                '<a value="{0}" href="#" class="{1}Blue9">{2}</a>'
-                .format(tcrs.pk, tcrs.name.lower(), tcrs.name)
+                '<i class="{0}" style="color: {1}"></i>{2}'
+                .format(execution_status.icon, execution_status.color, execution_status.name)
             )
 
     def test_get_status_options_with_permission(self):

--- a/tcms/testruns/views.py
+++ b/tcms/testruns/views.py
@@ -205,7 +205,7 @@ class GetTestRunView(TemplateView):  # pylint: disable=missing-permission-requir
         # 2. get test run's all executions
         test_executions = _open_run_get_executions(self.request, test_run)
 
-        status = TestExecutionStatus.objects.only('pk', 'name').order_by('pk')
+        status = TestExecutionStatus.objects.order_by('-weight', 'name')
 
         # Count the status
         # 3. calculate number of executions of each status
@@ -252,14 +252,12 @@ def _walk_executions(test_executions):
     for execution in test_executions:
         execution_pks.append(execution.pk)
     comments_subtotal = open_run_get_comments_subtotal(execution_pks)
-    status = TestExecutionStatus.get_names()
 
     for execution in test_executions:
         yield (execution,
                testers.get(execution.tested_by_id, None),
                assignees.get(execution.assignee_id, None),
                priorities.get(execution.case.priority_id),
-               status[execution.status_id],
                comments_subtotal.get(execution.pk, 0),
                LinkReference.objects.filter(is_defect=True,
                                             execution=execution.pk).count())


### PR DESCRIPTION
> In TR page; TE row and TE details -> status & comment widget: still using older icons. This is controlled via .btn_<status_name> styles in base.css. 

I still don't feel like deleting this CSS. Will do it as the last of this task.

> In TR page; bulk edit menu; Status menu -> no icons along status names! In base.css this was controlled via styles named .<status_name>Blue9 which are no longer used. 

It is using the `icon` and `color` property now. And it is sorted by `weight`