### PR TITLE
Fix name of default database in settings

### DIFF
--- a/tcms/settings/devel.py
+++ b/tcms/settings/devel.py
@@ -14,7 +14,7 @@ DEBUG = True
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': '/tmp/kiwi.devel.sqlite',  # nosec:B108:hardcoded_tmp_directory
+        'NAME': str(TEMP_DIR / 'kiwi.devel.sqlite'),  # noqa: F405
         'USER': 'root',
         'PASSWORD': '',
         'HOST': '',


### PR DESCRIPTION
This PR makes the location of the default database platform agnostic.

On Windows, the default database will now resolve to an appropriately named file in the directory used for temporary files.