### PR TITLE
Make use of DEFAULT_PAGE_SIZE setting for Test Plans search table rows

### DIFF
--- a/tcms/bugs/static/bugs/js/search.js
+++ b/tcms/bugs/static/bugs/js/search.js
@@ -1,6 +1,7 @@
 
 $(document).ready(function() {
     var table = $("#resultsTable").DataTable({
+        pageLength: $('#navbar').data('defaultpagesize'),
         ajax: function(data, callback, settings) {
             var params = {};
 

--- a/tcms/templates/navbar.html
+++ b/tcms/templates/navbar.html
@@ -3,7 +3,7 @@
 {% load tz %}
 
     <!-- PatternFly Horizontal Nav -->
-    <nav class="navbar navbar-default navbar-pf" role="navigation">
+    <nav class="navbar navbar-default navbar-pf" role="navigation" id="navbar" data-defaultpagesize="{{ SETTINGS.DEFAULT_PAGE_SIZE }}">
         <div class="navbar-header">
             <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse-1">
                 <span class="sr-only">{% trans "Toggle navigation" %}</span>

--- a/tcms/testcases/static/testcases/js/search.js
+++ b/tcms/testcases/static/testcases/js/search.js
@@ -11,6 +11,7 @@ function pre_process_data(data) {
 
 $(document).ready(function() {
     var table = $("#resultsTable").DataTable({
+        pageLength: $('#navbar').data('defaultpagesize'),
         ajax: function(data, callback, settings) {
             var params = {};
 

--- a/tcms/testplans/static/testplans/js/search.js
+++ b/tcms/testplans/static/testplans/js/search.js
@@ -9,7 +9,7 @@ function pre_process_data(data) {
 
 $(document).ready(function() {
     var table = $("#resultsTable").DataTable({
-        pageLength: 100,
+        pageLength: $('#navbar').data('defaultpagesize'),
         ajax: function(data, callback, settings) {
             var params = {};
 

--- a/tcms/testruns/static/testruns/js/search.js
+++ b/tcms/testruns/static/testruns/js/search.js
@@ -20,6 +20,7 @@ function pre_process_data(data) {
 
 $(document).ready(function() {
     var table = $("#resultsTable").DataTable({
+        pageLength: $('#navbar').data('defaultpagesize'),
         ajax: function(data, callback, settings) {
             var params = {};
 


### PR DESCRIPTION
The number of rows on page should be configurable. DEFAULT_PAGE_SIZE is now used to set this for Test Plan search results.