### PR TITLE
Prevent link follow-up when filtering

### DIFF
--- a/tcms/static/js/testrun_actions.js
+++ b/tcms/static/js/testrun_actions.js
@@ -190,9 +190,6 @@ Nitrate.TestRuns.Details.on_load = function() {
   jQ('.js-caserun-total').bind('click', function() {
     showCaseRunsWithSelectedStatus(jQ('#id_filter')[0], '');
   });
-  jQ('.status-link-button').bind('click', function() {
-    showCaseRunsWithSelectedStatus(jQ('#id_filter')[0], jQ(this).data('param'));
-  });
 };
 
 Nitrate.TestRuns.AssignCase.on_load = function() {
@@ -696,12 +693,8 @@ function renderProgressBars(positiveCount, negativeCount, allCount) {
 
 function renderCountPerStatusList(statusCount) {
   for (var status in statusCount) {
-    let element = "0";
     const count = statusCount[status].count
-    if (count) {
-      className = "status-link-button"
-      element = `<a href="#" class="status-link-button" data-param=${statusCount[status].id}>${count}</a>`
-    }
+    const element = count ? `<a href="?status_id=${statusCount[status].id}">${count}</a>` : '0'
 
     $(".count-per-status-list").append(`
     <li>

--- a/tcms/static/js/testrun_actions.js
+++ b/tcms/static/js/testrun_actions.js
@@ -574,11 +574,6 @@ function serializeCaseRunFromInputList(table, name) {
   return returnobj_list;
 }
 
-function showCaseRunsWithSelectedStatus(form, status_id) {
-  form.status__pk.value = status_id;
-  fireEvent(jQ(form).find('input[type="submit"]')[0], 'click');
-}
-
 function showCommentForm() {
   var dialog = getDialog();
   var runs = serializeCaseRunFromInputList(jQ('#id_table_cases')[0]);

--- a/tcms/static/js/testrun_actions.js
+++ b/tcms/static/js/testrun_actions.js
@@ -677,7 +677,7 @@ function renderProgressBars(positiveCount, negativeCount, allCount) {
   $(".progress-bar > .percent > .complete-percent").text(`${completePercent}%`)
   $(".progress-bar > .progress-inner").css("width", `${completePercent}%`)
   $(".progress-bar > .progress-inner > .progress-failed").css("width", `${failurePercent}%`)
-  $(".js-caserun-total").text(allCount)
+  $(".total-execution-count").text(allCount)
 
   $(".count-per-status-list").remove()
   $(".count-per-status-container").prepend('<span class="count-per-status-list"></span>')

--- a/tcms/static/js/testrun_actions.js
+++ b/tcms/static/js/testrun_actions.js
@@ -187,9 +187,6 @@ Nitrate.TestRuns.Details.on_load = function() {
     var params = jQ(this).data('params');
     removeRunCC(params[0], params[1], jQ('.js-cc-ul')[0]);
   });
-  jQ('.js-caserun-total').bind('click', function() {
-    showCaseRunsWithSelectedStatus(jQ('#id_filter')[0], '');
-  });
 };
 
 Nitrate.TestRuns.AssignCase.on_load = function() {

--- a/tcms/templates/run/status_statistics.html
+++ b/tcms/templates/run/status_statistics.html
@@ -6,7 +6,7 @@
 	<ul class="count-per-status-container">
 		<li>
 			<label>{% trans "TOTAL" %}</label>
-			[<a href="#" class="js-caserun-total"></a>]
+			[<a href="?" class="js-caserun-total"></a>]
 		</li>
 	</ul>
 	<div class="clear"></div>

--- a/tcms/templates/run/status_statistics.html
+++ b/tcms/templates/run/status_statistics.html
@@ -6,7 +6,7 @@
 	<ul class="count-per-status-container">
 		<li>
 			<label>{% trans "TOTAL" %}</label>
-			[<a href="?" class="js-caserun-total"></a>]
+			[<a href="?" class="total-execution-count"></a>]
 		</li>
 	</ul>
 	<div class="clear"></div>


### PR DESCRIPTION
on TestExecutionStatus

from https://stackoverflow.com/questions/1291942/what-does-javascriptvoid0-mean/1293130#1293130:
```
<a href="#"> is a common alternative which might arguably be less bad. However you must remember to return false from your onclick event handler to prevent the link being followed and scrolling up to the top of the page.
```