### PR TITLE
api: TestRun.update() will now accept %Y-%m-%d %H:%M:%S format

### DIFF
--- a/tcms/bugs/tests/test_permissions.py
+++ b/tcms/bugs/tests/test_permissions.py
@@ -6,7 +6,7 @@ from tcms.bugs.models import Bug
 from tcms.tests import factories
 
 
-class NewTestCase(tests.PermissionsTestCase):
+class TestNew(tests.PermissionsTestCase):
     permission_label = 'bugs.add_bug'
     url = reverse('bugs-new')
     http_method_names = ['get', 'post']

--- a/tcms/rpc/api/forms/testrun.py
+++ b/tcms/rpc/api/forms/testrun.py
@@ -46,9 +46,9 @@ class UpdateForm(NewForm):
     )
     stop_date = forms.DateTimeField(
         required=False,
-        input_formats=['%Y-%m-%d'],
+        input_formats=['%Y-%m-%d', '%Y-%m-%d %H:%M:%S'],
         error_messages={
-            'invalid': _('The stop date is invalid. The valid format is YYYY-MM-DD.')
+            'invalid': _('The stop date is invalid. The valid format is YYYY-MM-DD [HH:MM:SS].')
         }
     )
 

--- a/tcms/rpc/tests/test_testrun.py
+++ b/tcms/rpc/tests/test_testrun.py
@@ -299,7 +299,7 @@ class TestUpdateTestRun(APITestCase):
         }
 
         with self.assertRaisesMessage(Exception,
-                                      'The stop date is invalid. The valid format is YYYY-MM-DD.'):
+                                      'The stop date is invalid. The valid format is'):
             self.rpc_client.exec.TestRun.update(test_run.pk, update_fields)
 
         # assert test run fields have not been updated


### PR DESCRIPTION
because this is the default format in which datetime values are
serialized via PRC. We should acccept the same format at the very
minimum.

Note: this is used by methods in the upcoming RobotFramework plugin.

I am keeping the existing format for backwards compatibility.