### PR TITLE
Define TENANT_APPS b/c impossible to check for errors otherwise

### DIFF
--- a/tcms/settings/common.py
+++ b/tcms/settings/common.py
@@ -244,33 +244,40 @@ ROOT_URLCONF = 'tcms.urls'
 # Python dotted path to the WSGI application used by Django's runserver.
 WSGI_APPLICATION = 'tcms.wsgi.application'
 
-INSTALLED_APPS = [
-    'vinaigrette',
+# DANGER: DO NOT EDIT, see git log !!!
+# this is consumed by kiwitcms-tenants/django-tenants
+TENANT_APPS = [
+    'django.contrib.sites',
+
+    'attachments',
+    'django_comments',
+    'modernrpc',
+    'simple_history',
+
+    # if you wish to disable Kiwi TCMS bug tracker
+    # comment out the next line
+    'tcms.bugs.apps.AppConfig',
+    'tcms.core.contrib.linkreference',
+    'tcms.management',
+    'tcms.testcases.apps.AppConfig',
+    'tcms.testplans.apps.AppConfig',
+    'tcms.testruns.apps.AppConfig',
+]
+
+INSTALLED_APPS = TENANT_APPS + [
     'grappelli',
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
     'django.contrib.messages',
     'django.contrib.sessions',
-    'django.contrib.sites',
     'django.contrib.staticfiles',
 
-    'attachments',
-    'django_comments',
-    'modernrpc',
-    'simple_history',
     'colorfield',
+    'vinaigrette',
 
     'tcms.core',
-    # if you wish to disable Kiwi TCMS bug tracker
-    # comment out the next line
-    'tcms.bugs.apps.AppConfig',
     'tcms.kiwi_auth',
-    'tcms.core.contrib.linkreference',
-    'tcms.management',
-    'tcms.testcases.apps.AppConfig',
-    'tcms.testplans.apps.AppConfig',
-    'tcms.testruns.apps.AppConfig',
     'tcms.telemetry',
     'tcms.rpc',
 ]


### PR DESCRIPTION
this is a setting which is relevant only for
kiwitcms-tenants/django-tenants and for Kiwi TCMS represents a
subset of all applications accessible to each tenant. These are
the appilications which hold private data for that tenant.

In the past we've had issues where adding a new app into
INSTALLED_APPS (e.g. tcms.bugs) didn't make it into TENANT_APPS
and resulted in all users being able to share bugs which we didn't
want.

Because TENANT_APPS is always a subset of INSTALLED_APPS it is not
possible to check if we've added something to INSTALLED_APPS but
forgot to add it into TENANT_APPS. That's why I'm moving this
setting here and using it as a temporary variable to construct the
full list of INSTALLED_APPS.