### PR TITLE
Fix linter errors in migrations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ check: flake8 test
 .PHONY: pylint
 pylint:
 	pylint -d missing-docstring *.py kiwi_lint/
-	PYTHONPATH=.:./tcms/ DJANGO_SETTINGS_MODULE=$(DJANGO_SETTINGS_MODULE) pylint --load-plugins=pylint_django.checkers.migrations -d missing-docstring -d duplicate-code  tcms/*/migrations/*
+	PYTHONPATH=.:./tcms/ DJANGO_SETTINGS_MODULE=$(DJANGO_SETTINGS_MODULE) pylint --load-plugins=pylint_django.checkers.migrations -d missing-docstring -d duplicate-code --module-naming-style=any  tcms/*/migrations/*
 	PYTHONPATH=.:./tcms/ DJANGO_SETTINGS_MODULE=$(DJANGO_SETTINGS_MODULE) pylint --load-plugins=pylint_django --load-plugins=kiwi_lint --load-plugins=pylint.extensions.docparams -d missing-docstring -d duplicate-code tcms/ tcms_settings_dir/
 
 .PHONY: bandit

--- a/tcms/bugs/migrations/0002_add_permissions.py
+++ b/tcms/bugs/migrations/0002_add_permissions.py
@@ -7,19 +7,19 @@ def forwards_add_perms(apps, schema_editor):
         This is useful in case that is an existing installation
         upgrading post 7.0.
     """
-    Group = apps.get_model('auth', 'Group')
-    Permission = apps.get_model('auth', 'Permission')
+    group_model = apps.get_model('auth', 'Group')
+    permission_model = apps.get_model('auth', 'Permission')
 
-    tester = Group.objects.get(name='Tester')
-    app_perms = Permission.objects.filter(content_type__app_label__contains='bugs')
+    tester = group_model.objects.get(name='Tester')
+    app_perms = permission_model.objects.filter(content_type__app_label__contains='bugs')
     tester.permissions.add(*app_perms)
 
 
 def backwards(apps, schema_editor):
-    Group = apps.get_model('auth', 'Group')
-    Permission = apps.get_model('auth', 'Permission')
-    tester = Group.objects.get(name='Tester')
-    app_perms = Permission.objects.filter(content_type__app_label__contains='bugs')
+    group_model = apps.get_model('auth', 'Group')
+    permission_model = apps.get_model('auth', 'Permission')
+    tester = group_model.objects.get(name='Tester')
+    app_perms = permission_model.objects.filter(content_type__app_label__contains='bugs')
     tester.permissions.remove(*app_perms)
 
 

--- a/tcms/core/migrations/0001_squashed.py
+++ b/tcms/core/migrations/0001_squashed.py
@@ -4,47 +4,47 @@ from django.db import migrations
 
 
 def forwards_add_initial_data(apps, schema_editor):
-    Group = apps.get_model('auth', 'Group')
-    Group.objects.bulk_create([
-        Group(name='Administrator'),
-        Group(name='Tester'),
+    group_model = apps.get_model('auth', 'Group')
+    group_model.objects.bulk_create([
+        group_model(name='Administrator'),
+        group_model(name='Tester'),
     ])
 
-    Site = apps.get_model('sites', 'Site')
-    Site.objects.create(name='localhost', domain='127.0.0.1:8000')
+    site_model = apps.get_model('sites', 'Site')
+    site_model.objects.create(name='localhost', domain='127.0.0.1:8000')
 
 
 def reverse_remove_initial_data(apps, schema_editor):
-    Group = apps.get_model('auth', 'Group')
-    Group.objects.filter(name__in=['Administrator', 'Tester']).delete()
+    group_model = apps.get_model('auth', 'Group')
+    group_model.objects.filter(name__in=['Administrator', 'Tester']).delete()
 
-    Site = apps.get_model('sites', 'Site')
-    Site.objects.filter(name='localhost').delete()
+    site_model = apps.get_model('sites', 'Site')
+    site_model.objects.filter(name='localhost').delete()
 
 
 def forwards_add_default_perms(apps, schema_editor):
-    Group = apps.get_model('auth', 'Group')
-    Permission = apps.get_model('auth', 'Permission')
+    group_model = apps.get_model('auth', 'Group')
+    permission_model = apps.get_model('auth', 'Permission')
 
-    admin = Group.objects.get(name='Administrator')
-    all_perms = Permission.objects.all()
+    admin = group_model.objects.get(name='Administrator')
+    all_perms = permission_model.objects.all()
     admin.permissions.add(*all_perms)
 
-    tester = Group.objects.get(name='Tester')
+    tester = group_model.objects.get(name='Tester')
     # apply all permissions for test case & product management
     for app_name in ['bugs', 'django_comments', 'management', 'linkreference',
                      'testcases', 'testplans', 'testruns']:
-        app_perms = Permission.objects.filter(content_type__app_label__contains=app_name)
+        app_perms = permission_model.objects.filter(content_type__app_label__contains=app_name)
         tester.permissions.add(*app_perms)
 
 
 def reverse_remove_default_perms(apps, schema_editor):
-    Group = apps.get_model('auth', 'Group')
+    group_model = apps.get_model('auth', 'Group')
 
-    admin = Group.objects.get(name='Administrator')
+    admin = group_model.objects.get(name='Administrator')
     admin.permissions.clear()
 
-    tester = Group.objects.get(name='Tester')
+    tester = group_model.objects.get(name='Tester')
     tester.permissions.clear()
 
 

--- a/tcms/management/migrations/0003_squashed.py
+++ b/tcms/management/migrations/0003_squashed.py
@@ -12,19 +12,19 @@ if settings.DATABASES['default']['ENGINE'].find('sqlite') > -1:
 
 
 def forwards_add_initial_data(apps, schema_editor):
-    Priority = apps.get_model('management', 'Priority')
-    Priority.objects.bulk_create([
-        Priority(value='P1', sortkey=1),
-        Priority(value='P2', sortkey=2),
-        Priority(value='P3', sortkey=3),
-        Priority(value='P4', sortkey=4),
-        Priority(value='P5', sortkey=5),
+    priority_model = apps.get_model('management', 'Priority')
+    priority_model.objects.bulk_create([
+        priority_model(value='P1', sortkey=1),
+        priority_model(value='P2', sortkey=2),
+        priority_model(value='P3', sortkey=3),
+        priority_model(value='P4', sortkey=4),
+        priority_model(value='P5', sortkey=5),
     ])
 
 
 def reverse_remove_initial_data(apps, schema_editor):
-    Priority = apps.get_model('management', 'Priority')
-    Priority.objects.filter(value__in=['P1', 'P2', 'P3', 'P4', 'P5']).delete()
+    priority_model = apps.get_model('management', 'Priority')
+    priority_model.objects.filter(value__in=['P1', 'P2', 'P3', 'P4', 'P5']).delete()
 
 
 class Migration(migrations.Migration):

--- a/tcms/testcases/migrations/0001_initial.py
+++ b/tcms/testcases/migrations/0001_initial.py
@@ -18,13 +18,13 @@ def forwards_add_initial_data(apps, schema_editor):
     bug_system_model = apps.get_model('testcases', 'BugSystem')
     bug_system_model.objects.bulk_create([
         bug_system_model(name='Bugzilla',
-                  description='1-7 digit, e.g. 1001234',
-                  url_reg_exp='https://bugzilla.example.com/show_bug.cgi?id=%s',
-                  validate_reg_exp=r'^\d{1,7}$'),
+                         description='1-7 digit, e.g. 1001234',
+                         url_reg_exp='https://bugzilla.example.com/show_bug.cgi?id=%s',
+                         validate_reg_exp=r'^\d{1,7}$'),
         bug_system_model(name='JIRA',
-                  description='e.g. KIWI-222',
-                  url_reg_exp='https://jira.example.com/browse/%s',
-                  validate_reg_exp=r'^[A-Z0-9]+-\d+$'),
+                         description='e.g. KIWI-222',
+                         url_reg_exp='https://jira.example.com/browse/%s',
+                         validate_reg_exp=r'^[A-Z0-9]+-\d+$'),
     ])
 
     test_case_status_model = apps.get_model('testcases', 'TestCaseStatus')
@@ -209,7 +209,7 @@ class Migration(migrations.Migration):
                 ('history_change_reason', models.TextField(null=True)),
                 ('history_date', models.DateTimeField()),
                 ('history_type', models.CharField(choices=[
-                 ('+', 'Created'), ('~', 'Changed'), ('-', 'Deleted')], max_length=1)),
+                    ('+', 'Created'), ('~', 'Changed'), ('-', 'Deleted')], max_length=1)),
                 ('author', models.ForeignKey(blank=True, db_constraint=False, null=True,
                                              on_delete=models.deletion.DO_NOTHING,
                                              related_name='+',
@@ -281,9 +281,9 @@ class Migration(migrations.Migration):
                                                             'integrates with the IT system',
                                                   verbose_name='Type')),
                 ('base_url', models.CharField(
-                        max_length=1024, null=True, blank=True,
-                        verbose_name='Base URL',
-                        help_text="""Base URL, for example <strong>https://bugzilla.example.com</strong>!
+                    max_length=1024, null=True, blank=True,
+                    verbose_name='Base URL',
+                    help_text="""Base URL, for example <strong>https://bugzilla.example.com</strong>!
 Leave empty to disable!
 """)),
             ],

--- a/tcms/testcases/migrations/0001_initial.py
+++ b/tcms/testcases/migrations/0001_initial.py
@@ -283,7 +283,8 @@ class Migration(migrations.Migration):
                 ('base_url', models.CharField(
                     max_length=1024, null=True, blank=True,
                     verbose_name='Base URL',
-                    help_text="""Base URL, for example <strong>https://bugzilla.example.com</strong>!
+                    help_text="""Base URL, for example\
+ <strong>https://bugzilla.example.com</strong>!
 Leave empty to disable!
 """)),
             ],

--- a/tcms/testcases/migrations/0001_initial.py
+++ b/tcms/testcases/migrations/0001_initial.py
@@ -15,29 +15,29 @@ if settings.DATABASES['default']['ENGINE'].find('sqlite') > -1:
 
 
 def forwards_add_initial_data(apps, schema_editor):
-    BugSystem = apps.get_model('testcases', 'BugSystem')
-    BugSystem.objects.bulk_create([
-        BugSystem(name='Bugzilla',
+    bug_system_model = apps.get_model('testcases', 'BugSystem')
+    bug_system_model.objects.bulk_create([
+        bug_system_model(name='Bugzilla',
                   description='1-7 digit, e.g. 1001234',
                   url_reg_exp='https://bugzilla.example.com/show_bug.cgi?id=%s',
                   validate_reg_exp=r'^\d{1,7}$'),
-        BugSystem(name='JIRA',
+        bug_system_model(name='JIRA',
                   description='e.g. KIWI-222',
                   url_reg_exp='https://jira.example.com/browse/%s',
                   validate_reg_exp=r'^[A-Z0-9]+-\d+$'),
     ])
 
-    TestCaseStatus = apps.get_model('testcases', 'TestCaseStatus')
-    TestCaseStatus.objects.bulk_create(
-        [TestCaseStatus(name=name, description='') for name in test_case_statuss])
+    test_case_status_model = apps.get_model('testcases', 'TestCaseStatus')
+    test_case_status_model.objects.bulk_create(
+        [test_case_status_model(name=name, description='') for name in test_case_statuss])
 
 
 def reverse_add_initial_data(apps, schema_editor):
-    BugSystem = apps.get_model('testcases', 'BugSystem')
-    BugSystem.objects.filter(name__in=['Bugzilla', 'JIRA']).delete()
+    bug_system_model = apps.get_model('testcases', 'BugSystem')
+    bug_system_model.objects.filter(name__in=['Bugzilla', 'JIRA']).delete()
 
-    TestCaseStatus = apps.get_model('testcases', 'TestCaseStatus')
-    TestCaseStatus.objects.filter(name__in=test_case_statuss).delete()
+    test_case_status_model = apps.get_model('testcases', 'TestCaseStatus')
+    test_case_status_model.objects.filter(name__in=test_case_statuss).delete()
 
 
 class Migration(migrations.Migration):

--- a/tcms/testcases/migrations/0006_merge_text_field_into_testcase_model.py
+++ b/tcms/testcases/migrations/0006_merge_text_field_into_testcase_model.py
@@ -14,9 +14,9 @@ def convert_test_case_text(test_case_text):
 **Breakdown:**
 %s
 """ % (test_case_text.setup,
-        test_case_text.action,
-        test_case_text.effect,
-        test_case_text.breakdown)
+       test_case_text.action,
+       test_case_text.effect,
+       test_case_text.breakdown)
 
 
 def forward_copy_data(apps, schema_editor):
@@ -31,8 +31,8 @@ def forward_copy_data(apps, schema_editor):
             test_case.save()
             # b/c the above will not generate history
             history = historical_test_case_model.objects.filter(
-                        case_id=test_case.pk
-                      ).order_by('-history_id').first()
+                case_id=test_case.pk
+                ).order_by('-history_id').first()
             history.case_text = test_case.case_text
             history.save()
 

--- a/tcms/testcases/migrations/0006_merge_text_field_into_testcase_model.py
+++ b/tcms/testcases/migrations/0006_merge_text_field_into_testcase_model.py
@@ -20,17 +20,17 @@ def convert_test_case_text(test_case_text):
 
 
 def forward_copy_data(apps, schema_editor):
-    TestCase = apps.get_model('testcases', 'TestCase')
-    TestCaseText = apps.get_model('testcases', 'TestCaseText')
-    HistoricalTestCase = apps.get_model('testcases', 'HistoricalTestCase')
+    test_case_model = apps.get_model('testcases', 'TestCase')
+    test_case_text_model = apps.get_model('testcases', 'TestCaseText')
+    historical_test_case_model = apps.get_model('testcases', 'HistoricalTestCase')
 
-    for test_case in TestCase.objects.all():
-        latest_text = TestCaseText.objects.filter(case=test_case.pk).order_by('-pk').first()
+    for test_case in test_case_model.objects.all():
+        latest_text = test_case_text_model.objects.filter(case=test_case.pk).order_by('-pk').first()
         if latest_text:
             test_case.case_text = convert_test_case_text(latest_text)
             test_case.save()
             # b/c the above will not generate history
-            history = HistoricalTestCase.objects.filter(
+            history = historical_test_case_model.objects.filter(
                         case_id=test_case.pk
                       ).order_by('-history_id').first()
             history.case_text = test_case.case_text

--- a/tcms/testcases/migrations/0007_convert_is_automated_to_boolean.py
+++ b/tcms/testcases/migrations/0007_convert_is_automated_to_boolean.py
@@ -4,14 +4,14 @@ from django.db import migrations, models
 
 
 def forward_migrate_data(apps, schema_editor):
-    TestCase = apps.get_model('testcases', 'TestCase')
-    HistoricalTestCase = apps.get_model('testcases', 'HistoricalTestCase')
+    test_case_model = apps.get_model('testcases', 'TestCase')
+    historical_test_case_model = apps.get_model('testcases', 'HistoricalTestCase')
 
-    for test_case in TestCase.objects.all():
+    for test_case in test_case_model.objects.all():
         test_case.new_is_automated = test_case.is_automated >= 1
         test_case.save()
 
-    for tc_history in HistoricalTestCase.objects.all():
+    for tc_history in historical_test_case_model.objects.all():
         tc_history.new_is_automated = tc_history.is_automated >= 1
         tc_history.save()
 

--- a/tcms/testcases/migrations/0009_populate_missing_text_history.py
+++ b/tcms/testcases/migrations/0009_populate_missing_text_history.py
@@ -7,8 +7,7 @@ def forward_copy_data(apps, schema_editor):
 
     for test_case in test_case_model.objects.all():
         history = historical_test_case_model.objects.filter(
-                    case_id=test_case.pk
-                  ).order_by('-history_id').first()
+            case_id=test_case.pk).order_by('-history_id').first()
 
         # In 0006_merge_text_field_into_testcase_model we may have
         # failed to save the text into the history record leaving

--- a/tcms/testcases/migrations/0009_populate_missing_text_history.py
+++ b/tcms/testcases/migrations/0009_populate_missing_text_history.py
@@ -2,11 +2,11 @@ from django.db import migrations
 
 
 def forward_copy_data(apps, schema_editor):
-    TestCase = apps.get_model('testcases', 'TestCase')
-    HistoricalTestCase = apps.get_model('testcases', 'HistoricalTestCase')
+    test_case_model = apps.get_model('testcases', 'TestCase')
+    historical_test_case_model = apps.get_model('testcases', 'HistoricalTestCase')
 
-    for test_case in TestCase.objects.all():
-        history = HistoricalTestCase.objects.filter(
+    for test_case in test_case_model.objects.all():
+        history = historical_test_case_model.objects.filter(
                     case_id=test_case.pk
                   ).order_by('-history_id').first()
 

--- a/tcms/testcases/migrations/0010_remove_bug.py
+++ b/tcms/testcases/migrations/0010_remove_bug.py
@@ -2,14 +2,14 @@ from django.db import migrations
 
 
 def forward_copy_data(apps, schema_editor):
-    Bug = apps.get_model('testcases', 'Bug')
-    LinkReference = apps.get_model('linkreference', 'LinkReference')
+    bug_model = apps.get_model('testcases', 'Bug')
+    link_reference_model = apps.get_model('linkreference', 'LinkReference')
 
-    for bug in Bug.objects.all():
+    for bug in bug_model.objects.all():
         if not bug.case_run_id:
             continue
 
-        LinkReference.objects.create(
+        link_reference_model.objects.create(
             execution_id=bug.case_run_id,
             name="%s %s" % (bug.bug_system.name, bug.bug_id),
             url=bug.bug_system.url_reg_exp % bug.bug_id,

--- a/tcms/testcases/migrations/0014_update_issutracker_types.py
+++ b/tcms/testcases/migrations/0014_update_issutracker_types.py
@@ -2,18 +2,18 @@ from django.db import migrations
 
 
 def forwards(apps, schema_editor):
-    BugSystem = apps.get_model('testcases', 'BugSystem')
+    bug_system_model = apps.get_model('testcases', 'BugSystem')
 
-    for record in BugSystem.objects.all():
+    for record in bug_system_model.objects.all():
         if record.tracker_type:
             record.tracker_type = "tcms.issuetracker.types.%s" % record.tracker_type
             record.save()
 
 
 def backwards(apps, schema_editor):
-    BugSystem = apps.get_model('testcases', 'BugSystem')
+    bug_system_model = apps.get_model('testcases', 'BugSystem')
 
-    for record in BugSystem.objects.all():
+    for record in bug_system_model.objects.all():
         if record.tracker_type.startswith('tcms.issuetracker.types.'):
             record.tracker_type = record.tracker_type.replace('tcms.issuetracker.types.', '')
             record.save()

--- a/tcms/testplans/migrations/0005_squashed.py
+++ b/tcms/testplans/migrations/0005_squashed.py
@@ -26,15 +26,15 @@ if settings.DATABASES['default']['ENGINE'].find('sqlite') > -1:
 
 
 def forwards_add_initial_data(apps, schema_editor):
-    PlanType = apps.get_model('testplans', 'PlanType')
+    plan_type_model = apps.get_model('testplans', 'PlanType')
 
-    PlanType.objects.bulk_create(
-        [PlanType(name=name, description='') for name in plan_types])
+    plan_type_model.objects.bulk_create(
+        [plan_type_model(name=name, description='') for name in plan_types])
 
 
 def reverse_add_initial_data(apps, schema_editor):
-    PlanType = apps.get_model('testplans', 'PlanType')
-    PlanType.objects.filter(name__in=plan_types).delete()
+    plan_type_model = apps.get_model('testplans', 'PlanType')
+    plan_type_model.objects.filter(name__in=plan_types).delete()
 
 
 class Migration(migrations.Migration):

--- a/tcms/testplans/migrations/0005_squashed.py
+++ b/tcms/testplans/migrations/0005_squashed.py
@@ -168,7 +168,7 @@ class Migration(migrations.Migration):
                 ('history_change_reason', models.TextField(null=True)),
                 ('history_date', models.DateTimeField()),
                 ('history_type', models.CharField(choices=[
-                 ('+', 'Created'), ('~', 'Changed'), ('-', 'Deleted')], max_length=1)),
+                    ('+', 'Created'), ('~', 'Changed'), ('-', 'Deleted')], max_length=1)),
                 ('author', models.ForeignKey(blank=True, db_constraint=False, null=True,
                                              on_delete=models.deletion.DO_NOTHING,
                                              related_name='+', to=settings.AUTH_USER_MODEL)),

--- a/tcms/testruns/migrations/0004_squashed.py
+++ b/tcms/testruns/migrations/0004_squashed.py
@@ -196,7 +196,7 @@ class Migration(migrations.Migration):
                 ('history_change_reason', models.TextField(null=True)),
                 ('history_date', models.DateTimeField()),
                 ('history_type', models.CharField(choices=[
-                 ('+', 'Created'), ('~', 'Changed'), ('-', 'Deleted')], max_length=1)),
+                    ('+', 'Created'), ('~', 'Changed'), ('-', 'Deleted')], max_length=1)),
                 ('assignee', models.ForeignKey(blank=True, db_constraint=False, null=True,
                                                on_delete=models.deletion.DO_NOTHING,
                                                related_name='+', to=settings.AUTH_USER_MODEL)),
@@ -237,7 +237,7 @@ class Migration(migrations.Migration):
                 ('history_change_reason', models.TextField(null=True)),
                 ('history_date', models.DateTimeField()),
                 ('history_type', models.CharField(choices=[
-                 ('+', 'Created'), ('~', 'Changed'), ('-', 'Deleted')], max_length=1)),
+                    ('+', 'Created'), ('~', 'Changed'), ('-', 'Deleted')], max_length=1)),
                 ('build', models.ForeignKey(blank=True, db_constraint=False, null=True,
                                             on_delete=models.deletion.DO_NOTHING, related_name='+',
                                             to='management.Build')),

--- a/tcms/testruns/migrations/0004_squashed.py
+++ b/tcms/testruns/migrations/0004_squashed.py
@@ -12,24 +12,24 @@ if settings.DATABASES['default']['ENGINE'].find('sqlite') > -1:
 
 
 def forwards_add_initial_data(apps, schema_editor):
-    TestCaseRunStatus = apps.get_model('testruns', 'TestCaseRunStatus')
+    test_case_run_status_model = apps.get_model('testruns', 'TestCaseRunStatus')
 
-    TestCaseRunStatus.objects.bulk_create([
-        TestCaseRunStatus(name='IDLE'),
-        TestCaseRunStatus(name='RUNNING'),
-        TestCaseRunStatus(name='PAUSED'),
-        TestCaseRunStatus(name='PASSED'),
-        TestCaseRunStatus(name='FAILED'),
-        TestCaseRunStatus(name='BLOCKED'),
-        TestCaseRunStatus(name='ERROR'),
-        TestCaseRunStatus(name='WAIVED'),
+    test_case_run_status_model.objects.bulk_create([
+        test_case_run_status_model(name='IDLE'),
+        test_case_run_status_model(name='RUNNING'),
+        test_case_run_status_model(name='PAUSED'),
+        test_case_run_status_model(name='PASSED'),
+        test_case_run_status_model(name='FAILED'),
+        test_case_run_status_model(name='BLOCKED'),
+        test_case_run_status_model(name='ERROR'),
+        test_case_run_status_model(name='WAIVED'),
     ])
 
 
 def reverse_add_initial_data(apps, schema_editor):
-    TestCaseRunStatus = apps.get_model('testruns', 'TestCaseRunStatus')
+    test_case_run_status_model = apps.get_model('testruns', 'TestCaseRunStatus')
     status_names = ['IDLE', 'RUNNING', 'PAUSED', 'PASSED', 'FAILED', 'BLOCKED', 'ERROR', 'WAIVED']
-    TestCaseRunStatus.objects.filter(name__in=status_names).delete()
+    test_case_run_status_model.objects.filter(name__in=status_names).delete()
 
 
 class Migration(migrations.Migration):

--- a/tcms/testruns/migrations/0006_rename_test_case_run_to_test_execution.py
+++ b/tcms/testruns/migrations/0006_rename_test_case_run_to_test_execution.py
@@ -5,9 +5,9 @@ from django.db import migrations
 
 
 def rename_permissions(apps, schema_editor):
-    Permission = apps.get_model('auth', 'Permission')
+    permission_model = apps.get_model('auth', 'Permission')
 
-    for permission in Permission.objects.filter(codename__contains='testcaserun'):
+    for permission in permission_model.objects.filter(codename__contains='testcaserun'):
         new_name = permission.name.replace('test case run', 'test execution')
         new_codename = permission.codename.replace('testcaserun', 'testexecution')
 

--- a/tcms/testruns/migrations/0007_test_execution_statuses.py
+++ b/tcms/testruns/migrations/0007_test_execution_statuses.py
@@ -4,51 +4,51 @@ from django.db import migrations, models
 
 
 def insert_default_values(apps, schema_editor):
-    TestExecutionStatus = apps.get_model('testruns', 'TestExecutionStatus')
+    test_execution_status_model = apps.get_model('testruns', 'TestExecutionStatus')
 
-    failed = TestExecutionStatus.objects.get(name='FAILED')
+    failed = test_execution_status_model.objects.get(name='FAILED')
     failed.weight = -30
     failed.color = '#cc0000'
     failed.icon = 'fa fa-times-circle-o'
     failed.save()
 
-    error = TestExecutionStatus.objects.get(name='ERROR')
+    error = test_execution_status_model.objects.get(name='ERROR')
     error.weight = -20
     error.color = '#cc0000'
     error.icon = 'fa fa-minus-circle'
     error.save()
 
-    blocked = TestExecutionStatus.objects.get(name='BLOCKED')
+    blocked = test_execution_status_model.objects.get(name='BLOCKED')
     blocked.weight = -10
     blocked.color = '#cc0000'
     blocked.icon = 'fa fa-stop-circle-o'
     blocked.save()
 
-    idle = TestExecutionStatus.objects.get(name='IDLE')
+    idle = test_execution_status_model.objects.get(name='IDLE')
     idle.weight = 0
     idle.color = '#72767b'
     idle.icon = 'fa fa-question-circle-o'
     idle.save()
 
-    paused = TestExecutionStatus.objects.get(name='PAUSED')
+    paused = test_execution_status_model.objects.get(name='PAUSED')
     paused.weight = 0
     paused.color = '#72767b'
     paused.icon = 'fa fa-pause-circle-o'
     paused.save()
 
-    running = TestExecutionStatus.objects.get(name='RUNNING')
+    running = test_execution_status_model.objects.get(name='RUNNING')
     running.weight = 0
     running.color = '#72767b'
     running.icon = 'fa fa-play-circle-o'
     running.save()
 
-    waived = TestExecutionStatus.objects.get(name='WAIVED')
+    waived = test_execution_status_model.objects.get(name='WAIVED')
     waived.weight = 10
     waived.color = '#92d400'
     waived.icon = 'fa fa-commenting-o'
     waived.save()
 
-    passed = TestExecutionStatus.objects.get(name='PASSED')
+    passed = test_execution_status_model.objects.get(name='PASSED')
     passed.weight = 20
     passed.color = '#92d400'
     passed.icon = 'fa fa-check-circle-o'


### PR DESCRIPTION
Refs #1774 Fix linter errors in migrations except for recently created missing-backwards-migration-callable. Added `--module-naming-style=any` to silence invalid-name errors in migration module names.