### PR TITLE
JavaScript: Remove duplicate serialzeCaseForm()

### DIFF
--- a/tcms/static/js/testcase_actions.js
+++ b/tcms/static/js/testcase_actions.js
@@ -234,26 +234,3 @@ function serialzeCaseForm(form, table, serialized, exclude_cases) {
   }
   return data;
 }
-
-/*
- * New implementation of serialzeCaseForm to allow to choose whether the
- * TestCases' Ids are necessary to be serialized.
- *
- * Be default if no value is passed to exclude_cases, not exclude them.
- */
-function serializeCaseForm2(form, table, serialized, exclude_cases) {
-  if (typeof serialized != 'boolean') {
-    var serialized = true;
-  }
-  var data;
-  if (serialized) {
-    data = Nitrate.Utils.formSerialize(form);
-  } else {
-    data = jQ(form).serialize();
-  }
-  var _exclude = exclude_cases === undefined ? false : exclude_cases;
-  if (!_exclude) {
-    data['case'] = serializeCaseFromInputList(table);
-  }
-  return data;
-}

--- a/tcms/static/js/testplan_actions.js
+++ b/tcms/static/js/testplan_actions.js
@@ -938,7 +938,7 @@ function constructPlanDetailsCasesZoneCallback(options) {
     jQ(form).bind('submit', function(e) {
       e.stopPropagation();
       e.preventDefault();
-      var params = serializeCaseForm2(form, table, true, true);
+      var params = serialzeCaseForm(form, table, true, true);
       constructPlanDetailsCasesZone(container, plan_id, params);
     });
 
@@ -1212,7 +1212,7 @@ function requestOperationUponFilteredCases(options) {
     return false;
   }
   // Exclude selected cases, that will be added from the selection.
-  var params = serializeCaseForm2(form, casesContainer, true, true);
+  var params = serialzeCaseForm(form, casesContainer, true, true);
   if (selection.selectAll) {
     params.selectAll = selection.selectAll;
   }


### PR DESCRIPTION
- definition of serializeCaseForm2() in testcases_actions.js is
  functionally identical

should have gone into 7b575403e5c91a8e979beb64b8d1fb1744ec39b0
but I merged #1244 without realizing I didn't commit all files.
Rookie mistake :-(