### PR TITLE
Start testing with the internal bug tracker disabled. Refs #1370

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,11 @@ jobs:
 
     - env:
         - CMD=test
+        - TEST_DB=SQLite
+        - KIWI_DISABLE_BUGTRACKER=yes
+
+    - env:
+        - CMD=test
         - TEST_DB=MariaDB
         - LANG=sl
       addons:

--- a/docs/source/admin.rst
+++ b/docs/source/admin.rst
@@ -49,6 +49,14 @@ in :mod:`tcms.issuetracker`.
     these sections carefully before configuring integration with external bug tracking
     systems!
 
+.. important::
+
+    Kiwi TCMS comes with its own internal bug tracker. This is designed as
+    a light-weight solution for small teams. In case you are already using an
+    external defect tracking system like Bugzilla you may disable the internal
+    one by defining ``KIWI_DISABLE_BUGTRACKER=yes`` in your environment
+    variables!
+
 
 Managing permissions
 --------------------

--- a/tcms/bugs/tests/factory.py
+++ b/tcms/bugs/tests/factory.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=too-few-public-methods, unused-argument
+
+import factory
+from factory.django import DjangoModelFactory
+
+from tcms.tests.factories import BuildFactory
+from tcms.tests.factories import ProductFactory
+from tcms.tests.factories import UserFactory
+from tcms.tests.factories import VersionFactory
+
+
+class BugFactory(DjangoModelFactory):
+
+    class Meta:
+        model = 'bugs.Bug'
+
+    summary = factory.Sequence(lambda n: 'Bug %d' % n)
+    reporter = factory.SubFactory(UserFactory)
+    assignee = factory.SubFactory(UserFactory)
+    product = factory.SubFactory(ProductFactory)
+    version = factory.SubFactory(VersionFactory)
+    build = factory.SubFactory(BuildFactory)

--- a/tcms/bugs/tests/test_models.py
+++ b/tcms/bugs/tests/test_models.py
@@ -1,10 +1,18 @@
-from django.conf import settings
-from django.template.loader import render_to_string
-from django.test import TestCase
-from django.utils.translation import gettext_lazy as _
-from mock import patch
+# pylint: disable=wrong-import-position
+import unittest
 
-from tcms.tests.factories import BugFactory, UserFactory
+from django.conf import settings
+
+if 'tcms.bugs.apps.AppConfig' not in settings.INSTALLED_APPS:
+    raise unittest.SkipTest('tcms.bugs is disabled')
+
+from django.template.loader import render_to_string     # noqa: E402
+from django.test import TestCase                        # noqa: E402
+from django.utils.translation import gettext_lazy as _  # noqa: E402
+from mock import patch                                  # noqa: E402
+
+from tcms.tests.factories import UserFactory            # noqa: E402
+from tcms.bugs.tests.factory import BugFactory          # noqa: E402
 
 
 class TestSendMailOnAssigneeChange(TestCase):

--- a/tcms/bugs/tests/test_permissions.py
+++ b/tcms/bugs/tests/test_permissions.py
@@ -1,9 +1,17 @@
-from django.urls import reverse
-from django.utils.translation import gettext_lazy as _
+# pylint: disable=wrong-import-position
+import unittest
 
-from tcms import tests
-from tcms.bugs.models import Bug
-from tcms.tests import factories
+from django.conf import settings
+
+if 'tcms.bugs.apps.AppConfig' not in settings.INSTALLED_APPS:
+    raise unittest.SkipTest('tcms.bugs is disabled')
+
+from django.urls import reverse                         # noqa: E402
+from django.utils.translation import gettext_lazy as _  # noqa: E402
+
+from tcms import tests            # noqa: E402
+from tcms.bugs.models import Bug  # noqa: E402
+from tcms.tests import factories  # noqa: E402
 
 
 class TestNew(tests.PermissionsTestCase):

--- a/tcms/bugs/tests/test_views.py
+++ b/tcms/bugs/tests/test_views.py
@@ -1,11 +1,19 @@
-# pylint: disable=too-many-ancestors
-from django.urls import reverse
-from django.utils.translation import gettext_lazy as _
+# pylint: disable=too-many-ancestors,wrong-import-position
 
-from tcms.tests import BaseCaseRun, user_should_have_perm
-from tcms.tests.factories import BugFactory
-from tcms.utils.permissions import initiate_user_with_default_setups
-from tcms.core.templatetags.extra_filters import markdown2html
+import unittest
+
+from django.conf import settings
+
+if 'tcms.bugs.apps.AppConfig' not in settings.INSTALLED_APPS:
+    raise unittest.SkipTest('tcms.bugs is disabled')
+
+from django.urls import reverse                         # noqa: E402
+from django.utils.translation import gettext_lazy as _  # noqa: E402
+
+from tcms.core.templatetags.extra_filters import markdown2html        # noqa: E402
+from tcms.bugs.tests.factory import BugFactory                        # noqa: E402
+from tcms.tests import BaseCaseRun, user_should_have_perm             # noqa: E402
+from tcms.utils.permissions import initiate_user_with_default_setups  # noqa: E402
 
 
 class TestBugStatusChange(BaseCaseRun):

--- a/tcms/core/tests/test_admin.py
+++ b/tcms/core/tests/test_admin.py
@@ -40,10 +40,10 @@ class TestAdminView(LoggedInTestCase):
         self.assertContains(response, 'Tags')
         self.assertContains(response, 'Versions')
 
