### PR TITLE
Fix testing bugtracker integration

### DIFF
--- a/.github/workflows/integration_bugtracker.yml
+++ b/.github/workflows/integration_bugtracker.yml
@@ -37,6 +37,7 @@ jobs:
     # runs the tests. Some trackers may end up with empty initialization!
     - name: Install Python dependencies
       run: |
+        pip install -U pip
         pip install -r requirements/devel.txt
 
     - name: Initialize bugs DB


### PR DESCRIPTION
and update pip as an attempt to fix issues:

requests 2.25.0 requires chardet<4,>=3.0.2, but you'll have
                         chardet 4.0.0 which is incompatible.
pygithub 1.54 requires requests<2.25,>=2.14.0, but you'll have
                       requests 2.25.0 which is incompatible.

which can't be reproduced locally with 3.6/latest pip