### PR TITLE
[api] Use ModelForm for TestCase.update(). Fixes #630

### DIFF
--- a/tcms/rpc/api/forms/testcase.py
+++ b/tcms/rpc/api/forms/testcase.py
@@ -1,26 +1,24 @@
 from django import forms
+from django.forms.utils import ErrorList
 
-from tcms.management.models import Priority, Product
-from tcms.testcases.forms import BaseCaseForm
-from tcms.testcases.models import Category
+from tcms.testcases.models import TestCase
 
 
-class UpdateForm(BaseCaseForm):
-    summary = forms.CharField(
-        required=False,
-    )
-    priority = forms.ModelChoiceField(
-        queryset=Priority.objects.all(),
-        empty_label=None,
-        required=False,
-    )
-    product = forms.ModelChoiceField(
-        queryset=Product.objects.all(),
-        empty_label=None,
-        required=False,
-    )
-    category = forms.ModelChoiceField(
-        queryset=Category.objects.none(),
-        empty_label=None,
-        required=False,
-    )
+class UpdateForm(forms.ModelForm):
+    class Meta:
+        model = TestCase
+        exclude = ('tag', 'component', 'plan')
+
+    def __init__(self, data=None, files=None, auto_id='id_%s', prefix=None,
+                 initial=None, error_class=ErrorList, label_suffix=None,
+                 empty_permitted=False, instance=None, use_required_attribute=None,
+                 renderer=None):
+        super().__init__(
+            data, files, auto_id, prefix,
+            initial, error_class, label_suffix,
+            empty_permitted, instance, use_required_attribute,
+            renderer,
+        )
+
+        for field in self.fields:
+            self.fields[field].required = False


### PR DESCRIPTION
- ModelForm allows edditing all model fields except many-to-many
- will allow removal of BaseCaseForm, Refs #708, #812