### PR TITLE
Omit utils/test from coveralls. Fix #1631

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -8,6 +8,7 @@ omit =
     manage.py
     kiwi_lint/*.py
     tcms/settings/test/*
+    tcms/utils/tests/*
     */tests/__init__.py
     */tests.py
     */tests/test_*.py


### PR DESCRIPTION
Omitted the utils/tests from coverage reports.

Not sure if this is the right way. 