### PR TITLE
[WIP] add test for testexecutionstatus #1626

### DIFF
--- a/tcms/rpc/tests/test_testexecutionstatus.py
+++ b/tcms/rpc/tests/test_testexecutionstatus.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=attribute-defined-outside-init, invalid-name, objects-update-used
+
+from xmlrpc.client import ProtocolError
+from tcms.rpc.tests.utils import APITestCase, APIPermissionsTestCase
+
+
+class TestFilter(APITestCase):
+    """Test TestExecutionStatus.filter"""
+
+    def test_filter_statuses(self):
+        execution_statuses = self.rpc_client.TestExecutionStatus.filter(
+            {"weight__lt": 0}
+        )
+
+        self.assertGreater(len(execution_statuses), 0)
+        for execution_status in execution_statuses:
+            self.assertLess(execution_status['weight'], 0)
+            self.assertIsNotNone(execution_status['id'])
+            self.assertIsNotNone(execution_status['name'])
+            self.assertIsNotNone(execution_status['color'])
+            self.assertIsNotNone(execution_status['icon'])
+
+
+class TestFilterPermission(APIPermissionsTestCase):
+    """Test permission for TestExecutionStatus.filter"""
+
+    permission_label = "testruns.view_testexecutionstatus"
+
+    def verify_api_with_permission(self):
+        execution_statuses = self.rpc_client.TestExecutionStatus.filter(
+            {"weight__lt": 0}
+        )
+        self.assertGreater(len(execution_statuses), 0)
+
+    def verify_api_without_permission(self):
+        with self.assertRaisesRegex(ProtocolError, "403 Forbidden"):
+            self.rpc_client.TestExecutionStatus.filter({"weight__lt": 0})


### PR DESCRIPTION
This is a draft PR for adding automated tests for missing coverage in `tcms.rpc.api.testexecutionstatus` module according to #1626. This is my first time working with such a large codebase and I understand there might be a lot of problems with the PR so I'm looking for someone to help me figure out how I can improve and correct the code with a review.