### PR TITLE
Docs: replace references to `XML-RPC` with `RPC`

### DIFF
--- a/tcms/bugs/api.py
+++ b/tcms/bugs/api.py
@@ -18,7 +18,7 @@ __all__ = (
 @rpc_method(name='Bug.add_tag')
 def add_tag(bug_id, tag, **kwargs):
     """
-    .. function:: XML-RPC Bug.add_tag(bug_id, tag)
+    .. function:: RPC Bug.add_tag(bug_id, tag)
 
         Add one tag to the specified Bug.
 
@@ -42,7 +42,7 @@ def add_tag(bug_id, tag, **kwargs):
 @rpc_method(name='Bug.remove_tag')
 def remove_tag(bug_id, tag):
     """
-    .. function:: XML-RPC Bug.remove_tag(bug_id, tag)
+    .. function:: RPC Bug.remove_tag(bug_id, tag)
 
         Remove tag from a Bug.
 
@@ -62,7 +62,7 @@ def remove_tag(bug_id, tag):
 @rpc_method(name='Bug.remove')
 def remove(query):
     """
-    .. function:: XML-RPC Bug.remove(bug_id)
+    .. function:: RPC Bug.remove(bug_id)
 
         Remove Bug object(s).
 
@@ -77,7 +77,7 @@ def remove(query):
 @rpc_method(name='Bug.filter')
 def filter(query):  # pylint: disable=redefined-builtin
     """
-    .. function:: XML-RPC Bug.filter(query)
+    .. function:: RPC Bug.filter(query)
 
         Get list of bugs.
 

--- a/tcms/rpc/api/__init__.py
+++ b/tcms/rpc/api/__init__.py
@@ -1,18 +1,18 @@
 # -*- coding: utf-8 -*-
 
 """
-Kiwi TCMS XML-RPC Service
+Kiwi TCMS RPC Service
 -------------------------
 
-You need to invoke it using an XML-RPC Client! For the available XML-RPC methods
+You need to invoke it using an XML-RPC or JSON-RPC Client! For the available RPC methods
 checkout the **Submodules** section!
 
 `tcms-api <https://pypi.org/project/tcms-api/>`_ is the official Python
 interface for Kiwi TCMS! We strongly advise that you use it instead of
-directly calling the XML-RPC methods below!
+directly calling the RPC methods below!
 
 
-How does the XML-RPC interface work?
+How does the RPC interface work?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 - The XML-RPC enpoint is at ``https://your-kiwi-instance.com/xml-rpc/``.
@@ -34,7 +34,7 @@ How does the XML-RPC interface work?
 How to handle ForeignKey arguments?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The syntax of using ForeignKey in this XML-RPC API follows Django standards::
+The syntax of using ForeignKey in this RPC API follows Django standards::
 
     foreignkeyname + '__' + fieldname + '__' + field_lookup_syntax
 

--- a/tcms/rpc/api/attachment.py
+++ b/tcms/rpc/api/attachment.py
@@ -14,7 +14,7 @@ __all__ = (
 @rpc_method(name='Attachment.remove_attachment')
 def remove_attachment(attachment_id, **kwargs):
     """
-    .. function:: XML-RPC Attachment.remove_attachment(attachment_id)
+    .. function:: RPC Attachment.remove_attachment(attachment_id)
 
         Remove the given attachment file.
 

--- a/tcms/rpc/api/auth.py
+++ b/tcms/rpc/api/auth.py
@@ -13,7 +13,7 @@ __all__ = (
 @rpc_method(name='Auth.login')
 def login(username, password, **kwargs):  # pylint: disable=missing-api-permissions-required
     """
-    .. function:: XML-RPC Auth.login(username, password)
+    .. function:: RPC Auth.login(username, password)
 
         Login into Kiwi TCMS.
 
@@ -44,7 +44,7 @@ def login(username, password, **kwargs):  # pylint: disable=missing-api-permissi
 @rpc_method(name='Auth.logout')
 def logout(**kwargs):  # pylint: disable=missing-api-permissions-required
     """
-    .. function:: XML-RPC Auth.logout()
+    .. function:: RPC Auth.logout()
 
         Delete session information
     """

--- a/tcms/rpc/api/bug.py
+++ b/tcms/rpc/api/bug.py
@@ -20,7 +20,7 @@ __all__ = (
 @rpc_method(name='Bug.details')
 def details(url, **kwargs):
     """
-    .. function:: XML-RPC Bug.details(url)
+    .. function:: RPC Bug.details(url)
 
         Returns details about bug at the given URL address. This method is
         used when generating additional information which is shown in the UI.
@@ -48,7 +48,7 @@ def details(url, **kwargs):
 @rpc_method(name='Bug.report')
 def report(execution_id, tracker_id, **kwargs):
     """
-    .. function:: XML-RPC Bug.report(execution_id, tracker_id)
+    .. function:: RPC Bug.report(execution_id, tracker_id)
 
         Returns a URL which will open the bug tracker with predefined fields
         indicating the error was detected by the specified TestExecution.

--- a/tcms/rpc/api/build.py
+++ b/tcms/rpc/api/build.py
@@ -17,7 +17,7 @@ __all__ = (
 @rpc_method(name='Build.filter')
 def filter(query=None):  # pylint: disable=redefined-builtin
     """
-    .. function:: XML-RPC Build.filter(query)
+    .. function:: RPC Build.filter(query)
 
         Search and return builds matching query.
 
@@ -36,7 +36,7 @@ def filter(query=None):  # pylint: disable=redefined-builtin
 @permissions_required('management.add_build')
 def create(values):
     """
-    .. function:: XML-RPC Build.create(values)
+    .. function:: RPC Build.create(values)
 
         Create a new build object and store it in the database.
 
@@ -61,7 +61,7 @@ def create(values):
 @rpc_method(name='Build.update')
 def update(build_id, values):
     """
-    .. function:: XML-RPC Build.update(build_id, values)
+    .. function:: RPC Build.update(build_id, values)
 
         Updates the fields of the selected build.
 

--- a/tcms/rpc/api/category.py
+++ b/tcms/rpc/api/category.py
@@ -10,7 +10,7 @@ from tcms.rpc.decorators import permissions_required
 @rpc_method(name='Category.filter')
 def filter(query):  # pylint: disable=redefined-builtin
     """
-    .. function:: XML-RPC Category.filter(query)
+    .. function:: RPC Category.filter(query)
 
         Search and return Category objects matching query.
 

--- a/tcms/rpc/api/classification.py
+++ b/tcms/rpc/api/classification.py
@@ -12,7 +12,7 @@ from tcms.rpc.decorators import permissions_required
 @rpc_method(name='Classification.filter')
 def filter(query):  # pylint: disable=redefined-builtin
     """
-    .. function:: XML-RPC Classification.filter(query)
+    .. function:: RPC Classification.filter(query)
 
         Perform a search and return the resulting list of classifications.
 

--- a/tcms/rpc/api/component.py
+++ b/tcms/rpc/api/component.py
@@ -21,7 +21,7 @@ __all__ = (
 @rpc_method(name='Component.filter')
 def filter(query):  # pylint: disable=redefined-builtin
     """
-    .. function:: XML-RPC Component.filter(query)
+    .. function:: RPC Component.filter(query)
 
         Search and return the resulting list of components.
 
@@ -37,7 +37,7 @@ def filter(query):  # pylint: disable=redefined-builtin
 @rpc_method(name='Component.create')
 def create(values, **kwargs):
     """
-    .. function:: XML-RPC Component.create(values)
+    .. function:: RPC Component.create(values)
 
         Create new component.
 
@@ -82,7 +82,7 @@ def create(values, **kwargs):
 @rpc_method(name='Component.update')
 def update(component_id, values):
     """
-    .. function:: XML-RPC Component.update
+    .. function:: RPC Component.update
 
         Update component with new values.
 

--- a/tcms/rpc/api/plantype.py
+++ b/tcms/rpc/api/plantype.py
@@ -10,7 +10,7 @@ from tcms.rpc.decorators import permissions_required
 @rpc_method(name='PlanType.filter')
 def filter(query):  # pylint: disable=redefined-builtin
     """
-    .. function:: XML-RPC PlanType.filter(query)
+    .. function:: RPC PlanType.filter(query)
 
         Search and return a list of test plan types.
 

--- a/tcms/rpc/api/priority.py
+++ b/tcms/rpc/api/priority.py
@@ -10,7 +10,7 @@ from tcms.rpc.decorators import permissions_required
 @rpc_method(name='Priority.filter')
 def filter(query):  # pylint: disable=redefined-builtin
     """
-    .. function:: XML-RPC Priority.filter(query)
+    .. function:: RPC Priority.filter(query)
 
         Perform a search and return the resulting list of priorities.
 

--- a/tcms/rpc/api/product.py
+++ b/tcms/rpc/api/product.py
@@ -15,7 +15,7 @@ __all__ = (
 @permissions_required('management.add_product')
 def create(values):
     """
-    .. function:: XML-RPC Product.create(values)
+    .. function:: RPC Product.create(values)
 
         Create a new Product object and store it in the database.
 
@@ -32,7 +32,7 @@ def create(values):
 @rpc_method(name='Product.filter')
 def filter(query):  # pylint: disable=redefined-builtin
     """
-    .. function:: XML-RPC Product.filter(query)
+    .. function:: RPC Product.filter(query)
 
         Perform a search and return the resulting list of products.
 

--- a/tcms/rpc/api/tag.py
+++ b/tcms/rpc/api/tag.py
@@ -10,7 +10,7 @@ from tcms.rpc.decorators import permissions_required
 @rpc_method(name='Tag.filter')
 def filter(query):  # pylint: disable=redefined-builtin
     """
-    .. function:: XML-RPC Tag.filter(query)
+    .. function:: RPC Tag.filter(query)
 
         Search and return a list of tags
 

--- a/tcms/rpc/api/testcase.py
+++ b/tcms/rpc/api/testcase.py
@@ -39,7 +39,7 @@ __all__ = (
 @rpc_method(name='TestCase.add_component')
 def add_component(case_id, component):
     """
-    .. function:: XML-RPC TestCase.add_component(case_id, component)
+    .. function:: RPC TestCase.add_component(case_id, component)
 
         Add component to the selected test case.
 
@@ -65,7 +65,7 @@ def add_component(case_id, component):
 @rpc_method(name='TestCase.remove_component')
 def remove_component(case_id, component_id):
     """
-    .. function:: XML-RPC TestCase.remove_component(case_id, component_id)
+    .. function:: RPC TestCase.remove_component(case_id, component_id)
 
         Remove selected component from the selected test case.
 
@@ -115,7 +115,7 @@ def _validate_cc_list(cc_list):
 @rpc_method(name='TestCase.add_notification_cc')
 def add_notification_cc(case_id, cc_list):
     """
-    .. function:: XML-RPC TestCase.add_notification_cc(case_id, cc_list)
+    .. function:: RPC TestCase.add_notification_cc(case_id, cc_list)
 
         Add email addresses to the notification list of specified TestCase
 
@@ -138,7 +138,7 @@ def add_notification_cc(case_id, cc_list):
 @rpc_method(name='TestCase.remove_notification_cc')
 def remove_notification_cc(case_id, cc_list):
     """
-    .. function:: XML-RPC TestCase.remove_notification_cc(case_id, cc_list)
+    .. function:: RPC TestCase.remove_notification_cc(case_id, cc_list)
 
         Remove email addresses from the notification list of specified TestCase
 
@@ -160,7 +160,7 @@ def remove_notification_cc(case_id, cc_list):
 @rpc_method(name='TestCase.get_notification_cc')
 def get_notification_cc(case_id):
     """
-    .. function:: XML-RPC TestCase.get_notification_cc(case_id)
+    .. function:: RPC TestCase.get_notification_cc(case_id)
 
         Return notification list for specified TestCase
 
@@ -177,7 +177,7 @@ def get_notification_cc(case_id):
 @rpc_method(name='TestCase.add_tag')
 def add_tag(case_id, tag, **kwargs):
     """
-    .. function:: XML-RPC TestCase.add_tag(case_id, tag)
+    .. function:: RPC TestCase.add_tag(case_id, tag)
 
         Add one tag to the specified test case.
 
@@ -201,7 +201,7 @@ def add_tag(case_id, tag, **kwargs):
 @rpc_method(name='TestCase.remove_tag')
 def remove_tag(case_id, tag):
     """
-    .. function:: XML-RPC TestCase.remove_tag(case_id, tag)
+    .. function:: RPC TestCase.remove_tag(case_id, tag)
 
         Remove tag from a test case.
 
@@ -221,7 +221,7 @@ def remove_tag(case_id, tag):
 @rpc_method(name='TestCase.create')
 def create(values, **kwargs):
     """
-    .. function:: XML-RPC TestCase.create(values)
+    .. function:: RPC TestCase.create(values)
 
         Create a new TestCase object and store it in the database.
 
@@ -263,7 +263,7 @@ def create(values, **kwargs):
 @rpc_method(name='TestCase.filter')
 def filter(query=None):  # pylint: disable=redefined-builtin
     """
-    .. function:: XML-RPC TestCase.filter(query)
+    .. function:: RPC TestCase.filter(query)
 
         Perform a search and return the resulting list of test cases
         augmented with their latest ``text``.
@@ -283,7 +283,7 @@ def filter(query=None):  # pylint: disable=redefined-builtin
 @rpc_method(name='TestCase.update')
 def update(case_id, values):
     """
-    .. function:: XML-RPC TestCase.update(case_id, values)
+    .. function:: RPC TestCase.update(case_id, values)
 
         Update the fields of the selected test case.
 
@@ -312,7 +312,7 @@ def update(case_id, values):
 @rpc_method(name='TestCase.remove')
 def remove(query):
     """
-    .. function:: XML-RPC TestCase.remove(query)
+    .. function:: RPC TestCase.remove(query)
 
         Remove TestCase object(s).
 
@@ -336,7 +336,7 @@ def remove(query):
 @rpc_method(name='TestCase.list_attachments')
 def list_attachments(case_id, **kwargs):
     """
-    .. function:: XML-RPC TestCase.list_attachments(case_id)
+    .. function:: RPC TestCase.list_attachments(case_id)
 
         List attachments for the given TestCase.
 
@@ -357,7 +357,7 @@ def list_attachments(case_id, **kwargs):
 @rpc_method(name='TestCase.add_attachment')
 def add_attachment(case_id, filename, b64content, **kwargs):
     """
-    .. function:: XML-RPC TestCase.add_attachment(case_id, filename, b64content)
+    .. function:: RPC TestCase.add_attachment(case_id, filename, b64content)
 
         Add attachment to the given TestCase.
 

--- a/tcms/rpc/api/testcasestatus.py
+++ b/tcms/rpc/api/testcasestatus.py
@@ -10,7 +10,7 @@ from tcms.rpc.decorators import permissions_required
 @rpc_method(name='TestCaseStatus.filter')
 def filter(query):  # pylint: disable=redefined-builtin
     """
-    .. function:: XML-RPC TestCaseStatus.filter(query)
+    .. function:: RPC TestCaseStatus.filter(query)
 
         Search and return the list of test case statuses.
 

--- a/tcms/rpc/api/testexecution.py
+++ b/tcms/rpc/api/testexecution.py
@@ -38,7 +38,7 @@ __all__ = (
 @rpc_method(name='TestExecution.add_comment')
 def add_comment(execution_id, comment, **kwargs):
     """
-    .. function:: XML-RPC TestExecution.add_comment(execution_id, comment)
+    .. function:: RPC TestExecution.add_comment(execution_id, comment)
 
         Add comment to selected test execution.
 
@@ -80,7 +80,7 @@ def remove_comment(execution_id, comment_id=None):
 @rpc_method(name='TestExecution.filter')
 def filter(values):  # pylint: disable=redefined-builtin
     """
-    .. function:: XML-RPC TestExecution.filter(values)
+    .. function:: RPC TestExecution.filter(values)
 
         Perform a search and return the resulting list of test case executions.
 
@@ -96,7 +96,7 @@ def filter(values):  # pylint: disable=redefined-builtin
 @rpc_method(name='TestExecution.update')
 def update(execution_id, values):
     """
-    .. function:: XML-RPC TestExecution.update(execution_id, values)
+    .. function:: RPC TestExecution.update(execution_id, values)
 
         Update the selected TestExecution
 
@@ -128,7 +128,7 @@ def update(execution_id, values):
 @rpc_method(name='TestExecution.add_link')
 def add_link(values, update_tracker=False, **kwargs):
     """
-    .. function:: XML-RPC TestExecution.add_link(values)
+    .. function:: RPC TestExecution.add_link(values)
 
         Add new URL link to a TestExecution
 
@@ -167,7 +167,7 @@ def add_link(values, update_tracker=False, **kwargs):
 @rpc_method(name='TestExecution.remove_link')
 def remove_link(query):
     """
-    .. function:: XML-RPC TestExecution.remove_link(query)
+    .. function:: RPC TestExecution.remove_link(query)
 
         Remove URL link from TestExecution
 
@@ -182,7 +182,7 @@ def remove_link(query):
 @rpc_method(name='TestExecution.get_links')
 def get_links(query):
     """
-    .. function:: XML-RPC TestExecution.get_links(query)
+    .. function:: RPC TestExecution.get_links(query)
 
         Get URL links for the specified TestExecution
 

--- a/tcms/rpc/api/testexecutionstatus.py
+++ b/tcms/rpc/api/testexecutionstatus.py
@@ -12,7 +12,7 @@ from tcms.rpc.decorators import permissions_required
 @rpc_method(name='TestExecutionStatus.filter')
 def filter(query):  # pylint: disable=redefined-builtin
     """
-    .. function:: XML-RPC TestExecutionStatus.filter(query)
+    .. function:: RPC TestExecutionStatus.filter(query)
 
         Search and return the list of test case run statuses.
 

--- a/tcms/rpc/api/testplan.py
+++ b/tcms/rpc/api/testplan.py
@@ -30,7 +30,7 @@ __all__ = (
 @rpc_method(name='TestPlan.create')
 def create(values, **kwargs):
     """
-    .. function:: XML-RPC TestPlan.create(values)
+    .. function:: RPC TestPlan.create(values)
 
         Create new Test Plan object and store it in the database.
 
@@ -75,7 +75,7 @@ def create(values, **kwargs):
 @rpc_method(name='TestPlan.filter')
 def filter(query=None):  # pylint: disable=redefined-builtin
     """
-    .. function:: XML-RPC TestPlan.filter(query)
+    .. function:: RPC TestPlan.filter(query)
 
         Perform a search and return the resulting list of test plans.
 
@@ -95,7 +95,7 @@ def filter(query=None):  # pylint: disable=redefined-builtin
 @rpc_method(name='TestPlan.add_tag')
 def add_tag(plan_id, tag_name, **kwargs):
     """
-    .. function:: XML-RPC TestPlan.add_tag(plan_id, tag_name)
+    .. function:: RPC TestPlan.add_tag(plan_id, tag_name)
 
         Add a tag to the specified test plan.
 
@@ -119,7 +119,7 @@ def add_tag(plan_id, tag_name, **kwargs):
 @rpc_method(name='TestPlan.remove_tag')
 def remove_tag(plan_id, tag_name):
     """
-    .. function:: XML-RPC TestPlan.remove_tag(plan_id, tag_name)
+    .. function:: RPC TestPlan.remove_tag(plan_id, tag_name)
 
         Remove tag from the specified test plan.
 
@@ -138,7 +138,7 @@ def remove_tag(plan_id, tag_name):
 @rpc_method(name='TestPlan.update')
 def update(plan_id, values):
     """
-    .. function:: XML-RPC TestPlan.update(plan_id, values)
+    .. function:: RPC TestPlan.update(plan_id, values)
 
         Update the fields of the selected test plan.
 
@@ -166,7 +166,7 @@ def update(plan_id, values):
 @rpc_method(name='TestPlan.add_case')
 def add_case(plan_id, case_id):
     """
-    .. function:: XML-RPC TestPlan.add_case(plan_id, case_id)
+    .. function:: RPC TestPlan.add_case(plan_id, case_id)
 
         Link test case to the given plan.
 
@@ -187,7 +187,7 @@ def add_case(plan_id, case_id):
 @rpc_method(name='TestPlan.remove_case')
 def remove_case(plan_id, case_id):
     """
-    .. function:: XML-RPC TestPlan.remove_case(plan_id, case_id)
+    .. function:: RPC TestPlan.remove_case(plan_id, case_id)
 
         Unlink a test case from the given plan.
 
@@ -204,7 +204,7 @@ def remove_case(plan_id, case_id):
 @rpc_method(name='TestPlan.list_attachments')
 def list_attachments(plan_id, **kwargs):
     """
-    .. function:: XML-RPC TestPlan.list_attachments(plan_id)
+    .. function:: RPC TestPlan.list_attachments(plan_id)
 
         List attachments for the given TestPlan.
 
@@ -225,7 +225,7 @@ def list_attachments(plan_id, **kwargs):
 @rpc_method(name='TestPlan.add_attachment')
 def add_attachment(plan_id, filename, b64content, **kwargs):
     """
-    .. function:: XML-RPC TestPlan.add_attachment(plan_id, filename, b64content)
+    .. function:: RPC TestPlan.add_attachment(plan_id, filename, b64content)
 
         Add attachment to the given TestPlan.
 

--- a/tcms/rpc/api/testrun.py
+++ b/tcms/rpc/api/testrun.py
@@ -26,7 +26,7 @@ __all__ = (
 @rpc_method(name='TestRun.add_case')
 def add_case(run_id, case_id):
     """
-    .. function:: XML-RPC TestRun.add_case(run_id, case_id)
+    .. function:: RPC TestRun.add_case(run_id, case_id)
 
         Add a TestCase to the selected test run.
 
@@ -49,7 +49,7 @@ def add_case(run_id, case_id):
 @rpc_method(name='TestRun.remove_case')
 def remove_case(run_id, case_id):
     """
-    .. function:: XML-RPC TestRun.remove_case(run_id, case_id)
+    .. function:: RPC TestRun.remove_case(run_id, case_id)
 
         Remove a TestCase from the selected test run.
 
@@ -66,7 +66,7 @@ def remove_case(run_id, case_id):
 @rpc_method(name='TestRun.get_cases')
 def get_cases(run_id):
     """
-    .. function:: XML-RPC TestRun.get_cases(run_id)
+    .. function:: RPC TestRun.get_cases(run_id)
 
         Get the list of test cases that are attached to a test run.
 
@@ -94,7 +94,7 @@ def get_cases(run_id):
 @rpc_method(name='TestRun.add_tag')
 def add_tag(run_id, tag_name, **kwargs):
     """
-    .. function:: XML-RPC TestRun.add_tag(run_id, tag)
+    .. function:: RPC TestRun.add_tag(run_id, tag)
 
         Add one tag to the specified test run.
 
@@ -122,7 +122,7 @@ def add_tag(run_id, tag_name, **kwargs):
 @rpc_method(name='TestRun.remove_tag')
 def remove_tag(run_id, tag_name):
     """
-    .. function:: XML-RPC TestRun.remove_tag(run_id, tag)
+    .. function:: RPC TestRun.remove_tag(run_id, tag)
 
         Remove a tag from the specified test run.
 
@@ -145,7 +145,7 @@ def remove_tag(run_id, tag_name):
 @rpc_method(name='TestRun.create')
 def create(values):
     """
-    .. function:: XML-RPC TestRun.create(values)
+    .. function:: RPC TestRun.create(values)
 
         Create new TestRun object and store it in the database.
 
@@ -188,7 +188,7 @@ def create(values):
 @rpc_method(name='TestRun.filter')
 def filter(query=None):  # pylint: disable=redefined-builtin
     """
-    .. function:: XML-RPC TestRun.filter(query)
+    .. function:: RPC TestRun.filter(query)
 
         Perform a search and return the resulting list of test runs.
 
@@ -208,7 +208,7 @@ def filter(query=None):  # pylint: disable=redefined-builtin
 @rpc_method(name='TestRun.update')
 def update(run_id, values):
     """
-    .. function:: XML-RPC TestRun.update(run_id, values)
+    .. function:: RPC TestRun.update(run_id, values)
 
         Update the selected TestRun
 

--- a/tcms/rpc/api/user.py
+++ b/tcms/rpc/api/user.py
@@ -33,7 +33,7 @@ def _get_user_dict(user):
 @rpc_method(name='User.filter')
 def filter(query=None, **kwargs):  # pylint: disable=redefined-builtin
     """
-    .. function:: XML-RPC User.filter(query)
+    .. function:: RPC User.filter(query)
 
         Search and return the resulting list of users.
 
@@ -64,7 +64,7 @@ def filter(query=None, **kwargs):  # pylint: disable=redefined-builtin
 @rpc_method(name='User.update')
 def update(user_id, values, **kwargs):  # pylint: disable=missing-api-permissions-required
     """
-    .. function:: XML-RPC User.update(user_id, values)
+    .. function:: RPC User.update(user_id, values)
 
         Updates the fields of the selected user. Can be used to update
         password as well!
@@ -131,7 +131,7 @@ def update(user_id, values, **kwargs):  # pylint: disable=missing-api-permission
 @rpc_method(name='User.join_group')
 def join_group(username, groupname):
     """
-    .. function:: XML-RPC User.join_group(username, groupname)
+    .. function:: RPC User.join_group(username, groupname)
 
         Add user to a group specified by name.
 
@@ -150,7 +150,7 @@ def join_group(username, groupname):
 @rpc_method(name='User.add_attachment')
 def add_attachment(filename, b64content, **kwargs):
     """
-    .. function:: XML-RPC User.add_attachment(filename, b64content)
+    .. function:: RPC User.add_attachment(filename, b64content)
 
         Attach a file under the currently logged-in user!
 

--- a/tcms/rpc/api/version.py
+++ b/tcms/rpc/api/version.py
@@ -18,7 +18,7 @@ __all__ = (
 @rpc_method(name='Version.filter')
 def filter(query):  # pylint: disable=redefined-builtin
     """
-    .. function:: XML-RPC Version.filter(query)
+    .. function:: RPC Version.filter(query)
 
         Search and returns the resulting list of versions.
 
@@ -34,7 +34,7 @@ def filter(query):  # pylint: disable=redefined-builtin
 @rpc_method(name='Version.create')
 def create(values):
     """
-    .. function:: XML-RPC Version.create(values)
+    .. function:: RPC Version.create(values)
 
         Add new version.
 

--- a/tcms/telemetry/api.py
+++ b/tcms/telemetry/api.py
@@ -11,7 +11,7 @@ from tcms.testruns.models import TestExecution, TestExecutionStatus
 @rpc_method(name='Testing.breakdown')
 def breakdown(query=None):
     """
-    .. function:: XML-RPC Testing.breakdown(query)
+    .. function:: RPC Testing.breakdown(query)
 
         Perform a search and return the statistics for the selected test cases
 
@@ -71,7 +71,7 @@ def _map_query_set(query_set, field):
 @rpc_method(name='Testing.status_matrix')
 def status_matrix(query=None):
     """
-        .. function:: XML-RPC Testing.status_matrix(query)
+        .. function:: RPC Testing.status_matrix(query)
 
             Perform a search and return data_set needed to visualize the status matrix
             of test plans, test cases and test executions


### PR DESCRIPTION
because we expose two types of RCP APIs - XML and JSON
and using only XML-RPC is misleading

just a quick find and replace I felt like doing