### PR TITLE
Render test execution information

### DIFF
--- a/tcms/testruns/static/testruns/js/get.js
+++ b/tcms/testruns/static/testruns/js/get.js
@@ -253,6 +253,9 @@ function renderTestExecutionRow(testExecution) {
     template.find('.test-execution-info-link').attr('href', `/case/${testExecution.case_id}/`)
     template.find('.test-execution-tester').html(testExecution.tested_by || '-')
     template.find('.test-execution-asignee').html(testExecution.assignee || '-')
+    template.find('.test-execution-information .run-date').html(testExecution.close_date || '-')
+    template.find('.test-execution-information .build').html(testExecution.build)
+    template.find('.test-execution-information .text-version').html(testExecution.case_text_version)
 
     const testExecutionStatus = testExecutionStatuses.find(status => status.id === testExecution.status_id)
 

--- a/tcms/testruns/templates/testruns/get.html
+++ b/tcms/testruns/templates/testruns/get.html
@@ -260,6 +260,26 @@
                                                 <p class="test-execution-notes">
                                                     <strong>{% trans 'Notes' %}:</strong>
                                                 </p>
+                                                <div class="test-execution-information">
+                                                    <span style="padding-right: 1.5rem;">
+                                                        <span style="font-weight: bold">
+                                                            {% trans 'Run Date' %}:
+                                                        </span>
+                                                        <span class="run-date"></span>
+                                                    </span>
+                                                    <span style="padding-right: 1.5rem;">
+                                                        <span style="font-weight: bold">
+                                                            {% trans 'Build' %}:
+                                                        </span>
+                                                        <span class="build"></span>
+                                                    </span>
+                                                    <span style="padding-right: 1.5rem;">
+                                                        <span style="font-weight: bold">
+                                                            {% trans 'Text version' %}:
+                                                        </span>
+                                                        <span class="text-version"></span>
+                                                    </span>
+                                                </div>
                                                 <strong>{% trans "Bugs and hyperlinks" %}: </strong>
                                                 <div>
                                                     <ul class="test-execution-hyperlinks"></ul>


### PR DESCRIPTION
Not sure if styling and positioning is ideal. I am welcome to suggestions.

<img width="1266" alt="Screenshot 2020-09-26 at 16 16 12" src="https://user-images.githubusercontent.com/18421997/94341658-c8e8a300-0013-11eb-9cc7-8b85e4c576e9.png">
