### PR TITLE
Replace bleach-whitelist with bleach-allowlist. Closes #1813

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,6 +1,7 @@
 -r tarballs.txt
 
 bleach==3.1.5
+bleach-allowlist==1.0.2
 Django==3.0.9
 django-attachments==1.5
 django-contrib-comments==1.9.2

--- a/requirements/tarballs.txt
+++ b/requirements/tarballs.txt
@@ -1,6 +1,5 @@
 # these do not provide wheel packages
 
-bleach-whitelist==0.0.10
 django-glrm==1.1.3
 django-grappelli==2.14.2
 django-uuslug==1.2.0

--- a/tcms/core/templatetags/extra_filters.py
+++ b/tcms/core/templatetags/extra_filters.py
@@ -4,7 +4,7 @@
 
 import bleach
 import markdown
-from bleach_whitelist import markdown_attrs, markdown_tags, print_tags
+from bleach_allowlist import markdown_attrs, markdown_tags, print_tags
 from django import template
 from django.contrib.messages import constants as messages
 from django.utils.safestring import mark_safe


### PR DESCRIPTION
bleach-whitelist 0.0.11 has been deprecated and the package has
been renamed