### PR TITLE
Handle history when importing objects with ID field set

### DIFF
--- a/tcms/core/history.py
+++ b/tcms/core/history.py
@@ -73,7 +73,7 @@ class KiwiHistoricalRecords(HistoricalRecords):
             return
 
         if instance.pk and hasattr(instance, 'history'):
-            instance.previous = instance.__class__.objects.get(pk=instance.pk)
+            instance.previous = instance.__class__.objects.filter(pk=instance.pk).first()
 
     def post_save(self, instance, created, using=None, **kwargs):
         """
@@ -83,7 +83,7 @@ class KiwiHistoricalRecords(HistoricalRecords):
         if kwargs.get('raw', False):
             return
 
-        if hasattr(instance, 'previous'):
+        if hasattr(instance, 'previous') and instance.previous:
             # note: simple_history.utils.update_change_reason() performs an extra
             # DB query so it is better to use the private field instead!
             # In older simple_history version this field wasn't private but was renamed


### PR DESCRIPTION
in some cases, e.g. custom data restore, we're saving objects with
all of their fields set, including the PK/ID field. Without this
patch instance.pk will be present in .pre_save() but the actual
record doesn't exist in the DB yet hence an exception will be raised.

With this change instance.previous will be None in case the object
doesn't exist in the DB and the code in .post_save() will take care
to execute the diff_objects() function only when instance.previous
isn't None.