### PR TITLE
Add automated tests for missing coverage in tcms.rpc.api.auth

### DIFF
--- a/tcms/rpc/api/auth.py
+++ b/tcms/rpc/api/auth.py
@@ -17,7 +17,7 @@ def login(username, password, **kwargs):  # pylint: disable=missing-api-permissi
 
         Login into Kiwi TCMS.
 
-        :param username: A Kiwi TCMS login or email address
+        :param username: A Kiwi TCMS login
         :type username: str
         :param password: The password
         :type password: str

--- a/tcms/rpc/tests/test_auth.py
+++ b/tcms/rpc/tests/test_auth.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=attribute-defined-outside-init
+
+from xmlrpc.client import Fault as XmlRPCFault, ProtocolError
+from tcms.rpc.tests.utils import APITestCase
+
+
+class TestAuthLogin(APITestCase):
+    """Test Auth.login method"""
+
+    def _fixture_setup(self):
+        super()._fixture_setup()
+
+        self.rpc_client.Auth.logout()
+
+    def test_login_with_username(self):
+        sesson_id = self.rpc_client.Auth.login(self.api_user.username, "api-testing")
+        self.assertIsNotNone(sesson_id)
+
+    def test_login_without_password(self):
+        with self.assertRaisesRegex(XmlRPCFault, "Username and password is required"):
+            self.rpc_client.Auth.login(self.api_user.username, "")
+
+    def test_login_with_incorrect_password(self):
+        with self.assertRaisesRegex(XmlRPCFault, "Wrong username or password"):
+            self.rpc_client.Auth.login(self.api_user.username, "kiwi-password")
+
+
+class TestAuthLogout(APITestCase):
+    """Test Auth.logout method"""
+
+    def test_logout(self):
+        self.rpc_client.Auth.logout()
+        with self.assertRaisesRegex(ProtocolError, "403 Forbidden"):
+            # this method requires a logged-in user
+            self.rpc_client.Bug.details("http://some.url")


### PR DESCRIPTION
Addresses #1620 
- `TestAuthLogin` tests Auth.login method
- `TestAuthLogout` tests  Auth.logout method

According to docstring [here](https://github.com/kiwitcms/Kiwi/blob/ac31b26f129aef0bb4b0768334cdad4eeb092086/tcms/rpc/api/auth.py#L20), Auth.login method work with either username or email, but actually, it fails with email as a parameter.