### PR TITLE
Add a lint checker to warn against defining GenericForeignKey fields in models

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -60,3 +60,23 @@ jobs:
 
         export LANG=en-us
         make pylint
+
+  pylint_site_packages:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.7]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Lint with pylint
+      run: |
+        pip install pylint pylint-django
+        pip install -r requirements/mariadb.txt
+        pip install -r requirements/postgres.txt
+
+        make pylint_site_packages

--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,12 @@ pylint:
 	PYTHONPATH=.:./tcms/ DJANGO_SETTINGS_MODULE=$(DJANGO_SETTINGS_MODULE) pylint --load-plugins=pylint_django.checkers.migrations -d missing-docstring -d duplicate-code --module-naming-style=any  tcms/*/migrations/*
 	PYTHONPATH=.:./tcms/ DJANGO_SETTINGS_MODULE=$(DJANGO_SETTINGS_MODULE) pylint --load-plugins=pylint_django --load-plugins=kiwi_lint --load-plugins=pylint.extensions.docparams -d missing-docstring -d duplicate-code tcms/ tcms_settings_dir/
 
+.PHONY: pylint_site_packages
+pylint_site_packages:
+	if [ -d "$(PATH_TO_SITE_PACKAGES)" ]; then \
+	    PYTHONPATH=.:./tcms/ DJANGO_SETTINGS_MODULE=tcms.settings.common find $(PATH_TO_SITE_PACKAGES) -type d -maxdepth 1 -not -path '$(PATH_TO_SITE_PACKAGES)' -exec pylint --load-plugins=kiwi_lint --disable=all --enable=avoid-generic-foreign-key '{}' \; ;\
+	fi
+
 .PHONY: bandit
 bandit:
 	bandit -r *.py tcms/ kiwi_lint/ tcms_settings_dir/

--- a/kiwi_lint/__init__.py
+++ b/kiwi_lint/__init__.py
@@ -22,6 +22,7 @@ from .views import ClassBasedViewChecker
 from .datetime import DatetimeChecker
 from .forms import FormFieldChecker, ModelFormChecker
 from .db_column import DbColumnChecker
+from .generic_foreign_key import GenericForeignKeyChecker
 
 
 def register(linter):
@@ -45,3 +46,4 @@ def register(linter):
     linter.register_checker(FormFieldChecker(linter))
     linter.register_checker(ModelFormChecker(linter))
     linter.register_checker(DbColumnChecker(linter))
+    linter.register_checker(GenericForeignKeyChecker(linter))

--- a/kiwi_lint/generic_foreign_key.py
+++ b/kiwi_lint/generic_foreign_key.py
@@ -1,0 +1,25 @@
+import astroid
+from pylint.checkers import utils, BaseChecker
+from pylint.interfaces import IAstroidChecker
+
+
+class GenericForeignKeyChecker(BaseChecker):
+    __implements__ = (IAstroidChecker, )
+
+    name = 'generic-foreign-key-checker'
+
+    msgs = {
+        'E4851': (
+            'Avoid defining GenericForeignKey fields',
+            'avoid-generic-foreign-key',
+            'Avoid defining GenericForeignKey fields in models,'
+            'See: https://github.com/kiwitcms/Kiwi/issues/1303',
+        )
+    }
+
+    @utils.check_messages('avoid-generic-foreign-key')
+    def visit_call(self, node):
+        if isinstance(node.func, astroid.Name) and node.func.name == 'GenericForeignKey':
+            self.add_message('avoid-generic-foreign-key', node=node)
+        if isinstance(node.func, astroid.Attribute) and node.func.attrname == 'GenericForeignKey':
+            self.add_message('avoid-generic-foreign-key', node=node)


### PR DESCRIPTION
Resolves #1303 Add a lint checker to warn against defining GenericForeignKey fields in models