### PR TITLE
Alert on JSON-RPC error. Closes #625, #1333

### DIFF
--- a/tcms/static/js/jsonrpc.js
+++ b/tcms/static/js/jsonrpc.js
@@ -19,7 +19,11 @@ function jsonRPC(rpc_method, rpc_params, callback, is_sync) {
       dataType:"json",
       contentType: "application/json",
       success: function (result) {
-            callback(result.result);
+            if (result.error) {
+                alert(result.error.message);
+            } else {
+                callback(result.result);
+            }
       },
       error: function (err,status,thrown) {
              console.log("*** jsonRPC ERROR: " + err + " STATUS: " + status + " " + thrown );


### PR DESCRIPTION
if for some reason an RPC call doesn't return a result but ends
in an error (an exception on the server side) then alert the user
about what happened.  This makes problems more visible instead of
silently hiding them.