### PR TITLE
Documentation fixes for BitBucket and AzureBoards IssueTrackers.

### DIFF
--- a/tcms/issuetracker/azure_boards.py
+++ b/tcms/issuetracker/azure_boards.py
@@ -70,9 +70,8 @@ class AzureBoards(IssueTrackerType):
     """
         Support for AzureBoards. Requires:
 
-        :base_url: - URL to a AzureBoards project for which we're going to report issues
-        e.g. https://dev.azure.com/{organization}/{project}
-        :api_password: - AzureBoards API token - requires "Read & Write" permission
+        :base_url: URL to AzureBoards Project - e.g. https://dev.azure.com/{organization}/{project}
+        :api_password: AzureBoards API token - requires "Read & Write" permission
 
         .. note::
 

--- a/tcms/issuetracker/bitbucket.py
+++ b/tcms/issuetracker/bitbucket.py
@@ -81,7 +81,7 @@ class BitBucket(IssueTrackerType):
     """
         Support for BitBucket. Requires:
 
-        :base_url: - e.g. https://bitbucket.org/{workspace}/{repository}
+        :base_url: Repository URL - e.g. https://bitbucket.org/{workspace}/{repository}
         :api_username: BitBucket Username
         :api_password: BitBucket App Password - needs Issues: Read & write permission.
 
@@ -94,7 +94,7 @@ class BitBucket(IssueTrackerType):
 
             ``api_username`` is your BitBucket username, which you use to log in.
 
-        .. info::
+        .. note::
 
             ``api_password`` is "App Password" created in BitBucket.
             Here is a guide about creating and using an "App Password";


### PR DESCRIPTION
Fixed the below problems in RTD;
- AzureBoards
  1. Example url line was misalinged. 
  2. Unnecesary bullet removed for base_url.


- BitBucket 
  1.   There is no `info` tag in RTD. So it is changed as `note` for api_password.
  2.   Unnecessary bullet removed for base_url.