### PR TITLE
Add tests for API method tcms.bugs.api.add_tag(). Refs #1597

### DIFF
--- a/tcms/bugs/api.py
+++ b/tcms/bugs/api.py
@@ -14,7 +14,7 @@ __all__ = (
 )
 
 
-@permissions_required('bugs.add_bugtag')
+@permissions_required('bugs.add_bug_tags')
 @rpc_method(name='Bug.add_tag')
 def add_tag(bug_id, tag, **kwargs):
     """
@@ -28,7 +28,7 @@ def add_tag(bug_id, tag, **kwargs):
         :type tag: str
         :param kwargs: Dict providing access to the current request, protocol
                 entry point name and handler instance from the rpc method
-        :raises PermissionDenied: if missing *bugs.add_bugtag* permission
+        :raises PermissionDenied: if missing *bugs.add_bug_tags* permission
         :raises Bug.DoesNotExist: if object specified by PK doesn't exist
         :raises Tag.DoesNotExist: if missing *management.add_tag* permission and *tag*
                  doesn't exist in the database!

--- a/tcms/bugs/tests/test_api.py
+++ b/tcms/bugs/tests/test_api.py
@@ -1,0 +1,48 @@
+# pylint: disable=attribute-defined-outside-init
+# pylint: disable=wrong-import-position
+import unittest
+from xmlrpc.client import Fault as XmlRPCFault
+from xmlrpc.client import ProtocolError
+
+from django.conf import settings
+
+if "tcms.bugs.apps.AppConfig" not in settings.INSTALLED_APPS:
+    raise unittest.SkipTest("tcms.bugs is disabled")
+
+from tcms.bugs.tests.factory import BugFactory                          # noqa: E402
+from tcms.rpc.tests.utils import APITestCase, APIPermissionsTestCase    # noqa: E402
+from tcms.tests.factories import TagFactory                             # noqa: E402
+
+
+class TestAddTagPermissions(APIPermissionsTestCase):
+    """Test Bug.add_tag"""
+
+    permission_label = "bugs.add_bug_tags"
+
+    def _fixture_setup(self):
+        super()._fixture_setup()
+
+        self.bug = BugFactory()
+        self.tag = TagFactory()
+
+    def verify_api_with_permission(self):
+        self.rpc_client.Bug.add_tag(self.bug.pk, self.tag.name)
+        self.assertIn(self.tag, self.bug.tags.all())
+
+    def verify_api_without_permission(self):
+        with self.assertRaisesRegex(ProtocolError, "403 Forbidden"):
+            self.rpc_client.Bug.add_tag(self.bug.pk, self.tag.name)
+
+
+class TestAddTag(APITestCase):
+    """Test Bug.add_tag"""
+
+    def _fixture_setup(self):
+        super()._fixture_setup()
+
+        self.bug = BugFactory()
+        self.tag = TagFactory()
+
+    def test_add_tag_to_non_existent_bug(self):
+        with self.assertRaisesRegex(XmlRPCFault, 'Bug matching query does not exist'):
+            self.rpc_client.Bug.add_tag(-9, self.tag.name)


### PR DESCRIPTION
This PR adds tests for the `add_tag()` api method in `tcms/bugs/api.py` as per #1597