### PR TITLE
Another take on how we read settings overrides

### DIFF
--- a/tcms/utils/settings.py
+++ b/tcms/utils/settings.py
@@ -1,46 +1,34 @@
 # Copyright (c) 2020 Alexander Todorov <atodorov@MrSenko.com>
 
 import os
-import importlib
-
-from django.conf import settings as django_settings
+import glob
+import inspect
 
 import tcms.settings
 
 
-def local_settings_files(scan_dir):
+def import_local_settings(scan_dir, **kwargs):
     """
-        Returns a sorted list of 1st level files found under
-        @scan_dir, except __init__.py.
+        Add/override the global settings object with additional settings
+        defined in files found under @scan_dir.
 
-        These files will later be imported to override Django settings!
-
-        WARNING: file names must be valid Python module names!!!
-    """
-    module_names = []
-    for entry in os.scandir(scan_dir):
-        if entry.is_file() and entry.name != '__init__.py':
-            module_names.append(entry.name.replace('.py', ''))
-    module_names.sort()
-
-    return module_names
-
-
-def import_local_settings(scan_dir):
-    """
-        Performs `from scan_dir.<module> import *` in alphabetic order for all files
-        found under @scan_dir.
+        Files are executed in alphabetic order!
 
         @scan_dir is a directory(parent module) under tcms/settings/!
     """
-    absolute_scan_dir = os.path.join(os.path.dirname(tcms.settings.__file__), scan_dir)
-    for module_name in local_settings_files(absolute_scan_dir):
-        import_name = "tcms.settings.%s.%s" % (scan_dir, module_name)
-        module = importlib.import_module(import_name)
+    # we are getting globals() from previous frame globals - it is caller's globals()
+    scope = kwargs.pop('scope', inspect.stack()[1][0].f_globals)
 
-        # override anything which looks like a constant,
-        # e.g. capital letters. This is exactly what Django does
-        for setting_name in dir(module):
-            if setting_name.isupper():
-                setting_value = getattr(module, setting_name)
-                setattr(django_settings, setting_name, setting_value)
+    scan_dir = os.path.join(os.path.dirname(tcms.settings.__file__), scan_dir, '*.py')
+    override_files = glob.glob(scan_dir)
+    override_files.sort()
+    for fname in override_files:
+        if fname.endswith('__init__.py'):
+            continue
+        # Similar to what Transifex does
+        # https://code.djangoproject.com/wiki/SplitSettings#Usingexectoincorporatelocalsettings
+        # https://code.djangoproject.com/wiki/SplitSettings#UsingalistofconffilesTransifex
+        exec(  # nosec:B102:exec_used
+            open(fname, "rb").read(),
+            scope
+        )

--- a/tcms/utils/tests/test_local_settings_dir.py
+++ b/tcms/utils/tests/test_local_settings_dir.py
@@ -17,7 +17,7 @@ class ImportLocalSettingsTestCase(TestCase):
         self.assertNotIn('test_me', settings.INSTALLED_APPS)
 
         # perform the import which will override settings
-        import_local_settings('local_settings_test')
+        import_local_settings('local_settings_test', scope=settings.__dict__)
 
         # assert settings values have changed
         self.assertEqual(settings.KIWI_VERSION, "%s-Under-Test" % __version__)


### PR DESCRIPTION
because Django's LazySettings() modifies the underlying
object during application loading and that breaks for us.

Figure out the scope from the caller's context
(inspired by django-split-settings)

The current approach is used by Transifex:
https://code.djangoproject.com/wiki/SplitSettings#UsingalistofconffilesTransifex