### PR TITLE
Remove delete_selected action from admin, see 4d79de41

### DIFF
--- a/tcms/bugs/admin.py
+++ b/tcms/bugs/admin.py
@@ -8,8 +8,6 @@ from tcms.core.history import ReadOnlyHistoryAdmin
 
 
 class BugAdmin(ObjectPermissionsAdminMixin, ReadOnlyHistoryAdmin):
-    actions = ['delete_selected']
-
     def add_view(self, request, form_url='', extra_context=None):
         return HttpResponseRedirect(reverse('bugs-new'))
 

--- a/tcms/testcases/admin.py
+++ b/tcms/testcases/admin.py
@@ -45,8 +45,6 @@ class TestCaseStatusAdmin(admin.ModelAdmin):
 
 
 class TestCaseAdmin(ObjectPermissionsAdminMixin, ReadOnlyHistoryAdmin):
-    actions = ['delete_selected']
-
     def add_view(self, request, form_url='', extra_context=None):
         return HttpResponseRedirect(reverse('testcases-new'))
 

--- a/tcms/testplans/admin.py
+++ b/tcms/testplans/admin.py
@@ -17,8 +17,6 @@ class TestPlanAdmin(ObjectPermissionsAdminMixin, ReadOnlyHistoryAdmin):
     """
         Does not allow adding new or changing plans.
     """
-    actions = ['delete_selected']
-
     def add_view(self, request, form_url='', extra_context=None):
         return HttpResponseRedirect(reverse('admin:testplans_testplan_changelist'))
 

--- a/tcms/testruns/admin.py
+++ b/tcms/testruns/admin.py
@@ -11,8 +11,6 @@ from tcms.testruns.models import TestRun, TestExecutionStatus
 
 
 class TestRunAdmin(ObjectPermissionsAdminMixin, ReadOnlyHistoryAdmin):
-    actions = ['delete_selected']
-
     def add_view(self, request, form_url='', extra_context=None):
         return HttpResponseRedirect(reverse('admin:testruns_testrun_changelist'))
 


### PR DESCRIPTION
also makes it harder for anyone (even if they have permissions) to
just remove everything from the database as we've seen recently
happening on public.tenant.