### PR TITLE
Implement drag & reorder functionality & new API

### DIFF
--- a/tcms/package.json
+++ b/tcms/package.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
     "bootstrap-switch": "3.3.4",
+    "html5sortable": "0.9.18",
     "marked": "1.2.0",
     "patternfly": "3.59.5",
     "prismjs": "1.21.0",

--- a/tcms/rpc/api/testplan.py
+++ b/tcms/rpc/api/testplan.py
@@ -17,6 +17,7 @@ __all__ = (
 
     'add_case',
     'remove_case',
+    'update_case_order',
 
     'add_tag',
     'remove_tag',
@@ -200,6 +201,26 @@ def remove_case(plan_id, case_id):
         :raises PermissionDenied: if missing *testcases.delete_testcaseplan* permission
     """
     TestCasePlan.objects.filter(case=case_id, plan=plan_id).delete()
+
+
+@permissions_required('testcases.change_testcaseplan')
+@rpc_method(name='TestPlan.update_case_order')
+def update_case_order(plan_id, case_id, sortkey):
+    """
+    .. function:: RPC TestPlan.update_case_order(plan_id, case_id, sortkey)
+
+        Update sortkey which controls display order of the given test case in
+        the given test plan.
+
+        :param plan_id: PK of TestPlan holding the selected TestCase
+        :type plan_id: int
+        :param case_id: PK of TestCase to be modified
+        :type case_id: int
+        :param sortkey: Ordering value, e.g. 10, 20, 30
+        :type sortkey: int
+        :raises PermissionDenied: if missing *testcases.delete_testcaseplan* permission
+    """
+    TestCasePlan.objects.filter(case=case_id, plan=plan_id).update(sortkey=sortkey)
 
 
 @permissions_required('attachments.view_attachment')

--- a/tcms/testplans/templates/testplans/get.html
+++ b/tcms/testplans/templates/testplans/get.html
@@ -134,6 +134,12 @@
                                                 <span class="fa fa-sort-alpha-asc" data-order="1"></span>
                                                 <span class="fa fa-sort-alpha-desc hidden" data-order="-1"></span>
                                             </button>
+
+                                            {% if perms.testcases.change_testcaseplan %}
+                                            <button class="btn btn-link js-toolbar-manual-sort" type="button" title="{% trans 'Re-order cases' %}">
+                                                <span class="fa fa-sort"></span>
+                                            </button>
+                                            {% endif %}
                                         </div>
                                     </div>
                                     <div class="form-group">
@@ -195,6 +201,7 @@
                                             {% if perms.testcases.change_testcase %}
                                                 <li><a href="#">{% trans 'Reviewer' %}</a></li>
                                             {% endif %}
+
                                             </ul>
                                         </div>
 
@@ -240,10 +247,13 @@
     <div class="list-group-item js-testcase-row" data-testcase-pk="">
         <div class="list-group-item-header">
             <div class="list-view-pf-main-info">
-                <div class="list-view-pf-left">
+                <div class="list-view-pf-left hidden js-testcase-sort-handler">
+                    <span class="fa fa-sort handle"></span>
+                </div>
+                <div class="list-view-pf-left js-testcase-expand-arrow">
                     <span class="fa fa-angle-right"></span>
                 </div>
-                <div class="list-view-pf-checkbox" style="margin-top: 0; margin-bottom: 0">
+                <div class="list-view-pf-checkbox js-testcase-checkbox" style="margin-top: 0; margin-bottom: 0">
                     <input type="checkbox">
                 </div>
                 <div class="list-view-pf-actions" style="margin-top: 0; margin-bottom: 0;">
@@ -359,6 +369,7 @@
     <li data-filter-type="reviewer"><a>{% trans 'Reviewer' %}</a></li>
 </template>
 
+<script src="{% static 'html5sortable/dist/html5sortable.min.js' %}"></script>
 <script src="{% static 'typeahead.js/dist/typeahead.jquery.min.js' %}"></script>
 <script src="{% static 'js/utils.js' %}"></script>
 <script src="{% static 'js/jsonrpc.js' %}"></script>


### PR DESCRIPTION
NOTES:

- uses Sortable.js for drag & reorder
- manual sorting button is located after A-Z button in toolbar
- NEW API method TestPlan.update_case_order()
- Manual reorder & API require the testcases.change_testcaseplan
  permission

- toolbarDropdowns() is called from within toolbarEvents() b/c
  it really doesn't make sense to have this as stand-alone function
- toolbarEvents() is moved within the TestCases.filter() callback
  b/c we need the list of test cases to be fully initialized so we
  can get the initial sorting order and use it later

WARNINGS:

- may want to unbind the on-click event for rows if users are
  having problems with the rows expanding while dragging them
- the page doesn't use sortkey for initially displaying the rows
  of test cases because this field isn't available in the API result.

  Specifically sortkey is a field in the TestCasePlan model, which
  is a *through* model and the .filter() API is querying the TestCase
  model instead.