### PR TITLE
Fix display of Components in automatic bug reports

### DIFF
--- a/tcms/issuetracker/base.py
+++ b/tcms/issuetracker/base.py
@@ -33,6 +33,15 @@ class IssueTrackerType:
         """
         return int(RE_ENDS_IN_INT.search(url.strip()).group(0))
 
+    @staticmethod
+    def get_case_components(case):
+        """
+            Returns a string that contains comma separated list of components
+            bound to a given testcase
+        """
+        case_components = ', '.join(case.component.values_list('name', flat=True))
+        return case_components
+
     def details(self, url):  # pylint: disable=no-self-use
         """
             Returns bug details to be used later. By default this method
@@ -57,9 +66,7 @@ class IssueTrackerType:
         comment = "Filed from execution %s\n\n" % execution.get_full_url()
         comment += "**Product:**\n%s\n\n" % execution.run.plan.product.name
         comment += "**Component(s):**\n%s\n\n" % \
-                   ' '.join([str(i) for i in
-                             execution.case.component.values_list('name',
-                                                                  flat=True)])
+                   self.get_case_components(execution.case)
         comment += "**Version-Release number** (if applicable):\n"
         comment += "%s\n\n" % execution.build.name
         comment += "**Steps to reproduce**: \n%s\n\n" % txt

--- a/tcms/issuetracker/base.py
+++ b/tcms/issuetracker/base.py
@@ -57,7 +57,9 @@ class IssueTrackerType:
         comment = "Filed from execution %s\n\n" % execution.get_full_url()
         comment += "**Product:**\n%s\n\n" % execution.run.plan.product.name
         comment += "**Component(s):**\n%s\n\n" % \
-                   execution.case.component.values_list('name', flat=True)
+                   ' '.join([str(i) for i in
+                             execution.case.component.values_list('name',
+                                                                  flat=True)])
         comment += "**Version-Release number** (if applicable):\n"
         comment += "%s\n\n" % execution.build.name
         comment += "**Steps to reproduce**: \n%s\n\n" % txt

--- a/tcms/issuetracker/types.py
+++ b/tcms/issuetracker/types.py
@@ -81,8 +81,9 @@ class Bugzilla(IssueTrackerType):
         args['cf_build_id'] = execution.run.build.name
 
         args['comment'] = self._report_comment(execution)
-        args['component'] = execution.case.component.values_list('name',
-                                                                 flat=True)
+        args['component'] = ' '.join([str(i) for i in
+                                      execution.case.component.values_list('name',
+                                                                           flat=True)])
         args['product'] = execution.run.plan.product.name
         args['short_desc'] = 'Test case failure: %s' % execution.case.summary
         args['version'] = execution.run.product_version

--- a/tcms/issuetracker/types.py
+++ b/tcms/issuetracker/types.py
@@ -81,9 +81,7 @@ class Bugzilla(IssueTrackerType):
         args['cf_build_id'] = execution.run.build.name
 
         args['comment'] = self._report_comment(execution)
-        args['component'] = ' '.join([str(i) for i in
-                                      execution.case.component.values_list('name',
-                                                                           flat=True)])
+        args['component'] = self.get_case_components(execution.case)
         args['product'] = execution.run.plan.product.name
         args['short_desc'] = 'Test case failure: %s' % execution.case.summary
         args['version'] = execution.run.product_version


### PR DESCRIPTION
The Components queryset is converted to space delimited string for proper display in bug reports.
Closes #1157