### PR TITLE
Add the new duration fields in testcases/mutable.html template

### DIFF
--- a/tcms/core/widgets.py
+++ b/tcms/core/widgets.py
@@ -40,3 +40,33 @@ $(document).ready(function() {
             "prismjs/plugins/autoloader/prism-autoloader.min.js",
             "js/simplemde_security_override.js",
         ]
+
+
+class DurationWidget(forms.Textarea):
+    def render(self, name, value, attrs=None, renderer=None):
+        rendered_duration = super().render(name, value, attrs, renderer)
+        rendered_duration += """
+<input id="%s" type="text" style="display: none">
+<script>
+$(function () {
+    $('#%s').durationPicker({
+      showDays: true,
+      showHours: true,
+      showMinutes: true,
+      showSeconds: true,
+    });
+});
+</script>
+""" % (
+            attrs["id"],
+            attrs["id"],
+        )
+
+        return rendered_duration
+
+    class Media:
+        css = {"all": ["bootstrap-duration-picker/dist/bootstrap-duration-picker.css"]}
+        js = [
+            "bootstrap-duration-picker/dist/bootstrap-duration-picker.js",
+            "bootstrap-duration-picker/dist/bootstrap-duration-picker-debug.js",
+        ]

--- a/tcms/package.json
+++ b/tcms/package.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "bootstrap-duration-picker": "2.1.3",
     "bootstrap-switch": "3.3.4",
     "html5sortable": "0.11.1",
     "marked": "2.0.1",

--- a/tcms/testcases/forms.py
+++ b/tcms/testcases/forms.py
@@ -4,7 +4,7 @@ from django.forms import inlineformset_factory
 from django.utils.translation import gettext_lazy as _
 
 from tcms.core.forms.fields import UserField
-from tcms.core.widgets import SimpleMDE
+from tcms.core.widgets import DurationWidget, SimpleMDE
 from tcms.management.models import Component, Priority, Product
 from tcms.testcases.fields import MultipleEmailField
 from tcms.testcases.models import (
@@ -34,6 +34,14 @@ class TestCaseForm(forms.ModelForm):
     product = forms.ModelChoiceField(
         queryset=Product.objects.all(),
         empty_label=None,
+    )
+    setup_duration = forms.DurationField(
+        widget=DurationWidget(),
+        required=False,
+    )
+    testing_duration = forms.DurationField(
+        widget=DurationWidget(),
+        required=False,
     )
     text = forms.CharField(
         widget=SimpleMDE(),
@@ -80,7 +88,6 @@ class CaseNotifyForm(forms.ModelForm):
 _email_settings_fields = []  # pylint: disable=invalid-name
 for field in TestCaseEmailSettings._meta.fields:
     _email_settings_fields.append(field.name)
-
 
 # for usage in CreateView, UpdateView
 CaseNotifyFormSet = inlineformset_factory(  # pylint: disable=invalid-name

--- a/tcms/testcases/templates/testcases/mutable.html
+++ b/tcms/testcases/templates/testcases/mutable.html
@@ -101,6 +101,21 @@
             </div>
 
             <div class="form-group">
+                <label class="col-md-1 col-lg-1" >{% trans "Setup Duration" %}</label>
+                    <div class="col-md-3 col-lg-3">
+                            <div id="setup_duration">
+                                {{ form.setup_duration }}
+                            </div>
+                    </div>
+                <label class="col-md-1 col-lg-1" >{% trans "Testing Duration" %}</label>
+                    <div class="col-md-3 col-lg-3">
+                            <div id="testing-duration">
+                                {{ form.testing_duration }}
+                            </div>
+                    </div>
+            </div>
+
+            <div class="form-group">
                 <div class="col-md-12 col-lg-12">
                     <label class="{% if form.text.errors %}has-error{% endif %}">{% trans "Text" %}:</label>
                     <div>{{ form.text }}</div>
@@ -233,11 +248,14 @@
         </form>
     </div>
 
+
 <script src="{% static 'bootstrap-select/dist/js/bootstrap-select.min.js' %}"></script>
 <script src="{% static 'bootstrap-switch/dist/js/bootstrap-switch.min.js' %}"></script>
-<script src="{% static "grappelli/jquery/jquery.min.js" %}"></script>
-<script src="{% static "grappelli/js/grappelli.min.js" %}"></script>
-<script src="{% static "admin/js/admin/RelatedObjectLookups.js" %}"></script>
+<script src="{% static 'bootstrap-duration-picker/dist/bootstrap-duration-picker.js' %}"></script>
+<script src="{% static 'bootstrap-duration-picker/dist/bootstrap-duration-picker-debug.js' %}"></script>
+<script src="{% static 'grappelli/jquery/jquery.min.js' %}"></script>
+<script src="{% static 'grappelli/js/grappelli.min.js' %}"></script>
+<script src="{% static 'admin/js/admin/RelatedObjectLookups.js' %}"></script>
 
 <script src="{% static 'js/jsonrpc.js' %}"></script>
 <script src="{% static 'js/utils.js' %}"></script>

--- a/tcms/testcases/tests/test_views.py
+++ b/tcms/testcases/tests/test_views.py
@@ -88,6 +88,7 @@ class TestNewCase(BasePlanCase):
         cls.summary = "summary"
         cls.text = "some text description"
         cls.script = "some script"
+        cls.duration = "2:20:10:00"
         cls.arguments = "args1, args2, args3"
         cls.requirement = "requirement"
         cls.link = "http://somelink.net"
@@ -100,6 +101,8 @@ class TestNewCase(BasePlanCase):
             "category": cls.case.category.pk,
             "case_status": cls.case_status_confirmed.pk,
             "priority": cls.case.priority.pk,
+            "setup_duration": cls.duration,
+            "testing_duration": "00:00:00:00",
             "text": cls.text,
             "script": cls.script,
             "arguments": cls.arguments,
@@ -180,6 +183,8 @@ class TestNewCase(BasePlanCase):
         self.assertEqual(test_case.requirement, self.requirement)
         self.assertEqual(test_case.extra_link, self.link)
         self.assertEqual(test_case.notes, self.notes)
+        self.assertEqual(test_case.setup_duration, self.duration)
+        self.assertEqual(test_case.testing_duration, self.duration)
 
 
 class TestNewCasePermission(PermissionsTestCase):
@@ -282,6 +287,8 @@ class TestEditCaseView(BasePlanCase):
             "product": cls.case_1.category.product.pk,
             "category": cls.case_1.category.pk,
             "default_tester": "",
+            "testing_duration": "00:00:00:00",
+            "setup_duration": "01:02:00:00",
             "case_status": cls.case_status_confirmed.pk,
             "arguments": "",
             "extra_link": "",


### PR DESCRIPTION
Refs. [#1923](https://github.com/kiwitcms/Kiwi/issues/1923)

Because TestCase class now has 2 new duration fields (setup_duration and testing_duration) as well as one new property (expected_duration), they need to be added  to mutable.html template

- setup_duration & testing_duration are added in testcases/mutable.html and can be edited


