### PR TITLE
Revert back to Django 3.1.8

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -2,7 +2,7 @@
 
 bleach==3.3.0
 bleach-allowlist==1.0.3
-Django==3.2.1
+Django==3.1.8
 django-attachments==1.9.1
 django-contrib-comments==2.1.0
 django-extensions==3.1.3


### PR DESCRIPTION
3.2 and 3.2.1 lead to a very strange problem with middleware which
causes the existing tests to fail and the failure was overlooked when
merged! See
https://forum.djangoproject.com/t/site-objects-get-yields-recursionerror-with-https-but-not-with-http/7801