### PR TITLE
Add tests for tcms.bugs.views.Edit -- Closes #1599

### DIFF
--- a/tcms/bugs/tests/test_permissions.py
+++ b/tcms/bugs/tests/test_permissions.py
@@ -6,16 +6,16 @@ from django.conf import settings
 if 'tcms.bugs.apps.AppConfig' not in settings.INSTALLED_APPS:
     raise unittest.SkipTest('tcms.bugs is disabled')
 
-
 from django.contrib.auth.models import Permission           # noqa: E402
 from django.contrib.contenttypes.models import ContentType  # noqa: E402
-from django.test import TestCase                        # noqa: E402
-from django.urls import reverse                         # noqa: E402
-from django.utils.translation import gettext_lazy as _  # noqa: E402
+from django.test import TestCase                            # noqa: E402
+from django.urls import reverse                             # noqa: E402
+from django.utils.translation import gettext_lazy as _      # noqa: E402
 
-from tcms import tests            # noqa: E402
-from tcms.bugs.models import Bug  # noqa: E402
-from tcms.tests import factories  # noqa: E402
+from tcms import tests                                      # noqa: E402
+from tcms.bugs.models import Bug                            # noqa: E402
+from tcms.bugs.tests.factory import BugFactory              # noqa: E402
+from tcms.tests import factories                            # noqa: E402
 
 
 class TestNew(tests.PermissionsTestCase):
@@ -57,6 +57,50 @@ class TestNew(tests.PermissionsTestCase):
         self.assertEqual(self.tester, last_bug.reporter)
         self.assertContains(response, 'Bug created by test suite')
         self.assertContains(response, 'BUG-%d' % last_bug.pk)
+
+
+class TestEdit(tests.PermissionsTestCase):
+    permission_label = 'bugs.change_bug'
+    http_method_names = ['get', 'post']
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.bug = BugFactory()
+
+        cls.url = reverse('bugs-edit', args=(cls.bug.pk,))
+        cls.post_data = {
+            'summary': 'An edited summary',
+            'reporter': cls.bug.reporter.pk,
+            'assignee': cls.bug.assignee.pk,
+            'product': cls.bug.product.pk,
+            'version': cls.bug.version.pk,
+            'build': cls.bug.build.pk,
+        }
+
+        super().setUpTestData()
+        tests.user_should_have_perm(cls.tester, 'bugs.view_bug')
+
+    def verify_get_with_permission(self):
+        response = self.client.get(self.url)
+
+        self.assertContains(response, _('Edit bug'))
+        self.assertContains(response, self.url)
+        self.assertContains(response, self.bug.summary)
+        self.assertTemplateUsed(response, 'bugs/mutable.html')
+
+    def verify_post_with_permission(self):
+        response = self.client.post(self.url, self.post_data, follow=True)
+
+        self.assertRedirects(
+            response,
+            reverse('bugs-get', args=(self.bug.pk,)),
+            status_code=302,
+            target_status_code=200
+        )
+
+        self.bug.refresh_from_db()
+        self.assertContains(response, 'BUG-%d: %s' % (self.bug.pk, _(self.bug.summary)))
+        self.assertTemplateUsed(response, 'bugs/get.html')
 
 
 class TestM2MPermissionsExist(TestCase):


### PR DESCRIPTION
This PR adds tests for the view `Edit` in `tcms/bugs/views.py` as per #1599