### PR TITLE
Add left padding to ordered lists in test cases. Fix #339

### DIFF
--- a/tcms/static/style/base.css
+++ b/tcms/static/style/base.css
@@ -347,6 +347,7 @@ table.noborder,table.noborder td{border:none;background:transparent;}
 .case_detail .case_list{ width:50%; float:left;}
 .right_pannel{ float:right; margin-left:-265px; width:260px; padding-top:10px;}
 .case_detail .no-border td{ border:0px;}
+.case_detail ol{padding-left:1em;}
 
 /**********************************multiple select************/
 .last_login{ width:100%;}


### PR DESCRIPTION
This PR adds a `1em` left padding to ordered lists in the detail display of test cases, in order to ensure that list markers have enough space to sit inside their respective lists without flowing out through the left border.

`1em` is just enough to properly contain markers of <= 2 digits.

Containing markers of larger sizes will mean bumping this value upwards. But I think `1em` is perfect for the average use case &mdash; 99 seems to me a sensible limit to the number of items in a list made for humans 😇 😇 😇.

__IMAGE__: Before Change

![before](https://user-images.githubusercontent.com/50708034/73663000-0ff8e100-469d-11ea-9dc6-e125a7ac13bf.png)

__IIMAGE__: After Change

![after](https://user-images.githubusercontent.com/50708034/73663029-1be4a300-469d-11ea-91f2-55ef8090a36c.png)
