### PR TITLE
Hide empty values in Execution trends chart tooltip

### DIFF
--- a/tcms/telemetry/static/telemetry/js/testing/execution-trends.js
+++ b/tcms/telemetry/static/telemetry/js/testing/execution-trends.js
@@ -92,6 +92,11 @@ function drawChart() {
                 ratio: 1
             }
         };
+        config.tooltip = {
+            format: {
+                value: (value, _ratio, _id, _index) => value ? value : undefined
+            }
+        }
         c3.generate(config);
     });
 }
@@ -106,14 +111,14 @@ function drawPassingRateSummary(status_count) {
     positiveBar.css('width', positiveRateText)
     positiveBar.text(positiveRateText)
     $('.passing-rate-summary .positive').text(status_count.positive)
-    
+
     const neutralPercent = status_count.neutral ? roundDown(status_count.neutral / allCount * 100) : 0
     const neutralRateText = `${neutralPercent}%`
     const neutralBar = $('.progress > .progress-bar-remaining')
     neutralBar.css('width', neutralRateText)
     neutralBar.text(neutralRateText)
     $('.passing-rate-summary .neutral').text(status_count.neutral)
-    
+
     const negativePercent = status_count.negative ? roundDown(status_count.negative / allCount * 100) : 0
     const negativeRateText = `${negativePercent}%`
     const negativeBar = $('.progress > .progress-bar-danger')


### PR DESCRIPTION
Delete trailing whitespaces in `execution-trends.js`