### PR TITLE
Normalize file path separator in storage class

### DIFF
--- a/tcms/tests/storage.py
+++ b/tcms/tests/storage.py
@@ -9,6 +9,7 @@ def find_files():
     found_files = OrderedDict()
     for finder in get_finders():
         for path, storage in finder.list([]):
+            path = path.replace('\\', '/')
             if path not in found_files:
                 found_files[path] = (storage, path)
 


### PR DESCRIPTION
This PR makes `tcms.tests.storage.RaiseWhenFileNotFound` capable of finding static files in a Windows environment, where the backslash is used as the file path separator.

Solves this question on StackOverflow: [Static file “debug_toolbar/css/print.css” does not exist when starting Kiwi Tcms](https://stackoverflow.com/questions/55297178/static-file-debug-toolbar-css-print-css-does-not-exist-when-starting-kiwi-tcms)