### PR TITLE
Set Test Plans search result table rows to 100 per page

### DIFF
--- a/tcms/testplans/static/testplans/js/search.js
+++ b/tcms/testplans/static/testplans/js/search.js
@@ -9,6 +9,7 @@ function pre_process_data(data) {
 
 $(document).ready(function() {
     var table = $("#resultsTable").DataTable({
+        "pageLength": 100,
         ajax: function(data, callback, settings) {
             var params = {};
 

--- a/tcms/testplans/static/testplans/js/search.js
+++ b/tcms/testplans/static/testplans/js/search.js
@@ -9,7 +9,7 @@ function pre_process_data(data) {
 
 $(document).ready(function() {
     var table = $("#resultsTable").DataTable({
-        "pageLength": 100,
+        pageLength: 100,
         ajax: function(data, callback, settings) {
             var params = {};
 


### PR DESCRIPTION
Set Search Test Plan result table page length to 100 rows.