### PR TITLE
Add tests for API method tcms.bugs.api.remove_tag(). Refs #1597

### DIFF
--- a/tcms/bugs/api.py
+++ b/tcms/bugs/api.py
@@ -38,7 +38,7 @@ def add_tag(bug_id, tag, **kwargs):
     Bug.objects.get(pk=bug_id).tags.add(tag)
 
 
-@permissions_required('bugs.delete_bugtag')
+@permissions_required('bugs.delete_bug_tags')
 @rpc_method(name='Bug.remove_tag')
 def remove_tag(bug_id, tag):
     """
@@ -50,7 +50,7 @@ def remove_tag(bug_id, tag):
         :type bug_id: int
         :param tag: Tag name to remove
         :type tag: str
-        :raises PermissionDenied: if missing *bugs.delete_bugtag* permission
+        :raises PermissionDenied: if missing *bugs.delete_bug_tags* permission
         :raises DoesNotExist: if objects specified don't exist
     """
     Bug.objects.get(pk=bug_id).tags.remove(

--- a/tcms/bugs/tests/test_api.py
+++ b/tcms/bugs/tests/test_api.py
@@ -46,3 +46,24 @@ class TestAddTag(APITestCase):
     def test_add_tag_to_non_existent_bug(self):
         with self.assertRaisesRegex(XmlRPCFault, 'Bug matching query does not exist'):
             self.rpc_client.Bug.add_tag(-9, self.tag.name)
+
+
+class TestRemoveTagPermissions(APIPermissionsTestCase):
+    """Test Bug.remove_tag"""
+
+    permission_label = "bugs.delete_bug_tags"
+
+    def _fixture_setup(self):
+        super()._fixture_setup()
+
+        self.bug = BugFactory()
+        self.tag = TagFactory()
+        self.bug.tags.add(self.tag)
+
+    def verify_api_with_permission(self):
+        self.rpc_client.Bug.remove_tag(self.bug.pk, self.tag.name)
+        self.assertNotIn(self.tag, self.bug.tags.all())
+
+    def verify_api_without_permission(self):
+        with self.assertRaisesRegex(ProtocolError, "403 Forbidden"):
+            self.rpc_client.Bug.remove_tag(self.bug.pk, self.tag.name)


### PR DESCRIPTION
This PR adds tests for the `remove_tag()` api method in `tcms/bugs/api.py` as per #1597