### PR TITLE
Update stop date dinamically on Test Run completion

### DIFF
--- a/tcms/testruns/static/testruns/js/get.js
+++ b/tcms/testruns/static/testruns/js/get.js
@@ -8,12 +8,17 @@ $(document).ready(() => {
 
     $('#status_button').on('switchChange.bootstrapSwitch', (_event, state) => {
         if (state) {
-            jsonRPC('TestRun.update', [testRunId, { 'stop_date': null }], () => { })
+            jsonRPC('TestRun.update', [testRunId, { 'stop_date': null }], () => {
+                $('.stop-date').html('-')
+            })
         } else {
             const timeZone = $('#clock').data('time-zone')
             const now = currentTimeWithTimezone(timeZone)
 
-            jsonRPC('TestRun.update', [testRunId, { 'stop_date': now }], () => { })
+            jsonRPC('TestRun.update', [testRunId, { 'stop_date': now }], testRun => {
+                const stopDate = moment(testRun.stop_date).format("DD MMM YYYY, HH:mm a")
+                $('.stop-date').html(stopDate)
+            })
         }
     });
 

--- a/tcms/testruns/templates/testruns/get.html
+++ b/tcms/testruns/templates/testruns/get.html
@@ -68,11 +68,13 @@
 
                 <h2 class="card-pf-title" style="text-align: left">
                     <span class="fa fa-calendar-check-o"></span>{% trans 'Finished at' %}:
-                    {% if object.stop_date %}
-                        {{ object.stop_date }}
-                    {% else %}
-                        -
-                    {% endif %}
+                    <span class="stop-date">
+                        {% if object.stop_date %}
+                            {{ object.stop_date }}
+                        {% else %}
+                            -
+                        {% endif %}
+                    </span>
                 </h2>
 
                 <div class="card-pf-body"></div>


### PR DESCRIPTION
- wrap the stop date in `span.stop-date` for easy manipulation.
- upon completing the API call, set the html of that DOM field to:
  - `-` if plan is set to running
  - the actual stop date if plan is set to finished