### PR TITLE
API: add backwards compatibility for TestCase.create()

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,5 +8,6 @@ django-modern-rpc==0.12.0
 django-simple-history==2.8.0
 jira==2.0.0
 Markdown==3.1.1
+python-gitlab==1.15.0
 python-redmine==2.2.1
 topicaxis-opengraph==0.5

--- a/requirements/tarballs.txt
+++ b/requirements/tarballs.txt
@@ -7,4 +7,3 @@ django-uuslug==1.2.0
 django-vinaigrette==2.0.1
 python-bugzilla==2.3.0
 PyGithub==1.45
-python-gitlab==1.15.0

--- a/tcms/rpc/api/testcase.py
+++ b/tcms/rpc/api/testcase.py
@@ -266,6 +266,18 @@ def create(values, **kwargs):
     """
     request = kwargs.get(REQUEST_KEY)
 
+    # b/c form was designed badly in the past clients send 'product'
+    # as one of the fields. With the new forms product isn't accepted
+    # but we add this as backward compatibility for older clients
+    # otherwise they will start failing.
+    # todo: remove after all clients have been updated
+    if values.get('product'):
+        del values['product']
+
+    # todo: this is sent by junit-plugin while Python plugins use the above
+    if values.get('product_id'):
+        del values['product_id']
+
     if not (values.get('author') or values.get('author_id')):
         values['author'] = request.user.pk
 


### PR DESCRIPTION
- ignore 'product' parameter which is still sent by older clients