### PR TITLE
MariaDB: change charset and collation to utf8mb4. Closes #327

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -118,9 +118,9 @@ before_install:
 
             mysql -e 'SELECT VERSION();'
             mysql -e 'CREATE USER "kiwi" IDENTIFIED BY "";'
-            mysql -e 'CREATE DATABASE kiwi CHARACTER SET utf8 COLLATE utf8_unicode_ci;'
+            mysql -e 'CREATE DATABASE kiwi CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;'
             mysql -e 'GRANT ALL PRIVILEGES ON kiwi.* TO kiwi;'
-            mysql -e 'CREATE DATABASE test_kiwi CHARACTER SET utf8 COLLATE utf8_unicode_ci;'
+            mysql -e 'CREATE DATABASE test_kiwi CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;'
             mysql -e 'GRANT ALL PRIVILEGES ON test_kiwi.* TO kiwi;'
         fi
 

--- a/.travis/my.cnf
+++ b/.travis/my.cnf
@@ -1,11 +1,11 @@
 [client]
-default-character-set=utf8
+default-character-set=utf8mb4
 
 [mysql]
-default-character-set=utf8
+default-character-set=utf8mb4
 
 [mysqld]
-character-set-server = utf8
-character_set_server = utf8
-collation-server = utf8_unicode_ci
-collation_server = utf8_unicode_ci
+character-set-server = utf8mb4
+character_set_server = utf8mb4
+collation-server = utf8mb4_unicode_ci
+collation_server = utf8mb4_unicode_ci

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,8 +12,8 @@ services:
             MYSQL_DATABASE: kiwi
             MYSQL_USER: kiwi
             MYSQL_PASSWORD: kiwi
-            MYSQL_CHARSET: utf8
-            MYSQL_COLLATION: utf8_unicode_ci
+            MYSQL_CHARSET: utf8mb4
+            MYSQL_COLLATION: utf8mb4_unicode_ci
 
     web:
         container_name: kiwi_web

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -30,6 +30,21 @@ ones to augment the default behavior of Kiwi TCMS. For more information
 refer to :mod:`tcms.signals`.
 
 
+Language and emojis
+-------------------
+
+By default our ``docker-compose.yml`` file is configured with MariaDB and
+uses charset ``utf8mb4`` and collation ``utf8mb4_unicode_ci``. That should
+be sufficient to support many languages plus emojis. If you are having troubles
+consult `MariaDB Character Sets and Collations <https://mariadb.com/kb/en/character-sets/>`_
+documentation.
+
+If you need to change the default settings see ``docker-compose.yml`` or
+``/etc/mysql/conf.d/mariadb.cnf`` if using a stand alone DB server! On the
+application side see ``DATABASES['default']['OPTIONS']`` in
+``tcms/settings/common.py``.
+
+
 Time zone settings
 ------------------
 

--- a/tcms/settings/common.py
+++ b/tcms/settings/common.py
@@ -39,7 +39,8 @@ DATABASES = {
 if DATABASES['default']['ENGINE'].find('mysql') > -1:
     DATABASES['default']['OPTIONS'].update({  # pylint: disable=objects-update-used
         'init_command': "SET sql_mode='STRICT_TRANS_TABLES'",
-        })
+        'charset': 'utf8mb4',
+    })
 
 
 # Administrators error report email settings


### PR DESCRIPTION
also add short section in documentation to point out to more documentation