### PR TITLE
Add Automated tests for missing coverage in tcms.rpc.api.priority

### DIFF
--- a/tcms/rpc/tests/test_priority.py
+++ b/tcms/rpc/tests/test_priority.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=attribute-defined-outside-init
+
+from xmlrpc.client import ProtocolError
+from tcms.rpc.tests.utils import APITestCase, APIPermissionsTestCase
+
+
+class TestPriorityFilter(APITestCase):
+    """Test Priority.filter method"""
+
+    def test_filter_priority(self):
+        priorities = self.rpc_client.Priority.filter({})
+
+        self.assertGreater(len(priorities), 0)
+        for priority in priorities:
+            self.assertIsNotNone(priority["id"])
+            self.assertIsNotNone(priority["value"])
+            self.assertIsNotNone(priority["is_active"])
+
+
+class TestPriorityFilterPermissions(APIPermissionsTestCase):
+    """Test permission for Priority.filter method"""
+
+    permission_label = "management.view_priority"
+
+    def verify_api_with_permission(self):
+        priorities = self.rpc_client.Priority.filter({})
+        self.assertGreater(len(priorities), 0)
+
+    def verify_api_without_permission(self):
+        with self.assertRaisesRegex(ProtocolError, "403 Forbidden"):
+            self.rpc_client.Priority.filter({})


### PR DESCRIPTION
Addresses #1622 
- `TestPriorityFilter` tests Priority.filter method
- `TestPriorityFilterPermissions` tests permissions for Priority.filter method