### PR TITLE
Add Doc8  linter to GitHub workflow. Closes #1551

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,3 +23,21 @@ jobs:
       run: |
         pip install flake8
         make flake8
+        
+  doc8:
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 1
+      matrix:
+        python-version: [3.7]
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Lint with doc8
+      run: |
+        pip install doc8
+        make doc8  

--- a/.travis.yml
+++ b/.travis.yml
@@ -83,9 +83,6 @@ jobs:
             - graphviz
 
     - env:
-        - CMD=doc8
-
-    - env:
         - CMD=test_for_missing_migrations
         - TEST_DB=SQLite
 


### PR DESCRIPTION
- [x] doc8 job has been removed from Travis 
- [x] lint / doc8 (3.7) job is enabled for GitHub workflow
- [x] the new job reports its result on the pull request - see: https://github.com/Prome88/Kiwi/runs/595277339?check_suite_focus=true  and https://github.com/kiwitcms/Kiwi/pull/1557/checks?check_run_id=595309413