### PR TITLE
Status matrix page: show only ID of test run

### DIFF
--- a/tcms/telemetry/static/telemetry/css/testing/status-matrix.css
+++ b/tcms/telemetry/static/telemetry/css/testing/status-matrix.css
@@ -1,5 +1,9 @@
 .table-with-horizontal-scroll {
     display: block;
     overflow-x: auto;
+    white-space: normal;
+}
+
+.header-test-run {
     white-space: nowrap;
 }

--- a/tcms/telemetry/static/telemetry/js/testing/status-matrix.js
+++ b/tcms/telemetry/static/telemetry/js/testing/status-matrix.js
@@ -80,7 +80,11 @@ function drawTable() {
 
         Object.keys(data.columns).forEach(testRunId => {
             const testRunSummary = data.columns[testRunId];
-            $('.table > thead > tr').append(`<th>TR-${testRunId} ${testRunSummary}</th>`);
+            $('.table > thead > tr').append(`
+            <th class="header-test-run">
+                <a href="/runs/${testRunId}">TR-${testRunId}</a>
+                <span class="fa pficon-help" data-toggle="tooltip" data-placement="left" title="${testRunSummary}"></span>
+            </th>`);
 
             table_columns.push({
                 data: null,
@@ -99,6 +103,10 @@ function drawTable() {
 
         const cells = $('.table > tbody > tr > td:has(.execution-status)');
         Object.entries(cells).forEach(applyStyleToCell);
+
+        // initialize the tooltips by hand, because they are dinamically inserted
+        // and not handled by Bootstrap itself
+        $('span[data-toggle=tooltip]').tooltip();
     });
 }
 


### PR DESCRIPTION
- make the table header clickable, with link to the run
- add a tooltip that shows the summary of the test run
- wrap the text of the first column