### PR TITLE
Add tests for tcms.bugs.views.Search -- Closes #1601

### DIFF
--- a/tcms/bugs/tests/test_permissions.py
+++ b/tcms/bugs/tests/test_permissions.py
@@ -138,6 +138,17 @@ class TestAddComment(tests.PermissionsTestCase):
         self.assertEqual(comments.last().comment, 'A comment text')
 
 
+class TestSearch(tests.PermissionsTestCase):
+    permission_label = 'bugs.view_bug'
+    url = reverse('bugs-search')
+    http_method_names = ['get']
+
+    def verify_get_with_permission(self):
+        response = self.client.get(self.url)
+
+        self.assertTemplateUsed(response, 'bugs/search.html')
+
+
 class TestM2MPermissionsExist(TestCase):
     def test_permissions_exist(self):
         ctype = ContentType.objects.get_for_model(Bug.tags.through)

--- a/tcms/bugs/tests/test_views.py
+++ b/tcms/bugs/tests/test_views.py
@@ -14,6 +14,7 @@ from tcms.core.helpers.comments import get_comments                   # noqa: E4
 from tcms.core.templatetags.extra_filters import markdown2html        # noqa: E402
 from tcms.bugs.models import Bug                                      # noqa: E402
 from tcms.bugs.tests.factory import BugFactory                        # noqa: E402
+from tcms.management.models import Product                            # noqa: E402
 from tcms.tests import (                                              # noqa: E402
     BaseCaseRun,
     LoggedInTestCase,
@@ -247,3 +248,25 @@ class TestAddComment(LoggedInTestCase):
 
         self.assertEqual(comments.count(), old_comment_count + 1)
         self.assertEqual(comments.last().comment, _('*bug reopened*'))
+
+
+class TestSearch(LoggedInTestCase):
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        user_should_have_perm(cls.tester, 'bugs.view_bug')
+
+        ProductFactory()
+        VersionFactory()
+        BuildFactory()
+
+    def test_initial_form_field_states(self):
+        product_count = Product.objects.count()
+
+        response = self.client.get(reverse('bugs-search'))
+        fields = response.context['form'].fields
+
+        self.assertEqual(fields['product'].queryset.count(), product_count)
+        self.assertEqual(fields['version'].queryset.count(), 0)
+        self.assertEqual(fields['build'].queryset.count(), 0)


### PR DESCRIPTION
This PR adds tests for the view `Search` in `tcms/bugs/views.py` as per #1601