### PR TITLE
Remove CsrfDisableMiddleware. Closes #297

### DIFF
--- a/tcms/core/middleware.py
+++ b/tcms/core/middleware.py
@@ -8,11 +8,6 @@ from django.utils.deprecation import MiddlewareMixin
 from django.utils.translation import gettext_lazy as _
 
 
-class CsrfDisableMiddleware(MiddlewareMixin):
-    def process_view(self, request, _callback, _callback_args, _callback_kwargs):
-        setattr(request, '_dont_enforce_csrf_checks', True)
-
-
 class CheckSettingsMiddleware(MiddlewareMixin):
     def process_request(self, request):
         doc_url = 'https://kiwitcms.readthedocs.io/en/latest/admin.html#configure-kiwi-s-base-url'

--- a/tcms/settings/common.py
+++ b/tcms/settings/common.py
@@ -115,7 +115,6 @@ MIDDLEWARE = [
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.locale.LocaleMiddleware',
     'django.middleware.common.CommonMiddleware',
-    'tcms.core.middleware.CsrfDisableMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',


### PR DESCRIPTION
this is a legacy leftover which doesn't make any sense