### PR TITLE
Notify assignee of bug assignment. Fix #1154

### DIFF
--- a/tcms/bugs/apps.py
+++ b/tcms/bugs/apps.py
@@ -1,0 +1,13 @@
+# pylint: disable=import-outside-toplevel
+from django.apps import AppConfig as DjangoAppConfig
+
+
+class AppConfig(DjangoAppConfig):
+    name = 'tcms.bugs'
+
+    def ready(self):
+        from django.db.models.signals import post_save
+        from .models import Bug
+        from tcms import signals
+
+        post_save.connect(signals.handle_emails_post_bug_save, sender=Bug)

--- a/tcms/bugs/tests/test_models.py
+++ b/tcms/bugs/tests/test_models.py
@@ -1,0 +1,39 @@
+from django.conf import settings
+from django.template.loader import render_to_string
+from django.test import TestCase
+from django.utils.translation import gettext_lazy as _
+from mock import patch
+
+from tcms.tests.factories import BugFactory, UserFactory
+
+
+class TestSendMailOnAssigneeChange(TestCase):
+    """Test that assignee is notified by mail each time they are assigned a bug.
+
+    Ideally, notifications are sent out when:
+    * Assignee is assigned bug on bug creation
+    * Assignee is assigned bug which was previously assigned to someone other assignee
+    """
+
+    @patch('tcms.core.utils.mailto.send_mail')
+    def test_notify_assignee_on_bug_creation(self, send_mail):
+        assignee = UserFactory()
+        bug = BugFactory(assignee=assignee)
+
+        expected_subject = _('NEW: Bug #{} - {}').format(bug.pk, bug.summary)
+        expected_body = render_to_string('email/post_bug_save/email.txt', {'bug': bug})
+        expected_recipients = [assignee.email]
+
+        send_mail.assert_called_once_with(
+            settings.EMAIL_SUBJECT_PREFIX + expected_subject,
+            expected_body,
+            settings.DEFAULT_FROM_EMAIL,
+            expected_recipients,
+            fail_silently=False
+        )
+
+    @patch('tcms.core.utils.mailto.send_mail')
+    def test_no_notification_if_assignee_not_set(self, send_mail):
+        BugFactory(assignee=None)
+
+        self.assertFalse(send_mail.called)

--- a/tcms/settings/common.py
+++ b/tcms/settings/common.py
@@ -263,7 +263,7 @@ INSTALLED_APPS = [
     'tcms.core',
     # if you wish to disable Kiwi TCMS bug tracker
     # comment out the next line
-    'tcms.bugs',
+    'tcms.bugs.apps.AppConfig',
     'tcms.kiwi_auth',
     'tcms.core.contrib.linkreference',
     'tcms.management',

--- a/tcms/signals.py
+++ b/tcms/signals.py
@@ -34,6 +34,7 @@ __all__ = [
     'handle_emails_pre_case_delete',
     'handle_emails_post_plan_save',
     'handle_emails_post_run_save',
+    'handle_emails_post_bug_save',
 ]
 
 
@@ -175,3 +176,21 @@ def handle_comments_pre_delete(sender, **kwargs):
     instance = kwargs['instance']
 
     get_comments(instance).delete()
+
+
+def handle_emails_post_bug_save(sender, instance, created=False, **kwargs):
+    """
+        Send email updates to assignee after they've been
+        assigned a bug on bug creation.
+    """
+    if not created or instance.assignee is None:
+        return
+
+    from tcms.core.utils.mailto import mailto
+
+    mailto(
+        template_name='email/post_bug_save/email.txt',
+        recipients=[instance.assignee.email],
+        subject=_('NEW: Bug #{} - {}').format(instance.pk, instance.summary),
+        context={'bug': instance}
+    )

--- a/tcms/templates/email/post_bug_save/email.txt
+++ b/tcms/templates/email/post_bug_save/email.txt
@@ -1,0 +1,12 @@
+{% load i18n %}
+{% blocktrans with pk=bug.pk bug_url=bug.get_full_url summary=bug.summary creation_date=bug.created_at reporter=bug.reporter assignee=bug.assignee product=bug.product version=bug.version build=bug.build %}Bug {{ pk }} has been assigned to you.
+
+Link: {{ bug_url }}
+
+Summary: {{ summary }}
+Created at: {{ creation_date }}
+Reporter: {{ reporter }}
+Assignee: {{ assignee }}
+Product: {{ product }}
+Version: {{ version }}
+Build: {{ build }}{% endblocktrans %}

--- a/tcms/tests/factories.py
+++ b/tcms/tests/factories.py
@@ -317,3 +317,16 @@ class TestRunCCFactory(DjangoModelFactory):
 
     run = factory.SubFactory(TestRunFactory)
     user = factory.SubFactory(UserFactory)
+
+
+class BugFactory(DjangoModelFactory):
+
+    class Meta:
+        model = 'bugs.Bug'
+
+    summary = factory.Sequence(lambda n: 'Bug %d' % n)
+    reporter = factory.SubFactory(UserFactory)
+    assignee = factory.SubFactory(UserFactory)
+    product = factory.SubFactory(ProductFactory)
+    version = factory.SubFactory(VersionFactory)
+    build = factory.SubFactory(BuildFactory)


### PR DESCRIPTION
This PR adds email notification about assigned bugs on bug creation.

If assignee is not None, they are notified of the created bug to which they've been assigned.

The body of the email notification contains a summary of the bug and a link to the bug's detail page.

------

**PREVIOUSLY:**

~This PR adds email notification about assigned bugs on add/edit actions.~

~* __ADD__: On bug creation, if assignee is not None, they are notified of the created bug which they've been assigned to.~
~* __EDIT__: On subsequent bug saves, if assignee is not None, and is different from the previous assignee in the database, then the recently assigned assignee is notified of the assignment.~

~The body of the email notification contains a summary of the bug and a link to the bug's detail page.~