### PR TITLE
db: skip bugs which are attached directly to TCs

### DIFF
--- a/tcms/testcases/migrations/0010_remove_bug.py
+++ b/tcms/testcases/migrations/0010_remove_bug.py
@@ -6,6 +6,9 @@ def forward_copy_data(apps, schema_editor):
     LinkReference = apps.get_model('linkreference', 'LinkReference')
 
     for bug in Bug.objects.all():
+        if not bug.case_run_id:
+            continue
+
         LinkReference.objects.create(
             execution_id=bug.case_run_id,
             name="%s %s" % (bug.bug_system.name, bug.bug_id),


### PR DESCRIPTION
https://stackoverflow.com/questions/59321756/migration-from-v6-4-to-v7-2-fails-with-column-execution-id-cannot-be-null