### PR TITLE
Clarify e-mail settings and testing. Closes #1070

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -57,23 +57,46 @@ Your server/docker container clock should also match the accurate time of day!
     navigation bar! All other timestamps are in the same time zone!
 
 
-Using Amazon SES instead of SMTP email
---------------------------------------
-
+E-mail settings
+---------------
 Kiwi TCMS supports email notifications which by default are sent over SMTP and
-need to be configured via the following settings::
+need to be configured via the following settings:
 
-    # standard Django settings
-    EMAIL_HOST = 'smtp.example.com'
-    EMAIL_PORT = 25
+- Common settings::
+
     DEFAULT_FROM_EMAIL = 'kiwi@example.com'
-
     # additional Kiwi TCMS setting
     EMAIL_SUBJECT_PREFIX = '[Kiwi-TCMS] '
 
-If you'd like to use an external email service, like Amazon SES you also need
-to configure the following settings::
+- SMTP specific settings::
 
+    EMAIL_HOST = 'smtp.example.com'
+    EMAIL_PORT = 25
+    EMAIL_HOST_USER = 'smtp_username'
+    EMAIL_HOST_PASSWORD = 'smtp_password'
+
+To enable SSL or TLS support include one of the following::
+
+    EMAIL_USE_TLS = True
+    EMAIL_USE_SSL = True
+
+For more details refer to Django documentation at https://docs.djangoproject.com/en/3.0/topics/email/
+
+
+Testing and debugging e-mail configuration
+------------------------------------------
+Sending test e-mail to one or more addresses::
+
+    docker exec -it kiwi_web /Kiwi/manage.py sendtestemail user1@example1.tld user2@example2.tld ...
+
+More details at: https://docs.djangoproject.com/en/3.0/ref/django-admin/#sendtestemail
+
+
+Using Amazon SES instead of SMTP email
+--------------------------------------
+
+If you'd like to use an external email service, like Amazon SES you need
+to configure the following settings instead::
 
     EMAIL_BACKEND = 'django_ses.SESBackend'
     AWS_SES_ACCESS_KEY_ID = 'xxxxxxxxxxxxxxxxxxxx'

--- a/tcms/core/tests/test_sendtestemail.py
+++ b/tcms/core/tests/test_sendtestemail.py
@@ -1,0 +1,15 @@
+import socket
+
+from django.core.management import call_command
+from django.test import TestCase, override_settings
+
+
+class TestSendTestEmail(TestCase):
+    """Test manage.py sendtestemail command"""
+
+    @override_settings(EMAIL_HOST='bogus.nonexistent',
+                       EMAIL_BACKEND='django.core.mail.backends.smtp.EmailBackend')
+    def test_send_false_server(self):
+        """test command with fake SMTP server"""
+        with self.assertRaises(socket.gaierror):
+            call_command('sendtestemail', 'user@server')

--- a/tcms/settings/common.py
+++ b/tcms/settings/common.py
@@ -51,9 +51,16 @@ ADMINS = [
 # Email settings
 # DEFAULT_FROM_EMAIL must be defined if you want Kiwi TCMS to send emails.
 # You also need to configure the email backend. For more information see:
-# https://docs.djangoproject.com/en/2.0/topics/email/#quick-example
+# https://docs.djangoproject.com/en/3.0/topics/email/
 DEFAULT_FROM_EMAIL = 'kiwi@example.com'
+SERVER_EMAIL = DEFAULT_FROM_EMAIL
 EMAIL_SUBJECT_PREFIX = '[Kiwi-TCMS] '
+
+#  SMTP specific settings
+#  EMAIL_HOST = 'smtp.example.com'
+#  EMAIL_PORT = 25
+#  EMAIL_HOST_USER = 'smtp_username'
+#  EMAIL_HOST_PASSWORD = 'smtp_password'
 
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
I've tried to improve the documentation and the main config file to make e-mail setup more user friendly. Since users can spare some digging in Django documentation I hope that we will have less e-mail related support questions.