### PR TITLE
Add automated tests for tcms.rpc.api.testcasestatus

### DIFF
--- a/tcms/rpc/tests/test_testcasestatus.py
+++ b/tcms/rpc/tests/test_testcasestatus.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=attribute-defined-outside-init
+
+from xmlrpc.client import ProtocolError
+from tcms.rpc.tests.utils import APITestCase, APIPermissionsTestCase
+
+
+class TestCaseStatusFilter(APITestCase):
+    """Test TestCaseStatus.filter method"""
+
+    def test_filter_case_status(self):
+        case_statuses = self.rpc_client.TestCaseStatus.filter({})
+
+        self.assertGreater(len(case_statuses), 0)
+        for case_status in case_statuses:
+            self.assertIsNotNone(case_status['id'])
+            self.assertIsNotNone(case_status['name'])
+            self.assertIsNotNone(case_status['description'])
+
+
+class TestCaseStatusFilterPermissions(APIPermissionsTestCase):
+    """Test permission for TestCaseStatus.filter method"""
+
+    permission_label = "testcases.view_testcasestatus"
+
+    def verify_api_with_permission(self):
+        case_status = self.rpc_client.TestCaseStatus.filter({})
+        self.assertGreater(len(case_status), 0)
+
+    def verify_api_without_permission(self):
+        with self.assertRaisesRegex(ProtocolError, "403 Forbidden"):
+            self.rpc_client.TestCaseStatus.filter({})


### PR DESCRIPTION
Addresses #1624 

Add automated Tests for tcms.rpc.api.testcasestatus. Two test cases with two different test case status have been made for querying.
- `test_filter_case_status` filters case status using name.
- `test_filter_case_status` filters case status using case id.