### PR TITLE
Remove django-glrm

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -71,7 +71,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'Kiwi TCMS'
-copyright = u'2013, Red Hat, Inc.; 2017-2018 Kiwi TCMS project and its affiliates'
+copyright = u'2013, Red Hat, Inc.; 2017-2020 Kiwi TCMS project and its contributors'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -136,6 +136,19 @@ Anonymous read-only access
 --------------------------
 
 By default Kiwi TCMS requires permissions, including view permissions which
-means users must be logged in!
+means users must be logged in! If you wish to allow anonymous read-only access
+then define the following setting::
 
-If you wish to allow anonymous read-only access then:
+    AUTHENTICATION_BACKENDS = [
+        'django.contrib.auth.backends.ModelBackend',
+        'tcms.kiwi_auth.backends.AnonymousViewBackend',
+    ]
+
+.. versionadded:: 8.7
+
+.. warning::
+
+    The ``AUTHENTICATION_BACKENDS`` setting is usually not provided and defaults
+    to ``django.contrib.auth.backends.ModelBackend``, see
+    `Django's documentation <https://docs.djangoproject.com/en/3.1/ref/settings/#std:setting-AUTHENTICATION_BACKENDS>`_
+    for details.

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -132,15 +132,10 @@ See
 `kiwitcms-auth-kerberos <https://github.com/kiwitcms/kiwitcms-auth-kerberos>`_.
 
 
-Public read-only access
------------------------
+Anonymous read-only access
+--------------------------
 
-By default Kiwi TCMS requires all users to be logged in. This is achieved via
-``global_login_required.GlobalLoginRequiredMiddleware``. If you wish to allow
-public read-only access to certain pages (Search, TestCase view, TestPlan view,
-etc) simply disable this middleware. Add the following to
-your ``local_settings.py``::
+By default Kiwi TCMS requires permissions, including view permissions which
+means users must be logged in!
 
-    from django.conf import settings
-
-    settings.MIDDLEWARE.remove('global_login_required.GlobalLoginRequiredMiddleware')
+If you wish to allow anonymous read-only access then:

--- a/docs/source/modules/tcms.kiwi_auth.backends.rst
+++ b/docs/source/modules/tcms.kiwi_auth.backends.rst
@@ -1,0 +1,7 @@
+tcms.kiwi\_auth.backends module
+===============================
+
+.. automodule:: tcms.kiwi_auth.backends
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/modules/tcms.kiwi_auth.rst
+++ b/docs/source/modules/tcms.kiwi_auth.rst
@@ -13,6 +13,7 @@ Submodules
    :maxdepth: 4
 
    tcms.kiwi_auth.admin
+   tcms.kiwi_auth.backends
    tcms.kiwi_auth.forms
    tcms.kiwi_auth.models
    tcms.kiwi_auth.views

--- a/requirements/tarballs.txt
+++ b/requirements/tarballs.txt
@@ -1,6 +1,5 @@
 # these do not provide wheel packages
 
-django-glrm==1.1.3
 django-grappelli==2.14.2
 django-uuslug==1.2.0
 django-vinaigrette==2.0.1

--- a/tcms/kiwi_auth/backends.py
+++ b/tcms/kiwi_auth/backends.py
@@ -1,0 +1,16 @@
+# Copyright (c) 2020 Alexander Todorov <atodorov@MrSenko.com>
+
+from django.contrib.auth.backends import BaseBackend
+
+
+class AnonymousViewBackend(BaseBackend):
+    """
+        Backend which always returns True for *.view_* permissions for
+        anonymous users! Add it to ``AUTHENTICATION_BACKENDS`` setting
+        to enable read-only access which doesn't require login!
+    """
+    def has_perm(self, user_obj, perm, obj=None):
+        if user_obj.is_anonymous and perm.find('.view_') > -1:
+            return True
+
+        return super().has_perm(user_obj, perm, obj=obj)

--- a/tcms/settings/common.py
+++ b/tcms/settings/common.py
@@ -117,8 +117,6 @@ STATIC_ROOT = '/Kiwi/static/'
 
 
 # WARNING: Do not change this unless you know what you are doing !!!
-# If you want to allow read-only access to anonymous users you can disable
-# global_login_required.GlobalLoginRequiredMiddleware below!
 MIDDLEWARE = [
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.locale.LocaleMiddleware',
@@ -127,29 +125,9 @@ MIDDLEWARE = [
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
-    'global_login_required.GlobalLoginRequiredMiddleware',
     'simple_history.middleware.HistoryRequestMiddleware',
     'tcms.core.middleware.CheckSettingsMiddleware',
     'tcms.core.middleware.CheckUnappliedMigrationsMiddleware',
-]
-
-
-# You can also list additional views which will be available to
-# anonymous users here. Take care to keep the default ones!
-PUBLIC_VIEWS = [
-    'modernrpc.views.RPCEntryPoint',
-    'django.contrib.auth.views.LoginView',
-    'django.contrib.auth.views.LogoutView',
-    'django.contrib.auth.views.PasswordResetView',
-    'django.contrib.auth.views.PasswordResetDoneView',
-    'django.contrib.auth.views.PasswordResetConfirmView',
-    'django.contrib.auth.views.PasswordResetCompleteView',
-    'tcms.kiwi_auth.views.LoginViewWithCustomTemplate',
-    'tcms.kiwi_auth.views.PasswordResetView',
-    'tcms.kiwi_auth.views.Register',
-    'tcms.kiwi_auth.views.Confirm',
-    'tcms.core.views.NavigationView',
-    'tcms.core.views.TranslationMode',
 ]
 
 

--- a/tcms/tests/__init__.py
+++ b/tcms/tests/__init__.py
@@ -83,7 +83,7 @@ class LoggedInTestCase(test.TestCase):
 
     def setUp(self):
         """
-            Login because by default we have GlobalLoginRequiredMiddleware enabled!
+            Login because [view] permissions are required by default!
         """
         super().setUp()
         self.client.login(username=self.tester.username,  # nosec:B106:hardcoded_password_funcarg


### PR DESCRIPTION
now that every view requires permissions we don't need
GlobalLoginRequiredMiddleware anymore!