### PR TITLE
 Enable pylint plugin pylint.extensions.docparams and resolve errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ check: flake8 test
 .PHONY: pylint
 pylint:
 	pylint -d missing-docstring *.py kiwi_lint/
-	PYTHONPATH=.:./tcms/ DJANGO_SETTINGS_MODULE=$(DJANGO_SETTINGS_MODULE) pylint --load-plugins=pylint_django --load-plugins=kiwi_lint -d missing-docstring -d duplicate-code tcms/ tcms_settings_dir/
+	PYTHONPATH=.:./tcms/ DJANGO_SETTINGS_MODULE=$(DJANGO_SETTINGS_MODULE) pylint --load-plugins=pylint_django --load-plugins=kiwi_lint --load-plugins=pylint.extensions.docparams -d missing-docstring -d duplicate-code tcms/ tcms_settings_dir/
 
 .PHONY: bandit
 bandit:

--- a/tcms/bugs/api.py
+++ b/tcms/bugs/api.py
@@ -26,10 +26,11 @@ def add_tag(bug_id, tag, **kwargs):
         :type bug_id: int
         :param tag: Tag name to add
         :type tag: str
-        :return: None
-        :raises: PermissionDenied if missing *bugs.add_bugtag* permission
-        :raises: Bug.DoesNotExist if object specified by PK doesn't exist
-        :raises: Tag.DoesNotExist if missing *management.add_tag* permission and *tag*
+        :param kwargs: Dict providing access to the current request, protocol
+                entry point name and handler instance from the rpc method
+        :raises PermissionDenied: if missing *bugs.add_bugtag* permission
+        :raises Bug.DoesNotExist: if object specified by PK doesn't exist
+        :raises Tag.DoesNotExist: if missing *management.add_tag* permission and *tag*
                  doesn't exist in the database!
     """
     request = kwargs.get(REQUEST_KEY)
@@ -49,9 +50,8 @@ def remove_tag(bug_id, tag):
         :type bug_id: int
         :param tag: Tag name to remove
         :type tag: str
-        :return: None
-        :raises: PermissionDenied if missing *bugs.delete_bugtag* permission
-        :raises: DoesNotExist if objects specified don't exist
+        :raises PermissionDenied: if missing *bugs.delete_bugtag* permission
+        :raises DoesNotExist: if objects specified don't exist
     """
     Bug.objects.get(pk=bug_id).tags.remove(
         Tag.objects.get(name=tag)
@@ -68,8 +68,7 @@ def remove(query):
 
         :param query: Field lookups for :class:`tcms.bugs.models.Bug`
         :type query: dict
-        :return: None
-        :raises: PermissionDenied if missing *bugs.delete_bugtag* permission
+        :raises PermissionDenied: if missing *bugs.delete_bugtag* permission
     """
     Bug.objects.filter(**query).delete()
 
@@ -84,6 +83,7 @@ def filter(query):  # pylint: disable=redefined-builtin
         :param query: Field lookups for :class:`tcms.bugs.models.Bug`
         :type query: dict
         :return: List of serialized :class:`tcms.bugs.models.Bug` objects.
+        :rtype: list
     """
     result = Bug.objects.filter(**query).values(
         'pk',

--- a/tcms/issuetracker/base.py
+++ b/tcms/issuetracker/base.py
@@ -15,9 +15,13 @@ class IntegrationThread(threading.Thread):
     def __init__(self, rpc, bug_system, execution, bug_id):
         """
             :param rpc: Bug tracker RPC object
+            :type rpc: object
             :param bug_system: BugSystem object
+            :type bug_system: :class:`tcms.testcases.models.BugSystem`
             :param execution: TestExecution object
+            :type execution: :class:`tcms.testruns.models.TestExecution`
             :param bug_id: Unique defect identifier in the system. Usually an int.
+            :type bug_id: int or str
         """
         self.rpc = rpc
         self.bug_system = bug_system
@@ -162,7 +166,8 @@ class IssueTrackerType:
             When is linking a TC to a Bug report disabled?
             Usually when not all of the required credentials are provided.
 
-            :return: bool
+            :return: True if bug system api url, username and password are provided
+            :rtype: bool
         """
         return not (self.bug_system.api_url
                     and self.bug_system.api_username

--- a/tcms/rpc/api/attachment.py
+++ b/tcms/rpc/api/attachment.py
@@ -20,8 +20,9 @@ def remove_attachment(attachment_id, **kwargs):
 
         :param attachment_id: PK of attachment to remove
         :type attachment_id: int
-        :return: None
-        :raises: Exception if attachment doesn't exist,
+        :param kwargs: Dict providing access to the current request, protocol
+                entry point name and handler instance from the rpc method
+        :raises Exception: if attachment doesn't exist,
                  InternalError or removal fails
     """
     request = kwargs.get(REQUEST_KEY)

--- a/tcms/rpc/api/auth.py
+++ b/tcms/rpc/api/auth.py
@@ -21,6 +21,8 @@ def login(username, password, **kwargs):
         :type username: str
         :param password: The password
         :type password: str
+        :param kwargs: Dict providing access to the current request, protocol
+                entry point name and handler instance from the rpc method
         :return: Session ID
         :rtype: str
         :raises PermissionDenied: if username or password doesn't match or missing
@@ -45,8 +47,6 @@ def logout(**kwargs):
     .. function:: XML-RPC Auth.logout()
 
         Delete session information
-
-        :return: None
     """
     # Get the current request
     request = kwargs.get(REQUEST_KEY)

--- a/tcms/rpc/api/bug.py
+++ b/tcms/rpc/api/bug.py
@@ -49,6 +49,8 @@ def report(execution_id, tracker_id, **kwargs):
         :type execution_id: int
         :param tracker_id: PK for :class:`tcms.testcases.models.BugSystem` object
         :type tracker_id: int
+        :param kwargs: Dict providing access to the current request, protocol
+                entry point name and handler instance from the rpc method
         :return: Success response with bug URL or failure message
         :rtype: dict
     """

--- a/tcms/rpc/api/build.py
+++ b/tcms/rpc/api/build.py
@@ -43,7 +43,7 @@ def create(values):
         :type values: dict
         :return: Serialized :class:`tcms.management.models.Build` object
         :rtype: dict
-        :raises: ValueError if product or name not specified
+        :raises ValueError: if product or name not specified
         :raises: PermissionDenied if missing *management.add_build* permission
     """
     if not values.get('product') or not values.get('name'):

--- a/tcms/rpc/api/component.py
+++ b/tcms/rpc/api/component.py
@@ -42,6 +42,8 @@ def create(values, **kwargs):
 
         :param values: Field values for :class:`tcms.management.models.Component`
         :type values: dict
+        :param kwargs: Dict providing access to the current request, protocol
+                entry point name and handler instance from the rpc method
         :return: Serialized :class:`tcms.management.models.Component` object
         :rtype: dict
         :raises: PermissionDenied if missing *management.add_component* permission
@@ -89,8 +91,8 @@ def update(component_id, values):
         :type values: dict
         :return: Serialized :class:`tcms.management.models.Component` object
         :rtype: dict
-        :raises: ValueError if ``name`` is missing or empty string
-        :raises: PermissionDenied if missing *management.change_component* permission
+        :raises ValueError: if ``name`` is missing or empty string
+        :raises PermissionDenied: if missing *management.change_component* permission
     """
     if not isinstance(values, dict) or 'name' not in values:
         raise ValueError('Component name is not in values {0}.'.format(values))

--- a/tcms/rpc/api/testcase.py
+++ b/tcms/rpc/api/testcase.py
@@ -49,9 +49,10 @@ def add_component(case_id, component):
         :param component: Name of Component to add
         :type component: str
         :return: Serialized :class:`tcms.testcases.models.TestCase` object
-        :raises: PermissionDenied if missing the *testcases.add_testcasecomponent*
+        :rtype: dict
+        :raises PermissionDenied: if missing the *testcases.add_testcasecomponent*
                  permission
-        :raises: DoesNotExist if missing test case or component that match the
+        :raises DoesNotExist: if missing test case or component that match the
                  specified PKs
     """
     case = TestCase.objects.get(pk=case_id)
@@ -93,10 +94,9 @@ def remove_component(case_id, component_id):
         :type case_id: int
         :param component_id: PK of Component to remove
         :type component_id: int
-        :return: None
-        :raises: PermissionDenied if missing the *testcases.delete_testcasecomponent*
+        :raises PermissionDenied: if missing the *testcases.delete_testcasecomponent*
                  permission
-        :raises: DoesNotExist if missing test case or component that match the
+        :raises DoesNotExist: if missing test case or component that match the
                  specified PKs
     """
     TestCase.objects.get(pk=case_id).remove_component(
@@ -111,8 +111,7 @@ def _validate_cc_list(cc_list):
 
         :param cc_list: List of email addresses
         :type cc_list: list
-        :return: None
-        :raises: TypeError or ValidationError if addresses are not valid.
+        :raises TypeError or ValidationError: if addresses are not valid.
     """
 
     if not isinstance(cc_list, list):
@@ -142,13 +141,12 @@ def add_notification_cc(case_id, cc_list):
         Add email addresses to the notification list of specified TestCase
 
         :param case_id: PK of TestCase to be modified
-        :param case_id: int
+        :type case_id: int
         :param cc_list: List of email addresses
         :type cc_list: list(str)
-        :return: None
-        :raises: TypeError or ValidationError if email validation fails
-        :raises: PermissionDenied if missing *testcases.change_testcase* permission
-        :raises: TestCase.DoesNotExist if object with case_id doesn't exist
+        :raises TypeError or ValidationError: if email validation fails
+        :raises PermissionDenied: if missing *testcases.change_testcase* permission
+        :raises TestCase.DoesNotExist: if object with case_id doesn't exist
     """
 
     _validate_cc_list(cc_list)
@@ -169,10 +167,9 @@ def remove_notification_cc(case_id, cc_list):
         :type case_id: int
         :param cc_list: List of email addresses
         :type cc_list: list(str)
-        :return: None
-        :raises: TypeError or ValidationError if email validation fails
-        :raises: PermissionDenied if missing *testcases.change_testcase* permission
-        :raises: TestCase.DoesNotExist if object with case_id doesn't exist
+        :raises TypeError or ValidationError: if email validation fails
+        :raises PermissionDenied: if missing *testcases.change_testcase* permission
+        :raises TestCase.DoesNotExist: if object with case_id doesn't exist
     """
 
     _validate_cc_list(cc_list)
@@ -208,10 +205,11 @@ def add_tag(case_id, tag, **kwargs):
         :type case_id: int
         :param tag: Tag name to add
         :type tag: str
-        :return: None
-        :raises: PermissionDenied if missing *testcases.add_testcasetag* permission
-        :raises: TestCase.DoesNotExist if object specified by PK doesn't exist
-        :raises: Tag.DoesNotExist if missing *management.add_tag* permission and *tag*
+        :param kwargs: Dict providing access to the current request, protocol
+                entry point name and handler instance from the rpc method
+        :raises PermissionDenied: if missing *testcases.add_testcasetag* permission
+        :raises TestCase.DoesNotExist: if object specified by PK doesn't exist
+        :raises Tag.DoesNotExist: if missing *management.add_tag* permission and *tag*
                  doesn't exist in the database!
     """
     request = kwargs.get(REQUEST_KEY)
@@ -231,9 +229,8 @@ def remove_tag(case_id, tag):
         :type case_id: int
         :param tag: Tag name to remove
         :type tag: str
-        :return: None
-        :raises: PermissionDenied if missing *testcases.delete_testcasetag* permission
-        :raises: DoesNotExist if objects specified don't exist
+        :raises PermissionDenied: if missing *testcases.delete_testcasetag* permission
+        :raises DoesNotExist: if objects specified don't exist
     """
     TestCase.objects.get(pk=case_id).remove_tag(
         Tag.objects.get(name=tag)
@@ -250,9 +247,12 @@ def create(values, **kwargs):
 
         :param values: Field values for :class:`tcms.testcases.models.TestCase`
         :type values: dict
+        :param kwargs: Dict providing access to the current request, protocol
+                entry point name and handler instance from the rpc method
         :return: Serialized :class:`tcms.testcases.models.TestCase` object
         :rtype: dict
-        :raises: PermissionDenied if missing *testcases.add_testcase* permission
+        :raises ValueError: if form is not valid
+        :raises PermissionDenied: if missing *testcases.add_testcase* permission
 
         Minimal test case parameters::
 
@@ -312,8 +312,9 @@ def update(case_id, values):
         :type values: dict
         :return: Serialized :class:`tcms.testcases.models.TestCase` object
         :rtype: dict
-        :raises: TestCase.DoesNotExist if object specified by PK doesn't exist
-        :raises: PermissionDenied if missing *testcases.change_testcase* permission
+        :raises ValueError: if form is not valid
+        :raises TestCase.DoesNotExist: if object specified by PK doesn't exist
+        :raises PermissionDenied: if missing *testcases.change_testcase* permission
     """
     test_case = TestCase.objects.get(pk=case_id)
     form = UpdateForm(values, instance=test_case)
@@ -336,8 +337,10 @@ def remove(query):
 
         :param query: Field lookups for :class:`tcms.testcases.models.TestCase`
         :type query: dict
-        :return: None
         :raises: PermissionDenied if missing the *testcases.delete_testcase* permission
+        :return: The number of objects deleted and a dictionary with the
+                 number of deletions per object type.
+        :rtype: int, dict
 
         Example - removing bug from TestCase::
 
@@ -358,6 +361,8 @@ def list_attachments(case_id, **kwargs):
 
         :param case_id: PK of TestCase to inspect
         :type case_id: int
+        :param kwargs: Dict providing access to the current request, protocol
+                entry point name and handler instance from the rpc method
         :return: A list containing information and download URLs for attachements
         :rtype: list
         :raises: TestCase.DoesNotExit if object specified by PK is missing
@@ -381,7 +386,8 @@ def add_attachment(case_id, filename, b64content, **kwargs):
         :type filename: str
         :param b64content: Base64 encoded content
         :type b64content: str
-        :return: None
+        :param kwargs: Dict providing access to the current request, protocol
+                entry point name and handler instance from the rpc method
     """
     utils.add_attachment(
         case_id,
@@ -400,11 +406,12 @@ def add_comment(case_id, comment, **kwargs):
         Add comment to selected test case.
 
         :param case_id: PK of a TestCase object
-        :param case_id: int
+        :type case_id: int
         :param comment: The text to add as a comment
-        :param comment: str
-        :return: None or JSON string in case of errors
-        :raises: PermissionDenied if missing *django_comments.add_comment* permission
+        :type comment: str
+        :param kwargs: Dict providing access to the current request, protocol
+                entry point name and handler instance from the rpc method
+        :raises PermissionDenied: if missing *django_comments.add_comment* permission
 
         .. important::
 
@@ -423,11 +430,10 @@ def remove_comment(case_id, comment_id=None):
         Remove all or specified comment(s) from selected test case.
 
         :param case_id: PK of a TestCase object
-        :param case_id: int
+        :type case_id: int
         :param comment_id: PK of a Comment object or None
-        :param comment_id: int
-        :return: None
-        :raises: PermissionDenied if missing *django_comments.delete_comment* permission
+        :type comment_id: int
+        :raises PermissionDenied: if missing *django_comments.delete_comment* permission
     """
     case = TestCase.objects.get(pk=case_id)
     to_be_deleted = comments.get_comments(case)

--- a/tcms/rpc/api/testexecution.py
+++ b/tcms/rpc/api/testexecution.py
@@ -45,11 +45,12 @@ def add_comment(execution_id, comment, **kwargs):
         Add comment to selected test execution.
 
         :param execution_id: PK of a TestExecution object
-        :param execution_id: int
+        :type execution_id: int
         :param comment: The text to add as a comment
-        :param comment: str
-        :return: None or JSON string in case of errors
-        :raises: PermissionDenied if missing *django_comments.add_comment* permission
+        :type comment: str
+        :param kwargs: Dict providing access to the current request, protocol
+                entry point name and handler instance from the rpc method
+        :raises PermissionDenied: if missing *django_comments.add_comment* permission
     """
     execution = TestExecution.objects.get(pk=execution_id)
     comments.add_comment([execution], comment, kwargs.get(REQUEST_KEY).user)
@@ -64,11 +65,10 @@ def remove_comment(execution_id, comment_id=None):
         Remove all or specified comment(s) from selected test execution.
 
         :param execution_id: PK of a TestExecution object
-        :param execution_id: int
+        :type execution_id: int
         :param comment_id: PK of a Comment object or None
-        :param comment_id: int
-        :return: None
-        :raises: PermissionDenied if missing *django_comments.delete_comment* permission
+        :type comment_id: int
+        :raises PermissionDenied: if missing *django_comments.delete_comment* permission
     """
     execution = TestExecution.objects.get(pk=execution_id)
     to_be_deleted = comments.get_comments(execution)
@@ -91,7 +91,11 @@ def create(values):
         :param values: Field values for :class:`tcms.testruns.models.TestExecution`
         :type values: dict
         :return: Serialized :class:`tcms.testruns.models.TestExecution` object
-        :raises: PermissionDenied if missing *testruns.add_testexecution* permission
+        :rtype: dict
+        :raises TypeError: if argument values is not in dict type
+        :raises ValueError: if argument values is empty
+        :raises ValueError: if data validations fail
+        :raises PermissionDenied: if missing *testruns.add_testexecution* permission
 
         Minimal parameters::
 
@@ -154,8 +158,12 @@ def update(execution_id, values, **kwargs):
         :type execution_id: int
         :param values: Field values for :class:`tcms.testruns.models.TestExecution`
         :type values: dict
+        :param kwargs: Dict providing access to the current request, protocol
+                entry point name and handler instance from the rpc method
         :return: Serialized :class:`tcms.testruns.models.TestExecution` object
-        :raises: PermissionDenied if missing *testruns.change_testexecution* permission
+        :rtype: dict
+        :raises ValueError: if data validations fail
+        :raises PermissionDenied: if missing *testruns.change_testexecution* permission
     """
 
     execution = TestExecution.objects.get(pk=execution_id)
@@ -214,7 +222,8 @@ def add_link(values, update_tracker=False):
         :type update_tracker: bool, default=False
         :return: Serialized
                  :class:`tcms.core.contrib.linkreference.models.LinkReference` object
-        :raises: RuntimeError if operation not successfull
+        :rtype: dict
+        :raises RuntimeError: if operation not successfull
 
         .. note::
 
@@ -244,7 +253,6 @@ def remove_link(query):
         :param query: Field lookups for
                       :class:`tcms.core.contrib.linkreference.models.LinkReference`
         :type query: dict
-        :return: None
     """
     LinkReference.objects.filter(**query).delete()
 
@@ -261,6 +269,7 @@ def get_links(query):
         :type query: dict
         :return: Serialized list of :class:`tcms.core.contrib.linkreference.models.LinkReference`
                  objects
+        :rtype: dict
     """
     links = LinkReference.objects.filter(**query)
     serialier = Serializer(links)

--- a/tcms/rpc/api/testplan.py
+++ b/tcms/rpc/api/testplan.py
@@ -36,10 +36,12 @@ def create(values, **kwargs):
 
         :param values: Field values for :class:`tcms.testplans.models.TestPlan`
         :type values: dict
+        :param kwargs: Dict providing access to the current request, protocol
+                entry point name and handler instance from the rpc method
         :return: Serialized :class:`tcms.testplans.models.TestPlan` object
         :rtype: dict
-        :raises: PermissionDenied if missing *testplans.add_testplan* permission
-        :raises: ValueError if data validation fails
+        :raises PermissionDenied: if missing *testplans.add_testplan* permission
+        :raises ValueError: if data validation fails
 
         Minimal parameters::
 
@@ -100,10 +102,11 @@ def add_tag(plan_id, tag_name, **kwargs):
         :type plan_id: int
         :param tag_name: Tag name to add
         :type tag_name: str
-        :return: None
-        :raises: PermissionDenied if missing *testplans.add_testplantag* permission
-        :raises: TestPlan.DoesNotExist if object specified by PK doesn't exist
-        :raises: Tag.DoesNotExist if missing *management.add_tag* permission and *tag_name*
+        :param kwargs: Dict providing access to the current request, protocol
+                entry point name and handler instance from the rpc method
+        :raises PermissionDenied: if missing *testplans.add_testplantag* permission
+        :raises TestPlan.DoesNotExist: if object specified by PK doesn't exist
+        :raises Tag.DoesNotExist: if missing *management.add_tag* permission and *tag_name*
                  doesn't exist in the database!
     """
     request = kwargs.get(REQUEST_KEY)
@@ -123,9 +126,8 @@ def remove_tag(plan_id, tag_name):
         :type plan_id: int
         :param tag_name: Tag name to remove
         :type tag_name: str
-        :return: None
-        :raises: PermissionDenied if missing *testplans.delete_testplantag* permission
-        :raises: DoesNotExist if objects specified don't exist
+        :raises PermissionDenied: if missing *testplans.delete_testplantag* permission
+        :raises DoesNotExist: if objects specified don't exist
     """
     tag = Tag.objects.get(name=tag_name)
     TestPlan.objects.get(pk=plan_id).remove_tag(tag)
@@ -145,9 +147,9 @@ def update(plan_id, values):
         :type values: dict
         :return: Serialized :class:`tcms.testplans.models.TestPlan` object
         :rtype: dict
-        :raises: TestPlan.DoesNotExist if object specified by PK doesn't exist
-        :raises: PermissionDenied if missing *testplans.change_testplan* permission
-        :raises: ValueError if validations fail
+        :raises TestPlan.DoesNotExist: if object specified by PK doesn't exist
+        :raises PermissionDenied: if missing *testplans.change_testplan* permission
+        :raises ValueError: if validations fail
     """
     test_plan = TestPlan.objects.get(pk=plan_id)
     form = EditPlanForm(values, instance=test_plan)
@@ -171,10 +173,9 @@ def add_case(plan_id, case_id):
         :type plan_id: int
         :param case_id: PK of TestCase to be added to plan
         :type case_id: int
-        :return: None
-        :raises: TestPlan.DoesNotExit or TestCase.DoesNotExist if objects specified
+        :raises TestPlan.DoesNotExit or TestCase.DoesNotExist: if objects specified
                  by PKs are missing
-        :raises: PermissionDenied if missing *testcases.add_testcaseplan* permission
+        :raises PermissionDenied: if missing *testcases.add_testcaseplan* permission
     """
     plan = TestPlan.objects.get(pk=plan_id)
     case = TestCase.objects.get(pk=case_id)
@@ -193,8 +194,7 @@ def remove_case(plan_id, case_id):
         :type plan_id: int
         :param case_id: PK of TestCase to be removed from plan
         :type case_id: int
-        :return: None
-        :raises: PermissionDenied if missing *testcases.delete_testcaseplan* permission
+        :raises PermissionDenied: if missing *testcases.delete_testcaseplan* permission
     """
     TestCasePlan.objects.filter(case=case_id, plan=plan_id).delete()
 
@@ -209,9 +209,11 @@ def list_attachments(plan_id, **kwargs):
 
         :param plan_id: PK of TestPlan to inspect
         :type plan_id: int
+        :param kwargs: Dict providing access to the current request, protocol
+                entry point name and handler instance from the rpc method
         :return: A list containing information and download URLs for attachements
         :rtype: list
-        :raises: TestPlan.DoesNotExit if object specified by PK is missing
+        :raises TestPlan.DoesNotExit: if object specified by PK is missing
     """
     plan = TestPlan.objects.get(pk=plan_id)
     request = kwargs.get(REQUEST_KEY)
@@ -232,7 +234,8 @@ def add_attachment(plan_id, filename, b64content, **kwargs):
         :type filename: str
         :param b64content: Base64 encoded content
         :type b64content: str
-        :return: None
+        :param kwargs: Dict providing access to the current request, protocol
+                entry point name and handler instance from the rpc method
     """
     utils.add_attachment(
         plan_id,

--- a/tcms/rpc/api/testrun.py
+++ b/tcms/rpc/api/testrun.py
@@ -35,8 +35,9 @@ def add_case(run_id, case_id):
         :param case_id: PK of TestCase to be added
         :type case_id: int
         :return: Serialized :class:`tcms.testruns.models.TestExecution` object
-        :raises: DoesNotExist if objects specified by the PKs don't exist
-        :raises: PermissionDenied if missing *testruns.add_testexecution* permission
+        :rtype: dict
+        :raises DoesNotExist: if objects specified by the PKs don't exist
+        :raises PermissionDenied: if missing *testruns.add_testexecution* permission
     """
     execution = TestRun.objects.get(pk=run_id).add_case_run(
         case=TestCase.objects.get(pk=case_id)
@@ -56,8 +57,7 @@ def remove_case(run_id, case_id):
         :type run_id: int
         :param case_id: PK of TestCase to be removed
         :type case_id: int
-        :return: None
-        :raises: PermissionDenied if missing *testruns.delete_testexecution* permission
+        :raises PermissionDenied: if missing *testruns.delete_testexecution* permission
     """
     TestExecution.objects.filter(run=run_id, case=case_id).delete()
 
@@ -101,7 +101,10 @@ def add_tag(run_id, tag_name, **kwargs):
         :type run_id: int
         :param tag_name: Tag name to add
         :type tag_name: str
+        :param kwargs: Dict providing access to the current request, protocol
+                entry point name and handler instance from the rpc method
         :return: Serialized list of :class:`tcms.management.models.Tag` objects
+        :rtype: dict
         :raises: PermissionDenied if missing *testruns.add_testruntag* permission
         :raises: TestRun.DoesNotExist if object specified by PK doesn't exist
         :raises: Tag.DoesNotExist if missing *management.add_tag* permission and *tag_name*
@@ -127,6 +130,7 @@ def remove_tag(run_id, tag_name):
         :param tag_name: Tag name to add
         :type tag_name: str
         :return: Serialized list of :class:`tcms.management.models.Tag` objects
+        :rtype: dict
         :raises: PermissionDenied if missing *testruns.delete_testruntag* permission
         :raises: DoesNotExist if objects specified don't exist
     """
@@ -147,8 +151,9 @@ def create(values):
         :param values: Field values for :class:`tcms.testruns.models.TestRun`
         :type values: dict
         :return: Serialized :class:`tcms.testruns.models.TestRun` object
-        :raises: PermissionDenied if missing *testruns.add_testrun* permission
-        :raises: ValueError if data validations fail
+        :rtype: dict
+        :raises PermissionDenied: if missing *testruns.add_testrun* permission
+        :raises ValueError: if data validations fail
 
         Example::
 
@@ -210,8 +215,9 @@ def update(run_id, values):
         :param values: Field values for :class:`tcms.testruns.models.TestRun`
         :type values: dict
         :return: Serialized :class:`tcms.testruns.models.TestRun` object
-        :raises: PermissionDenied if missing *testruns.change_testrun* permission
-        :raises: ValueError if data validations fail
+        :rtype: dict
+        :raises PermissionDenied: if missing *testruns.change_testrun* permission
+        :raises ValueError: if data validations fail
     """
     test_run = TestRun.objects.get(pk=run_id)
     form = UpdateForm(values, instance=test_run)

--- a/tcms/rpc/api/user.py
+++ b/tcms/rpc/api/user.py
@@ -34,6 +34,8 @@ def filter(query=None, **kwargs):  # pylint: disable=redefined-builtin
 
         :param query: Field lookups for :class:`django.contrib.auth.models.User`
         :type query: dict
+        :param kwargs: Dict providing access to the current request, protocol
+                entry point name and handler instance from the rpc method
         :return: Serialized :class:`django.contrib.auth.models.User` object without
                  the password field!
         :rtype: dict
@@ -66,8 +68,11 @@ def update(user_id, values, **kwargs):
         :type user_id: int
         :param values: Field values for :class:`django.contrib.auth.models.User`
         :type values: dict
+        :param kwargs: Dict providing access to the current request, protocol
+                entry point name and handler instance from the rpc method
         :return: Serialized :class:`django.contrib.auth.models.User` object
-        :raises: PermissionDenied if missing the *auth.change_user* permission
+        :rtype: dict
+        :raises PermissionDenied: if missing the *auth.change_user* permission
                  when updating another user or when passwords don't match.
 
         .. note::
@@ -129,8 +134,7 @@ def join_group(username, groupname):
         :type username: str
         :param groupname: Name of group to join, must exist!
         :type groupname: str
-        :return: None
-        :raises: PermissionDenied if missing *auth.change_user* permission
+        :raises PermissionDenied: if missing *auth.change_user* permission
     """
     user = User.objects.get(username=username)
     group = Group.objects.get(name=groupname)

--- a/tcms/rpc/api/version.py
+++ b/tcms/rpc/api/version.py
@@ -38,11 +38,11 @@ def create(values):
         Add new version.
 
         :param values: Field values for :class:`tcms.management.models.Version`
-        :type query: dict
+        :type values: dict
         :return: Serialized :class:`tcms.management.models.Version` object
         :rtype: dict
-        :raises: ValueError if input data validation fails
-        :raises: PermissionDenied if missing *management.add_version* permission
+        :raises ValueError: if input data validation fails
+        :raises PermissionDenied: if missing *management.add_version* permission
 
     Example::
 

--- a/tcms/rpc/serializer.py
+++ b/tcms/rpc/serializer.py
@@ -139,10 +139,12 @@ def _get_related_object_pks(m2m_fields_query, model_pk, field_name):
     Any object pk with value 0 or None values will be excluded in the final
     list.
 
-    :param dict m2m_field_query: the result returned from _query_m2m_fields
+    :param m2m_fields_query: the result returned from _query_m2m_fields
+    :type m2m_fields_query: dict
     :param model_pk: whose object's related object pks will be retrieved
     :type model_pk: int or long
-    :param str field_name: field name of the related object
+    :param field_name: field name of the related object
+    :type field_name: str
     :return: list of related objects' pks
     :rtype: list
     """

--- a/tcms/rpc/utils.py
+++ b/tcms/rpc/utils.py
@@ -95,8 +95,11 @@ def distinct_m2m_rows(cls, values, op_type):
     @type cls: subclass of django.db.models.Model
     @param values: fields in where condition.
     @type values: dict
+    @param op_type:
+    @type op_type: int
     @return: QuerySet
-    @rtype: django.db.models.query.QuerySet
+    @rtype: :class:`django.db.models.query.QuerySet`
+    @raises TypeError:
     """
     flag = False
     for field in values.keys():

--- a/tcms/testcases/views.py
+++ b/tcms/testcases/views.py
@@ -117,7 +117,11 @@ def calculate_for_testcases(plan, testcases):
 
     :param plan: the TestPlan containing searched TestCases. None means testcases
                  are not limited to a specific TestPlan.
+    :type plan: :class:`tcms.testplans.models.TestPlan`
     :param testcases: a queryset of TestCases.
+    :type testcases: :class:`django.db.models.query.QuerySet`
+    :return: testcases
+    :rtype: :class:`django.db.models.query.QuerySet`
     """
     tc_ids = []
     for test_case in testcases:
@@ -182,11 +186,14 @@ def build_cases_search_form(request, populate=None, plan=None):
 def paginate_testcases(request, testcases):  # pylint: disable=missing-permission-required
     """Paginate queried TestCases
 
-    Arguments:
-    - request: django's HttpRequest from which to get pagination data
-    - testcases: an object queryset representing already queried TestCases
+    :param request: django's HttpRequest from which to get pagination data
+    :type request: :class:`django.http.HttpRequest`
 
-    Return value: return the queryset for chain call
+    :param testcases: an object queryset representing already queried TestCases
+    :type testcases: :class:`django.db.models.query.QuerySet`
+
+    :return: the queryset for chain call
+    :rtype: :class:`django.db.models.query.QuerySet`
     """
 
     page_index = int(request.POST.get('page_index', 1))
@@ -203,9 +210,14 @@ def paginate_testcases(request, testcases):  # pylint: disable=missing-permissio
 def sort_queried_testcases(request, testcases):  # pylint: disable=missing-permission-required
     """Sort querid TestCases according to sort key
 
-    Arguments:
-    - request: REQUEST object
-    - testcases: object of QuerySet containing queried TestCases
+    :param request: django's HttpRequest
+    :type request: :class:`django.http.HttpRequest`
+
+    :param testcases: an object queryset representing already queried TestCases
+    :type testcases: :class:`django.db.models.query.QuerySet`
+
+    :return: Queryset with testcases
+    :rtype: :class:`django.db.models.query.QuerySet`
     """
     order_by = request.POST.get('order_by', 'create_date')
     asc = bool(request.POST.get('asc', None))
@@ -229,8 +241,14 @@ def query_testcases_from_request(request, plan=None):  # pylint: disable=missing
     """Query TestCases according to criterias coming within REQUEST
 
     :param request: the REQUEST object.
+    :type request: :class:`django.http.HttpRequest`
+
     :param plan: instance of TestPlan to restrict only those TestCases belongs to
                  the TestPlan. Can be None. As you know, query from all TestCases.
+    :type plan: :class:`tcms.testplans.models.TestPlan`
+
+    :return: Queryset with testcases and search form
+    :rtype: :class:`django.db.models.query.QuerySet`, dict
     """
     search_form = build_cases_search_form(request, True, plan)
 
@@ -272,8 +290,11 @@ def get_selected_testcases(request):  # pylint: disable=missing-permission-requi
 
     If neither variables mentioned exists, empty query result is returned.
 
-    Arguments:
-    - request: REQUEST object.
+    :param request: django's HttpRequest
+    :type request: :class:`django.http.HttpRequest`
+
+    :return: Queryset with testcases
+    :rtype: :class:`django.db.models.query.QuerySet`
     """
     method = request.POST or request.GET
     if method.get('selectAll', None):
@@ -310,10 +331,11 @@ def load_more_cases(request,  # pylint: disable=missing-permission-required
 def get_tags_from_cases(case_ids, plan=None):
     """Get all tags from test cases
 
-    @param cases: an iterable object containing test cases' ids
-    @type cases: list, tuple
+    @param case_ids: an iterable object containing test cases' ids
+    @type case_ids: list, tuple
 
     @param plan: TestPlan object
+    @type plan: :class:`tcms.testplans.models.TestPlan`
 
     @return: a list containing all found tags with id and name
     @rtype: list

--- a/tcms/testplans/models.py
+++ b/tcms/testplans/models.py
@@ -108,17 +108,26 @@ class TestPlan(TCMSActionModel):
               new_author=None, set_parent=False, copy_testcases=False, **_kwargs):
         """Clone this plan
 
-        :param str name: New name of cloned plan. If not passed, make_cloned_name is called
+        :param name: New name of cloned plan. If not passed, make_cloned_name is called
             to generate a default one.
+        :type name: str
         :param product: Product of cloned plan. If not passed, original plan's product is used.
+        :type product: :class:`tcms.management.models.Product`
         :param version: Product version of cloned plan. If not passed use from source plan.
+        :type version: :class:`tcms.management.models.Version`
         :param new_author: New author of cloned plan. If not passed, original plan's
             author is used.
-        :param bool set_parent: Whether to set original plan as parent of cloned plan.
+        :type new_author: settings.AUTH_USER_MODEL
+        :param set_parent: Whether to set original plan as parent of cloned plan.
             Default is False.
-        :param bool copy_testcases: Whether to copy cases to cloned plan instead of just
+        :type set_parent: bool
+        :param copy_testcases: Whether to copy cases to cloned plan instead of just
             linking them. Default is False.
-        :rtype: cloned plan
+        :type copy_testcases: bool
+        :param _kwargs: Unused catch-all variable container for any extra input
+            which may be present
+        :return: cloned plan
+        :rtype: :class:`tcms.testplans.models.TestPlan`
         """
         tp_dest = TestPlan.objects.create(
             name=name or self.make_cloned_name(),

--- a/tcms/testplans/views.py
+++ b/tcms/testplans/views.py
@@ -113,12 +113,12 @@ class SearchTestPlanView(TemplateView):  # pylint: disable=missing-permission-re
 def get_number_of_plans_cases(plan_ids):
     """Get the number of cases related to each plan
 
-    Arguments:
-    - plan_ids: a tuple or list of TestPlans' id
+    :param plan_ids: a tuple or list of TestPlans' ids
+    :type plan_ids: list or tuple
 
-    Return value:
-    Return value is an dict object, where key is plan_id and the value is the
-    total count.
+    :return: a dict where key is plan_id and the value is the
+        total count.
+    :rtype: dict
     """
     query_set = TestCasePlan.objects.filter(plan__in=plan_ids).values('plan').annotate(
         total_count=Count('pk')).order_by('-plan')
@@ -133,12 +133,12 @@ def get_number_of_plans_cases(plan_ids):
 def get_number_of_plans_runs(plan_ids):
     """Get the number of runs related to each plan
 
-    Arguments:
-    - plan_ids: a tuple or list of TestPlans' id
+    :param plan_ids: a tuple or list of TestPlans' ids
+    :type plan_ids: list or tuple
 
-    Return value:
-    Return value is an dict object, where key is plan_id and the value is the
-    total count.
+    :return: a dict where key is plan_id and the value is the
+        total count.
+    :rtype: dict
     """
     query_set = TestRun.objects.filter(plan__in=plan_ids).values('plan').annotate(
         total_count=Count('pk')).order_by('-plan')
@@ -152,12 +152,12 @@ def get_number_of_plans_runs(plan_ids):
 def get_number_of_children_plans(plan_ids):
     """Get the number of children plans related to each plan
 
-    Arguments:
-    - plan_ids: a tuple or list of TestPlans' id
+    :param plan_ids: a tuple or list of TestPlans' ids
+    :type plan_ids: list or tuple
 
-    Return value:
-    Return value is an dict object, where key is plan_id and the value is the
-    total count.
+    :return: a dict where key is plan_id and the value is the
+        total count.
+    :rtype: dict
     """
     query_set = TestPlan.objects.filter(parent__in=plan_ids).values('parent').annotate(
         total_count=Count('parent')).order_by('-parent')
@@ -171,12 +171,11 @@ def get_number_of_children_plans(plan_ids):
 def calculate_stats_for_testplans(plans):
     """Attach the number of cases and runs for each TestPlan
 
-    Arguments:
-    - plans: the queryset of TestPlans
-
-    Return value:
-    A list of TestPlans, each of which is attached the statistics which is
-    with prefix cal meaning calculation result.
+    :param plans: the queryset of TestPlans
+    :type plans: dict
+    :return: A list of TestPlans, each of which is attached the statistics which is
+        with prefix cal meaning calculation result.
+    :rtype: list
     """
     plan_ids = []
     for plan in plans:


### PR DESCRIPTION
Resolves #1192. Enable pylint plugin pylint.extensions.docparams and resolve errors

Can I get some clarification on a few things I'm not clear on to complete the doc-params : 

- I'm not quite sure what `op_type` is in:
https://github.com/kiwitcms/Kiwi/blob/dd295479eae3b73bb1b99811c610f5d20657f5ca/tcms/rpc/utils.py#L90
and why its used here and why the TypeError is raised.

- I'm not familiar with how to document kwargs in docparams. May I please get a sample to go off on, for example in:
https://github.com/kiwitcms/Kiwi/blob/dd295479eae3b73bb1b99811c610f5d20657f5ca/tcms/rpc/api/auth.py#L14