-        # for tcms.bugs
-        self.assertContains(response, '<a href="/admin/bugs/" class="grp-section">%s</a>' %
-                            _('Bugs'), html=True)
-        self.assertContains(response, '<strong>Bugs</strong>', html=True)
+        if 'tcms.bugs.apps.AppConfig' in settings.INSTALLED_APPS:
+            self.assertContains(response, '<a href="/admin/bugs/" class="grp-section">%s</a>' %
+                                _('Bugs'), html=True)
+            self.assertContains(response, '<strong>Bugs</strong>', html=True)
 
         # for tcms.testcases
         self.assertContains(response, 'Bug trackers')

--- a/tcms/issuetracker/types.py
+++ b/tcms/issuetracker/types.py
@@ -19,7 +19,11 @@ from tcms.issuetracker import (bugzilla_integration, github_integration,
                                gitlab_integration, jira_integration,
                                redmine_integration)
 from tcms.issuetracker.base import IssueTrackerType
-from tcms.issuetracker.kiwitcms import KiwiTCMS  # noqa, pylint: disable=unused-import
+
+
+# conditional import b/c this App can be disabled
+if 'tcms.bugs.apps.AppConfig' in settings.INSTALLED_APPS:
+    from tcms.issuetracker.kiwitcms import KiwiTCMS  # noqa, pylint: disable=unused-import
 
 
 def from_name(name):

--- a/tcms/rpc/api/testexecution.py
+++ b/tcms/rpc/api/testexecution.py
@@ -1,17 +1,26 @@
 # -*- coding: utf-8 -*-
 
+from django.conf import settings
 from django.forms.models import model_to_dict
 from modernrpc.core import REQUEST_KEY, rpc_method
 
 from tcms.core.contrib.linkreference.models import LinkReference
 from tcms.core.helpers import comments
 from tcms.core.utils import form_errors_to_list
-from tcms.issuetracker.kiwitcms import KiwiTCMS
 from tcms.rpc.api.forms.testrun import NewExecutionForm, UpdateExecutionForm
 from tcms.rpc.api.utils import tracker_from_url
 from tcms.rpc.decorators import permissions_required
 from tcms.rpc.serializer import Serializer
 from tcms.testruns.models import TestExecution
+
+
+# conditional import b/c this App can be disabled
+if 'tcms.bugs.apps.AppConfig' in settings.INSTALLED_APPS:
+    from tcms.issuetracker.kiwitcms import KiwiTCMS
+else:
+    class KiwiTCMS:  # pylint: disable=remove-empty-class,nested-class-found,too-few-public-methods
+        pass
+
 
 __all__ = (
     'create',

--- a/tcms/settings/common.py
+++ b/tcms/settings/common.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-import os.path
+import os
 from importlib import import_module
 
 import pkg_resources
@@ -261,15 +261,18 @@ TENANT_APPS = [
     'modernrpc',
     'simple_history',
 
-    # if you wish to disable Kiwi TCMS bug tracker
-    # comment out the next line
-    'tcms.bugs.apps.AppConfig',
     'tcms.core.contrib.linkreference',
     'tcms.management',
     'tcms.testcases.apps.AppConfig',
     'tcms.testplans.apps.AppConfig',
     'tcms.testruns.apps.AppConfig',
 ]
+
+# if you wish to disable Kiwi TCMS bug tracker
+# define the KIWI_DISABLE_BUGTRACKER ENV variable
+if os.environ.get('KIWI_DISABLE_BUGTRACKER') is None:
+    TENANT_APPS.append('tcms.bugs.apps.AppConfig')
+
 
 INSTALLED_APPS = TENANT_APPS + [
     'grappelli',

--- a/tcms/tests/factories.py
+++ b/tcms/tests/factories.py
@@ -317,16 +317,3 @@ class TestRunCCFactory(DjangoModelFactory):
 
     run = factory.SubFactory(TestRunFactory)
     user = factory.SubFactory(UserFactory)
-
-
-class BugFactory(DjangoModelFactory):
-
-    class Meta:
-        model = 'bugs.Bug'
-
-    summary = factory.Sequence(lambda n: 'Bug %d' % n)
-    reporter = factory.SubFactory(UserFactory)
-    assignee = factory.SubFactory(UserFactory)
-    product = factory.SubFactory(ProductFactory)
-    version = factory.SubFactory(VersionFactory)
-    build = factory.SubFactory(BuildFactory)

--- a/tcms/urls.py
+++ b/tcms/urls.py
@@ -13,7 +13,6 @@ from grappelli import urls as grappelli_urls
 from modernrpc.core import JSONRPC_PROTOCOL, XMLRPC_PROTOCOL
 from modernrpc.views import RPCEntryPoint
 
-from tcms.bugs import urls as bugs_urls
 from tcms.core import ajax
 from tcms.core import views as core_views
 from tcms.kiwi_auth import urls as auth_urls
@@ -39,8 +38,6 @@ urlpatterns = [
         name='ajax.update.cases-actor'),
     url(r'^management/tags/$', ajax.tags, name='ajax-tags'),
 
-    url(r'^bugs/', include(bugs_urls)),
-
     # Account information zone, such as login method
     url(r'^accounts/', include(auth_urls)),
 
@@ -61,6 +58,12 @@ urlpatterns = [
     # https://docs.djangoproject.com/en/2.1/topics/i18n/translation/#django.views.i18n.JavaScriptCatalog
     url(r'^jsi18n/$', JavaScriptCatalog.as_view(), name='javascript-catalog'),
 ]
+
+
+# conditional import b/c this App can be disabled
+if 'tcms.bugs.apps.AppConfig' in settings.INSTALLED_APPS:
+    from tcms.bugs import urls as bugs_urls
+    urlpatterns.append(url(r'^bugs/', include(bugs_urls)))
 
 
 for plugin in pkg_resources.iter_entry_points('kiwitcms.plugins'):


### PR DESCRIPTION
- all tests should be passign with and without this App
- specific tcms.bugs related tests should be skipped when the
  App is not found in INSTALLED_APPS