### PR TITLE
Collapse TestPlan document card if text is very long

### DIFF
--- a/tcms/testplans/static/testplans/js/get.js
+++ b/tcms/testplans/static/testplans/js/get.js
@@ -31,7 +31,29 @@ $(document).ready(function() {
 
     toolbarDropdowns();
     toolbarEvents();
+
+    collapseDocumentText();
 });
+
+function collapseDocumentText() {
+    // for some reason .height() reports a much higher value than
+    // reality and the 59% reduction seems to work nicely
+    const infoCardHeight = 0.59 * $('#testplan-info').height();
+
+    if ($('#testplan-text').height() > infoCardHeight) {
+        $('#testplan-text-collapse-btn').removeClass('hidden');
+
+        $('#testplan-text').css('min-height', infoCardHeight);
+        $('#testplan-text').css('height', infoCardHeight);
+        $('#testplan-text').css('overflow', 'hidden');
+
+        $('#testplan-text').on('hidden.bs.collapse', function () {
+            $('#testplan-text').removeClass('collapse').css({
+                'height': infoCardHeight
+            })
+        });
+    }
+}
 
 function adjustTestPlanFamilyTree() {
     // remove the > arrows from elements which don't have children

--- a/tcms/testplans/templates/testplans/get.html
+++ b/tcms/testplans/templates/testplans/get.html
@@ -27,14 +27,20 @@
         <div class="col-xs-12 col-sm-12 col-md-9">
             <div class="card-pf card-pf-accented">
                 <div class="card-pf-body">
-                    <div class="markdown-text">
+                    <div class="markdown-text" id="testplan-text">
                         {{ object.text|markdown2html }}
                     </div>
+
+                    <a id="testplan-text-collapse-btn" class="hidden"
+                        style="float: right" title="{% trans 'Show more' %}"
+                        data-toggle="collapse" href="#testplan-text">
+                        <span class="fa fa-angle-double-down"></span>
+                    </a>
                 </div>
             </div>
         </div>
 
-        <div class="col-xs-12 col-sm-12 col-md-3">
+        <div class="col-xs-12 col-sm-12 col-md-3" id="testplan-info">
             <div class="card-pf card-pf-accented card-pf-aggregate-status" style="text-align: left">
                 <h2 class="card-pf-title">
                     <span class="fa pficon-user"></span>{% trans 'Author' %}:


### PR DESCRIPTION
for clues we take the height of the info card next to the document
text and expand/collapse trying to match that height for visual
consistency.