### PR TITLE
Make it possible to use reCAPTCHA during registration

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -7,6 +7,7 @@ django-attachments==1.8
 django-contrib-comments==1.9.2
 django-extensions==3.0.8
 django-modern-rpc==0.12.1
+django-recaptcha==2.0.6
 django-simple-history==2.11.0
 jira==2.0.0
 Markdown==3.2.2

--- a/tcms/kiwi_auth/forms.py
+++ b/tcms/kiwi_auth/forms.py
@@ -69,7 +69,7 @@ class RegistrationForm(UserCreationForm):
         )
 
 
-class PasswordResetForm(DjangoPasswordResetForm):
+class PasswordResetForm(DjangoPasswordResetForm):  # pylint: disable=must-inherit-from-model-form
     """
         Overrides the default form b/c it uses Site.objects.get_current()
         which uses an internal cache and produces wrong results when

--- a/tcms/kiwi_auth/forms.py
+++ b/tcms/kiwi_auth/forms.py
@@ -17,9 +17,16 @@ from tcms.utils.permissions import initiate_user_with_default_setups
 
 User = get_user_model()  # pylint: disable=invalid-name
 
+# actually enable only if app is configured
+if 'captcha' in settings.INSTALLED_APPS:
+    from captcha.fields import ReCaptchaField
+else:
+    ReCaptchaField = None.__class__  # pylint: disable=invalid-name
+
 
 class RegistrationForm(UserCreationForm):
     email = forms.EmailField()
+    captcha = ReCaptchaField()
 
     class Meta:
         model = User

--- a/tcms/templates/registration/registration_form.html
+++ b/tcms/templates/registration/registration_form.html
@@ -42,6 +42,17 @@
             <span class="help-block">{{ form.email.help_text }}</span>
           </div>
         </div>
+
+    {% if 'captcha' in form.fields %}
+        <div class="form-group">
+
+          <label class="col-sm-2 col-md-2"></label>
+          <div class="col-sm-10 col-md-10">
+            {{ form.captcha }}
+          </div>
+        </div>
+    {% endif %}
+
         <div class="form-group">
           <div class="col-xs-12 col-sm-offset-2 col-sm-10 col-md-offset-2 col-md-10 submit">
             <button type="submit" class="btn btn-primary btn-lg" tabindex="5">{% trans "Register" %}</button>

--- a/tests/check-build
+++ b/tests/check-build
@@ -82,6 +82,8 @@ echo "..... Trying to install the new tarballs inside a virtualenv"
 virtualenv -q -p $(which python) .venv/test-tarball
 source .venv/test-tarball/bin/activate
 pip install --upgrade setuptools pip
+# https://github.com/praekelt/django-recaptcha/issues/222
+pip install django-recaptcha  # workaround missing tar.gz
 pip install --no-binary :all: dist/kiwitcms*.tar.gz
 pip freeze | grep kiwitcms
 deactivate

--- a/tests/check-build
+++ b/tests/check-build
@@ -75,8 +75,8 @@ tar -tvf dist/kiwitcms-*.tar.gz | grep "tcms/testcases/templates"
 tar -tvf dist/kiwitcms-*.tar.gz | grep "tcms/testplans/static"
 tar -tvf dist/kiwitcms-*.tar.gz | grep "tcms/testplans/templates"
 
-tar -tvf dist/kiwitcms-*.tar.gz | grep "tcms/testplans/static"
-tar -tvf dist/kiwitcms-*.tar.gz | grep "tcms/testplans/templates"
+tar -tvf dist/kiwitcms-*.tar.gz | grep "tcms/testruns/static"
+tar -tvf dist/kiwitcms-*.tar.gz | grep "tcms/testruns/templates"
 
 echo "..... Trying to install the new tarballs inside a virtualenv"
 virtualenv -q -p $(which python) .venv/test-tarball


### PR DESCRIPTION
If you want to enable this then add the following to your settings:

```
if 'captcha' not in INSTALLED_APPS:
    INSTALLED_APPS.append('captcha')

    RECAPTCHA_PUBLIC_KEY = '......'
    RECAPTCHA_PRIVATE_KEY = '.....'
    RECAPTCHA_USE_SSL = True
```
For more info see https://www.google.com/recaptcha/admin/

