### PR TITLE
Point TestPlanAdmin add button to correct URL

### DIFF
--- a/tcms/testplans/admin.py
+++ b/tcms/testplans/admin.py
@@ -14,12 +14,8 @@ class PlanTypeAdmin(admin.ModelAdmin):
 
 
 class TestPlanAdmin(ObjectPermissionsAdminMixin, ReadOnlyHistoryAdmin):
-    """
-    Does not allow adding new or changing plans.
-    """
-
     def add_view(self, request, form_url="", extra_context=None):
-        return HttpResponseRedirect(reverse("admin:testplans_testplan_changelist"))
+        return HttpResponseRedirect(reverse("plans-new"))
 
     def change_view(self, request, object_id, form_url="", extra_context=None):
         return HttpResponseRedirect(reverse("test_plan_url_short", args=[object_id]))

--- a/tcms/testplans/tests/test_admin.py
+++ b/tcms/testplans/tests/test_admin.py
@@ -14,9 +14,9 @@ class TestTestPlanAdmin(LoggedInTestCase):
         initiate_user_with_default_setups(cls.tester)
         cls.test_plan = TestPlanFactory()
 
-    def test_users_can_not_add_testplan(self):
+    def test_users_can_add_testplan_via_customized_page(self):
         response = self.client.get(reverse("admin:testplans_testplan_add"))
-        self.assertRedirects(response, reverse("admin:testplans_testplan_changelist"))
+        self.assertRedirects(response, reverse("plans-new"))
 
     def test_users_can_not_change_testplan(self):
         response = self.client.get(


### PR DESCRIPTION
which will open the correct page for creating new test plans
instead of disallowing users to create new objects!