### PR TITLE
Send the stop_date in server timezone.

### DIFF
--- a/tcms/static/js/utils.js
+++ b/tcms/static/js/utils.js
@@ -163,3 +163,5 @@ function treeViewBind() {
       }
     });
 }
+
+const currentTimeWithTimezone = timeZone => moment().tz(timeZone).format('YYYY-MM-DD HH:mm:ss')

--- a/tcms/templates/navbar.html
+++ b/tcms/templates/navbar.html
@@ -101,8 +101,8 @@
 
                 <li style="float:right">
                     <a>
-                        <span class="fa fa-clock-o">
-                            {% get_current_timezone as TIME_ZONE %}
+                        {% get_current_timezone as TIME_ZONE %}
+                        <span id="clock" class="fa fa-clock-o" data-time-zone="{{ TIME_ZONE }}">
                             {{ SERVER_TIME }} {{ TIME_ZONE }}
                         </span>
                     </a>

--- a/tcms/testruns/static/testruns/js/get.js
+++ b/tcms/testruns/static/testruns/js/get.js
@@ -10,8 +10,9 @@ $(document).ready(() => {
         if (state) {
             jsonRPC('TestRun.update', [testRunId, { 'stop_date': null }], () => { })
         } else {
-            let now = new Date().toISOString().replace("T", " ")
-            now = now.slice(0, now.length-5)
+            const timeZone = $('#clock').data('time-zone')
+            const now = currentTimeWithTimezone(timeZone)
+
             jsonRPC('TestRun.update', [testRunId, { 'stop_date': now }], () => { })
         }
     });
@@ -20,7 +21,7 @@ $(document).ready(() => {
 
     // bind everything in tags table
     tagsCard('TestRun', testRunId, { run: testRunId }, permRemoveTag);
-    
+
     jsonRPC('TestExecutionStatus.filter', {}, data => {
         executionStatuses = data
         drawPercentBar(testRunId)

--- a/tcms/testruns/templates/testruns/get.html
+++ b/tcms/testruns/templates/testruns/get.html
@@ -119,6 +119,8 @@
 
 <script src="{% static 'typeahead.js/dist/typeahead.jquery.min.js' %}"></script>
 <script src="{% static 'bootstrap-switch/dist/js/bootstrap-switch.min.js' %}"></script>
+<script src="{% static 'moment/min/moment.min.js' %}"></script>
+<script src="{% static 'moment-timezone/builds/moment-timezone-with-data.min.js' %}"></script>
 
 <script src="{% static 'js/utils.js' %}"></script>
 <script src="{% static 'js/jsonrpc.js' %}"></script>


### PR DESCRIPTION
Encapsulate the html showing the server's timezone into
a `span` with id and data attribute.

When clicking the OFF button, read the value from there
and use `moment-with-timezone` to converr the date which is
in the client's timezone to the server's timezone.

For the purpose we need to vendor the `moment-timezone-with-data.js`,
because it contains all the data about timezones, time differences, etc.

Without doing that, all convertions fall back to UTC and I found no other way
to download the file (via npm or something else).