### PR TITLE
Update: API method for start_date and stop_date Refs. #1924

### DIFF
--- a/tcms/rpc/tests/test_testexecution.py
+++ b/tcms/rpc/tests/test_testexecution.py
@@ -443,7 +443,7 @@ class TestExecutionUpdate(APITestCase):
         self.execution_2 = TestExecutionFactory()
         self.status_positive = TestExecutionStatus.objects.filter(weight__gt=0).last()
 
-    def test_update_with_single_caserun(self):
+    def test_update_with_single_test_execution(self):
         execution = TestExecutionFactory(tested_by=None)
 
         result = self.rpc_client.TestExecution.update(

--- a/tcms/testcases/tests/test_models.py
+++ b/tcms/testcases/tests/test_models.py
@@ -4,11 +4,13 @@
 from django.conf import settings
 from django.template.loader import render_to_string
 from django.test import TestCase
+from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 from mock import patch
 
 from tcms.core.history import history_email_for
 from tcms.testcases.helpers.email import get_case_notification_recipients
+from tcms.testruns.models import TestExecution
 from tcms.tests import BasePlanCase
 from tcms.tests.factories import (
     ComponentFactory,
@@ -157,3 +159,30 @@ class TestSendMailOnCaseIsDeleted(BasePlanCase):
             recipients,
             fail_silently=False,
         )
+
+
+class TestActualDurationProperty(TestCase):
+    """Test TestExecution.actual_duration"""
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+
+        cls.test_execution = TestExecution()
+        cls.test_execution.start_date = timezone.now()
+        cls.test_execution.stop_date = (
+            cls.test_execution.start_date + timezone.timedelta(days=1)
+        )
+
+    def test_calculation_of_actual_duration(self):
+        self.assertEqual(
+            self.test_execution.actual_duration, timezone.timedelta(days=1)
+        )
+
+    def test_actual_duration_empty_start_date(self):
+        empty_start_date_actual_duration = TestExecution(start_date=None)
+        self.assertEqual(empty_start_date_actual_duration.actual_duration, None)
+
+    def test_actual_duration_empty_stop_date(self):
+        empty_stop_date_actual_duration = TestExecution(stop_date=None)
+        self.assertEqual(empty_stop_date_actual_duration.actual_duration, None)

--- a/tcms/testruns/models.py
+++ b/tcms/testruns/models.py
@@ -203,10 +203,6 @@ class TestExecution(models.Model, UrlMixin):
     stop_date = models.DateTimeField(null=True, blank=True, db_index=True)
     sortkey = models.IntegerField(null=True, blank=True)
 
-    @property
-    def actual_duration(self):
-        return self.stop_date - self.start_date
-
     run = models.ForeignKey(
         TestRun, related_name="executions", on_delete=models.CASCADE
     )
@@ -231,6 +227,12 @@ class TestExecution(models.Model, UrlMixin):
     def _get_absolute_url(self):
         # NOTE: this returns the URL to the TestRun containing this TestExecution!
         return reverse("testruns-get", args=[self.run_id])
+
+    @property
+    def actual_duration(self):
+        if self.stop_date is None or self.start_date is None:
+            return None
+        return self.stop_date - self.start_date
 
 
 class TestRunTag(models.Model):


### PR DESCRIPTION
Hello @atodorov, could you please give a recommendation or any advice on how to write test cases for the new start_date and renamed stop_date changes? Also should I add the new property of TestExecution.expected_duration or not yet?

Also for the current commit I made, I was referencing this task from the issue:
`API method TestExecution.update() or the UpdateExecutionForm() - upon changing the status field must set stop_date to the current timestamp if status.weight != 0 (API fix for #1820)`