### PR TITLE
Replace beforeunload & unload window events with a function call.

### DIFF
--- a/tcms/static/js/utils.js
+++ b/tcms/static/js/utils.js
@@ -254,20 +254,11 @@ function showPopup(href) {
 // href - URL of the search page
 // errorMessage - message to display in case of RPC errors
 function advancedSearchAndAddTestCases(objId, rpcMethod, href, errorMessage) {
-    $('#popup-selection').val('');
+    window.addTestCases = function(testCaseIDs, sender){
+        let rpcErrors = 0
 
-    if (href.indexOf('?') === -1) {
-        href += '?allow_select=1';
-    } else {
-        href += '&allow_select=1';
-    }
-
-    let rpcErrors = 0,
-        testCaseIDs = [];
-    popupWindow = showPopup(href);
-
-    $(popupWindow).on('beforeunload', function(){
-        testCaseIDs = $('#popup-selection').val();
+        // close the popup
+        sender.close()
 
         if (testCaseIDs) {
             // monkey-patch the alert() function
@@ -277,28 +268,33 @@ function advancedSearchAndAddTestCases(objId, rpcMethod, href, errorMessage) {
             }
 
             // add the selected test cases
-            testCaseIDs.split(",").forEach(function(testCase) {
+            testCaseIDs.forEach(function(testCase) {
                 jsonRPC(rpcMethod, [objId, testCase], function(result) {}, true)
             })
 
             // revert monkey-patch
             alert = window.alert = oldAlert;
         }
-    });
-
-    $(popupWindow).on('unload', function(){
-        let message;
 
         if (rpcErrors) {
             alert(errorMessage);
         }
 
         // something was added so reload the page
-        if (testCaseIDs.length > rpcErrors) {
+        if (rpcErrors < testCaseIDs.length) {
             window.location.reload(true);
             // TODO: figure out how to reload above and add the new value to the page
         }
-    });
+    };
+
+
+    if (href.indexOf('?') === -1) {
+        href += '?allow_select=1';
+    } else {
+        href += '&allow_select=1';
+    }
+
+    showPopup(href);
 
     return false;
 }

--- a/tcms/testcases/static/testcases/js/search.js
+++ b/tcms/testcases/static/testcases/js/search.js
@@ -175,7 +175,7 @@ $(document).ready(function() {
     table.on('deselect', function (e, dt, type, indexes) {
         if (type === 'row') {
             selectAllButton.prop("checked", false)
-        } 
+        }
     });
 
     $('#select-btn').click(function(event){
@@ -187,8 +187,7 @@ $(document).ready(function() {
         });
 
         if (testCaseIDs && window.opener) {
-            window.opener.$('#popup-selection').val(testCaseIDs);
-            window.close();
+            window.opener.addTestCases(testCaseIDs, window);
         }
 
         return false;

--- a/tcms/testplans/templates/testplans/get.html
+++ b/tcms/testplans/templates/testplans/get.html
@@ -262,7 +262,6 @@
                                             id="btn-search-cases" title="{% trans 'Advanced search' %}">
                                             <span class="fa fa-search"></span>
                                         </button>
-                                        <input type="hidden" id="popup-selection">
                                     </div>
                                 {% endif %}
                                 </form>

--- a/tcms/testruns/templates/testruns/get.html
+++ b/tcms/testruns/templates/testruns/get.html
@@ -304,7 +304,6 @@
                                         id="btn-search-cases" title="{% trans 'Advanced search' %}">
                                         <span class="fa fa-search"></span>
                                     </button>
-                                    <input type="hidden" id="popup-selection">
                                 </div>
                             {% endif %}
                             </form>


### PR DESCRIPTION
because they are deprecated in Chrome browser and lead to
problems for users. Fixes #2100