### PR TITLE
Fix for issue 1327. URL and Name validation.

### DIFF
--- a/tcms/static/js/testrun_actions.js
+++ b/tcms/static/js/testrun_actions.js
@@ -755,9 +755,16 @@ function initialize_addlink_dialog() {
             is_defect = $('#is_defect').is(':checked'),
             update_tracker = $('#update_tracker').is(':checked'),
             case_id = dialog_p.dialog('option', 'case_id');
+        var error = jQ('#testlog_dialog_error')[0];
+
+        if (name.length > 64) {
+            error.innerHTML = "Name length should not exceed 64 characters.";
+            return;
+        }
 
         //check if url is valid
         if (url.length === 0 || url.indexOf('://') === -1) {
+            error.innerHTML = "Not a valid URL."
             return;
         }
 
@@ -797,6 +804,8 @@ function initialize_addlink_dialog() {
       // clean name and url for next input
       jQ('#testlog_name').val('');
       jQ('#testlog_url').val('');
+      // clean error message
+      jQ('#testlog_dialog_error')[0].innerHTML = '';
 
       return true;
     },

--- a/tcms/templates/run/get_case_runs.html
+++ b/tcms/templates/run/get_case_runs.html
@@ -154,6 +154,7 @@
             <input type="text" id="testlog_name" name="testlog_name" style="width: 95%"/>
         </fieldset>
     </form>
+    <span id="testlog_dialog_error" style="color:red"></span>
 </div>
 
 	<script id="add_issue_form_template" type="text/x-handlebars-template">


### PR DESCRIPTION
Fix proposal for #1327 
 
--- Added a error message for invalid or not provided URL field.

![image](https://user-images.githubusercontent.com/8937774/78168185-2c748800-7458-11ea-9b97-18389e5665d8.png)

--- Added a name length check (max 64 characters.)

![image](https://user-images.githubusercontent.com/8937774/78168276-4f9f3780-7458-11ea-9dff-d889fad6d8a0.png)


1 - Are error messages ok from users point of view?
2 - Is it possible to write unit tests for these js's?
