### PR TITLE
Add DbColumnChecker lint checker class

### DIFF
--- a/kiwi_lint/__init__.py
+++ b/kiwi_lint/__init__.py
@@ -21,6 +21,7 @@ from .one_to_one_field import OneToOneFieldChecker
 from .views import ClassBasedViewChecker
 from .datetime import DatetimeChecker
 from .forms import FormFieldChecker, ModelFormChecker
+from .db_column import DbColumnChecker
 
 
 def register(linter):
@@ -43,3 +44,4 @@ def register(linter):
     linter.register_checker(DatetimeChecker(linter))
     linter.register_checker(FormFieldChecker(linter))
     linter.register_checker(ModelFormChecker(linter))
+    linter.register_checker(DbColumnChecker(linter))

--- a/kiwi_lint/db_column.py
+++ b/kiwi_lint/db_column.py
@@ -1,0 +1,22 @@
+from pylint import interfaces, checkers
+from pylint.checkers import utils
+
+
+class DbColumnChecker(checkers.BaseChecker):
+    __implements__ = (interfaces.IAstroidChecker, )
+
+    name = 'db-column-used'
+
+    msgs = {
+        'E4841': (
+            'Do not use db_column in model field definitions',
+            'db-column-used',
+            'Do not use db_column argument in model field definitions,'
+            'See: https://github.com/kiwitcms/Kiwi/issues/736'
+        )
+    }
+
+    @utils.check_messages('db-column-used')
+    def visit_keyword(self, node):
+        if node.arg == 'db_column':
+            self.add_message('db-column-used', node=node)


### PR DESCRIPTION
Resolves #736. Add a lint checker class to check for use of db_column argument in model field definition.

@atodorov I had tried `node_is_subclass` with Django's `django.db.models.Field` but I'm not sure which node/node_attribute to check in this case. May I please get clarification on I could use to check? So far, I have just gone with checking attribute node; checking if the `node.attrname` ends with 'Field' or 'Key' and checking the node's expression name is 'models' to tell apart from form fields