### PR TITLE
Disable VinaigretteAdminLanguageMiddleware => translated Admin

### DIFF
--- a/docs/source/admin.rst
+++ b/docs/source/admin.rst
@@ -335,11 +335,11 @@ For this purpose the following fields are available:
 
   .. note::
 
-      Status names in Admin will always appear in English!
-      For statuses shipped with Kiwi TCMS by default the names may appear
-      translated into local language when displayed outside Admin pages!
+      For statuses shipped with Kiwi TCMS the names may appear translated
+      into local language! If you change these default names they will
+      appear untranslated!
 
-      Translation of non-default statuses is currently almost impossible,
+      Translation of non-default names is currently not straight forward,
       see https://github.com/ecometrica/django-vinaigrette/issues/45.
 
 - **Color** - a color to be used for icons, charts, etc.

--- a/tcms/settings/common.py
+++ b/tcms/settings/common.py
@@ -130,7 +130,6 @@ MIDDLEWARE = [
     'global_login_required.GlobalLoginRequiredMiddleware',
     'simple_history.middleware.HistoryRequestMiddleware',
     'tcms.core.middleware.CheckSettingsMiddleware',
-    'vinaigrette.middleware.VinaigretteAdminLanguageMiddleware',
 ]
 
 


### PR DESCRIPTION
our Admin interface only shows TestExecutionStatus objects which
also use vinaigrette for translating model fields. We don't really
need to disable the translation of the entire Admin panel because
of 1 model.

In any case if users modify the default values for
TestExecutionStatus they will appear untranslated.