### PR TITLE
Fix broken drop-down when status names are too long

### DIFF
--- a/tcms/templates/run/get_case_runs.html
+++ b/tcms/templates/run/get_case_runs.html
@@ -33,9 +33,9 @@
 		<div class="btnBlueCaserun">
                     <span>{% trans "Status" %}</span>
 			{% if perms.testruns.change_testexecution %}
-				<ul class="statusOptions">
+				<ul class="statusOptions" style="width: auto; white-space: nowrap">
 					{% for execution_status in test_status %}
-					<li><a value="{{ execution_status.pk }}" href="#"><i class="{{execution_status.icon}}" style="color: {{execution_status.color}}"></i> {{ execution_status.name }}</a></li>
+					<li><a style="padding-left: 0" value="{{ execution_status.pk }}" href="#"><i class="{{execution_status.icon}}" style="color: {{execution_status.color}}"></i> {{ execution_status.name }}</a></li>
 					{% endfor %}
 				</ul>
 			{% endif %}


### PR DESCRIPTION
Also, remove pading on elements, which made the dropdowns inconsistent with the other ones.

There was a 15 px padding on all the elements in the list.

I could have removed remove it if I remove the class `btnBlueCaserun` of the dropdown, but that breaks the whole layout AND functionality, because there are jQuery selectors that depend on this class.

So I decided to just inline the css that will ovveride this padding. Not the cleanest solution in terms of code, but the least painful one + having in mind that this page will be refactored to Patternfly soon, it's not worth it spending more time and effort on it.