### PR TITLE
Render test case text and notes for each TestExecution in TestRun page

### DIFF
--- a/tcms/testruns/static/testruns/js/get.js
+++ b/tcms/testruns/static/testruns/js/get.js
@@ -120,6 +120,8 @@ function renderAdditionalInformation(testExecutions, testExecutionCaseIds) {
             const listGroupItem = $(`.test-execution-${testExecution.id}`)
             listGroupItem.find('.test-execution-priority').html(testCase.priority)
             listGroupItem.find('.test-execution-category').html(testCase.category)
+            listGroupItem.find('.test-execution-text').html(testCase.text)
+            listGroupItem.find('.test-execution-notes').append(testCase.notes)
 
             const isAutomatedElement = listGroupItem.find('.test-execution-automated')
             const isAutomatedIcon = testCase.is_automated ? 'fa-cog' : 'fa-thumbs-up'

--- a/tcms/testruns/templates/testruns/get.html
+++ b/tcms/testruns/templates/testruns/get.html
@@ -171,7 +171,19 @@
                                     </div>
                                 </div>
                                 <div class="list-group-item-container container-fluid hidden">
-                                    {% comment %} TODO: exandable content goes here {% endcomment %}
+                                    <div class="row">
+                                        <div class="col-md-9">
+                                            <div class="test-execution-text-container markdown-text">
+                                                <p class="test-execution-text"></p>
+                                                <p class="test-execution-notes">
+                                                    <strong>{% trans 'Notes' %}:</strong>
+                                                </p>
+                                                <div>
+                                                    {% comment %} TODO: bugs come here {% endcomment %}
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
                                 </div>
                             </div>
                         </template>


### PR DESCRIPTION
contains the changes from #1546 

currently, UI looks like this:
<img width="1329" alt="Screen Shot 2020-04-27 at 12 08 00" src="https://user-images.githubusercontent.com/18421997/80354689-beb55380-887f-11ea-9eca-846a0d9f0bda.png">
