### PR TITLE
API TestExecution.update() will adjust close_date. Fixes #1820

### DIFF
--- a/tcms/rpc/api/forms/testrun.py
+++ b/tcms/rpc/api/forms/testrun.py
@@ -42,3 +42,4 @@ class UpdateExecutionForm(UpdateModelFormMixin, forms.ModelForm):
 
     assignee = UserField()
     tested_by = UserField()
+    close_date = DateTimeField()

--- a/tcms/rpc/api/testexecution.py
+++ b/tcms/rpc/api/testexecution.py
@@ -2,6 +2,7 @@
 
 from django.conf import settings
 from django.forms.models import model_to_dict
+from django.utils import timezone
 from modernrpc.core import REQUEST_KEY, rpc_method
 
 from tcms.core.contrib.linkreference.models import LinkReference
@@ -124,6 +125,14 @@ def update(execution_id, values):
         test_execution = form.save()
     else:
         raise ValueError(form_errors_to_list(form))
+
+    # if this call updated TE.status then adjust timestamps
+    if values.get('status'):
+        if test_execution.status.weight != 0:
+            test_execution.close_date = timezone.now()
+        else:
+            test_execution.close_date = None
+        test_execution.save()
 
     return test_execution.serialize()
 

--- a/tcms/rpc/tests/test_testexecution.py
+++ b/tcms/rpc/tests/test_testexecution.py
@@ -393,3 +393,33 @@ class TestExecutionUpdate(APITestCase):
         with self.assertRaisesRegex(ProtocolError, '403 Forbidden'):
             self.rpc_client.TestExecution.update(self.execution_1.pk,
                                                  {"close_date": timezone.now()})
+
+    def test_update_non_zero_status_changes_close_date(self):
+        """
+            Non-zero weight statuses will set close_date
+        """
+        few_secs_ago = timezone.now()
+        self.execution_1.close_date = None
+        self.execution_1.save()
+
+        self.rpc_client.TestExecution.update(self.execution_1.pk, {
+            'status': self.status_positive.pk,
+        })
+
+        self.execution_1.refresh_from_db()
+        self.assertGreater(self.execution_1.close_date, few_secs_ago)
+
+    def test_update_zero_status_changes_close_date(self):
+        """
+            Zero weight statuses will set close_date to None,
+            e.g. re-test the TE!
+        """
+        self.execution_1.close_date = timezone.now()
+        self.execution_1.save()
+
+        self.rpc_client.TestExecution.update(self.execution_1.pk, {
+            'status': TestExecutionStatus.objects.filter(weight=0).first().pk,
+        })
+
+        self.execution_1.refresh_from_db()
+        self.assertIsNone(self.execution_1.close_date)


### PR DESCRIPTION
When changing status the close_date field will be updated according to status.weight

cherry-picked from the refactoring branch.