### PR TITLE
Add tests for tcms.bugs.views.New -- Refs #1598

### DIFF
--- a/tcms/bugs/tests/test_views.py
+++ b/tcms/bugs/tests/test_views.py
@@ -11,8 +11,20 @@ from django.urls import reverse                         # noqa: E402
 from django.utils.translation import gettext_lazy as _  # noqa: E402
 
 from tcms.core.templatetags.extra_filters import markdown2html        # noqa: E402
+from tcms.bugs.models import Bug                                      # noqa: E402
 from tcms.bugs.tests.factory import BugFactory                        # noqa: E402
-from tcms.tests import BaseCaseRun, user_should_have_perm             # noqa: E402
+from tcms.tests import (                                              # noqa: E402
+    BaseCaseRun,
+    LoggedInTestCase,
+    user_should_have_perm
+)
+from tcms.tests.factories import (                                    # noqa: E402
+    BuildFactory,
+    ComponentFactory,
+    ProductFactory,
+    UserFactory,
+    VersionFactory
+)
 from tcms.utils.permissions import initiate_user_with_default_setups  # noqa: E402
 
 
@@ -68,3 +80,62 @@ class TestBugStatusChange(BaseCaseRun):
         self.assertRedirects(response, redirect_url)
         bug.refresh_from_db()
         self.assertTrue(bug.status)
+
+
+class TestNewBug(LoggedInTestCase):
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        user_should_have_perm(cls.tester, 'bugs.add_bug')
+
+        cls.url = reverse('bugs-new')
+
+        cls.summary = 'A shiny new bug!'
+        cls.product = ProductFactory()
+        cls.version = VersionFactory(product=cls.product)
+        cls.build = BuildFactory(product=cls.product)
+        cls.post_data = {
+            'summary': cls.summary,
+            'reporter': cls.tester.pk,
+            'product': cls.product.pk,
+            'version': cls.version.pk,
+            'build': cls.version.pk,
+        }
+
+    def test_get_view(self):
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context['page_title'], _('New bug'))
+        self.assertEqual(response.context['form_post_url'], reverse('bugs-new'))
+        self.assertTemplateUsed(response, 'bugs/mutable.html')
+
+        form = response.context['form']
+        self.assertEqual(form.initial['reporter'].pk, self.tester.pk)
+        self.assertEqual(form.fields['version'].queryset.count(), 0)
+        self.assertEqual(form.fields['build'].queryset.count(), 0)
+
+    def test_create_new_bug(self):
+        initial_bug_count = Bug.objects.count()
+
+        response = self.client.post(self.url, self.post_data)
+
+        bug_created = Bug.objects.last()
+        self.assertRedirects(
+            response,
+            reverse('bugs-get', args=(bug_created.pk,)),
+            status_code=302,
+            target_status_code=200
+        )
+        self.assertEqual(Bug.objects.count(), initial_bug_count + 1)
+        self.assertEqual(bug_created.summary, self.summary)
+
+    def test_new_bug_assignee_inferred_from_components(self):
+        comp = ComponentFactory(initial_owner=UserFactory(), product=self.product)
+
+        self.client.post(self.url, self.post_data, follow=True)
+
+        bug_created = Bug.objects.last()
+        self.assertEqual(bug_created.summary, self.summary)
+        self.assertEqual(bug_created.assignee, comp.initial_owner)


### PR DESCRIPTION
This PR adds (non-permissions related) tests for the view `New` in tcms/bugs/views.py as per #1598

* Permissions related tests already exists in tcms/bugs/tests/test_permissions.py