### PR TITLE
tests: Use exit code from the last command

### DIFF
--- a/tests/runner.sh
+++ b/tests/runner.sh
@@ -6,10 +6,13 @@
 rm -rf /var/tmp/beakerlib-*/
 export BEAKERLIB_JOURNAL=0
 
-# install beakerlib from a fork b/c
-# https://github.com/beakerlib/beakerlib/pull/11
+# install beakerlib from source b/c beakerlib doesn't ship
+# .deb packages
 if [ ! -f "/usr/share/beakerlib/beakerlib.sh" ]; then
-    curl -o- https://raw.githubusercontent.com/atodorov/beakerlib/web-install/install.sh | bash
+    sudo apt-get update
+    sudo apt-get install git make
+    git clone https://github.com/beakerlib/beakerlib.git
+    make -C beakerlib/ install
 fi
 
 # execute test scripts

--- a/tests/runner.sh
+++ b/tests/runner.sh
@@ -22,7 +22,8 @@ fi
 
 
 # look for failures
-grep RESULT_STRING /var/tmp/beakerlib-*/TestResults | grep -v PASS && exit 1
+cat /var/tmp/beakerlib-*/TestResults || exit 11
+grep RESULT_STRING /var/tmp/beakerlib-*/TestResults | grep -v PASS && exit 22
 
 # explicit return code for Makefile
 exit $?

--- a/tests/runner.sh
+++ b/tests/runner.sh
@@ -22,4 +22,4 @@ fi
 grep RESULT_STRING /var/tmp/beakerlib-*/TestResults | grep -v PASS && exit 1
 
 # explicit return code for Makefile
-exit 0
+exit $?


### PR DESCRIPTION
Should catch things like:
/usr/share/beakerlib/beakerlib.sh: line 431: /usr/share/beakerlib/ya.sh: No such file or directory
grep: /var/tmp/beakerlib-*/TestResults: No such file or directory