### PR TITLE
Refresh execution row after reporting a bug

### DIFF
--- a/tcms/testruns/templates/testruns/get.html
+++ b/tcms/testruns/templates/testruns/get.html
@@ -187,7 +187,7 @@
                 <div class="card-pf-body">
                     <div id="test-executions-container" class="list-group tree-list-view-pf">
                         <template id="test-execution-row">
-                            <div class="list-group-item">
+                            <div class="list-group-item test-execution-element">
                                 <div class="list-group-item-header">
                                     <div class="list-view-pf-main-info">
                                         <div class="list-view-pf-left">


### PR DESCRIPTION
~~For whatever reason ATM the `animate` callback is executed twice and the bug counter and list is updated with 2 bugs(not 1). I will try to troubleshoot this and solve it before merging this.~~

02d07575b483d7ca4d02d7510326a00d2e0e41a2 solved it - there were 2 elements with this class, so the `fadeOut` was executed twice.