### PR TITLE
Add missing __init__.py & adjust an import outside toplevel

### DIFF
--- a/tcms/settings/test/__init__.py
+++ b/tcms/settings/test/__init__.py
@@ -3,14 +3,18 @@
 import os
 import warnings
 import pkg_resources
-from tcms.settings.devel import *  # noqa: F401,F403
-# prented there are telemetry plugins installed so we can check
+
+# pretend there are telemetry plugins installed so we can check
 # the plugin loading code in settings/common.py
 dist = pkg_resources.Distribution(__file__)
 entry_point = pkg_resources.EntryPoint.parse('a_fake_plugin = tcms.telemetry.tests.plugin',
                                              dist=dist)
 dist._ep_map = {'kiwitcms.telemetry.plugins': {'a_fake_plugin': entry_point}}
 pkg_resources.working_set.add(dist)
+
+# this needs to be here so that  discovery tests can work
+from tcms.settings.devel import *  # noqa: F401,F403 pylint: disable=import-outside-toplevel
+
 
 # silence resource warnings while testing, see
 # https://emptysqua.re/blog/against-resourcewarnings-in-python-3/


### PR DESCRIPTION
will cause test_discovery.py to be automatically executed and
makes pylint happier