### PR TITLE
Add tests for presense of mysql/psql binaries in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM centos:centos8
 
-RUN dnf -y --setopt=tsflags=nodocs install python3 mariadb-connector-c postgresql \
+RUN dnf -y --setopt=tsflags=nodocs install python3 mariadb mariadb-connector-c postgresql \
     httpd python3-mod_wsgi mod_ssl sscg && \
     dnf clean all
 

--- a/tests/runner.sh
+++ b/tests/runner.sh
@@ -15,6 +15,7 @@ fi
 # execute test scripts
 ./tests/test_docker.sh
 ./tests/test_http.sh
+./tests/test_mysql_psql.sh
 
 
 # look for failures

--- a/tests/test_mysql_psql.sh
+++ b/tests/test_mysql_psql.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+. /usr/share/beakerlib/beakerlib.sh
+
+assert_up_and_running() {
+    sleep 10
+    IP_ADDRESS=`docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' kiwi_web`
+    # both HTTP and HTTPS display the login page
+    rlRun -t -c "curl -k -L -o- https://$IP_ADDRESS:8443/ | grep 'Welcome to Kiwi TCMS'"
+}
+
+rlJournalStart
+    rlPhaseStartSetup
+        # wait for tear-down from previous script b/c
+        # in Travis CI subsequent tests can't find the db host
+        sleep 5
+        rlRun -t -c "docker-compose up -d"
+        sleep 10
+        rlRun -t -c "docker exec -it kiwi_web /Kiwi/manage.py migrate"
+        assert_up_and_running
+    rlPhaseEnd
+
+    rlPhaseStartTest "mysql binary is present"
+        rlRun -t -c "docker exec -u 0 -it kiwi_web mysql --help"
+    rlPhaseEnd
+
+    rlPhaseStartTest "psql binary is present"
+        rlRun -t -c "docker exec -u 0 -it kiwi_web psql --help"
+    rlPhaseEnd
+
+    rlPhaseStartCleanup
+        rlRun -t -c "docker-compose down"
+    rlPhaseEnd
+rlJournalEnd
+
+rlJournalPrintText


### PR DESCRIPTION
because we tend to install only the libraries for the DB drivers.

Last time when we switched to MariaDB 10.3 we broke this!

These binaries are the main DB cli tool which is also used by
`manage.py dbshell`, which in turn is referenced in some use-cases
around truncating and restoring data into existing databases!