### PR TITLE
Refactor add execution link form to use modelform

### DIFF
--- a/docs/source/modules/tcms.rpc.api.forms.rst
+++ b/docs/source/modules/tcms.rpc.api.forms.rst
@@ -14,5 +14,6 @@ Submodules
 
    tcms.rpc.api.forms.management
    tcms.rpc.api.forms.testcase
+   tcms.rpc.api.forms.testexecution
    tcms.rpc.api.forms.testplan
    tcms.rpc.api.forms.testrun

--- a/docs/source/modules/tcms.rpc.api.forms.testexecution.rst
+++ b/docs/source/modules/tcms.rpc.api.forms.testexecution.rst
@@ -1,0 +1,7 @@
+tcms.rpc.api.forms.testexecution module
+=======================================
+
+.. automodule:: tcms.rpc.api.forms.testexecution
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/tcms/rpc/api/forms/testexecution.py
+++ b/tcms/rpc/api/forms/testexecution.py
@@ -1,28 +1,9 @@
 from django import forms
-from django.contrib.auth import get_user_model
 
 from tcms.core.contrib.linkreference.models import LinkReference
-from tcms.core.forms.fields import UserField
-from tcms.rpc.api.forms import UpdateModelFormMixin, DateTimeField
-from tcms.testruns.models import TestExecution
-
-User = get_user_model()  # pylint: disable=invalid-name
 
 
-class UpdateExecutionForm(UpdateModelFormMixin, forms.ModelForm):
-    class Meta:
-        model = TestExecution
-        fields = '__all__'
-
-    assignee = UserField()
-    tested_by = UserField()
-    close_date = DateTimeField()
-
-
-class AddExecutionLinkForm(forms.ModelForm):
+class LinkReferenceForm(forms.ModelForm):
     class Meta:
         model = LinkReference
-        fields = '__all__'
-
-    def populate(self, execution_id):
-        self.fields['execution'].queryset = TestExecution.objects.filter(pk=execution_id)
+        fields = "__all__"

--- a/tcms/rpc/api/forms/testexecution.py
+++ b/tcms/rpc/api/forms/testexecution.py
@@ -1,0 +1,28 @@
+from django import forms
+from django.contrib.auth import get_user_model
+
+from tcms.core.contrib.linkreference.models import LinkReference
+from tcms.core.forms.fields import UserField
+from tcms.rpc.api.forms import UpdateModelFormMixin, DateTimeField
+from tcms.testruns.models import TestExecution
+
+User = get_user_model()  # pylint: disable=invalid-name
+
+
+class UpdateExecutionForm(UpdateModelFormMixin, forms.ModelForm):
+    class Meta:
+        model = TestExecution
+        fields = '__all__'
+
+    assignee = UserField()
+    tested_by = UserField()
+    close_date = DateTimeField()
+
+
+class AddExecutionLinkForm(forms.ModelForm):
+    class Meta:
+        model = LinkReference
+        fields = '__all__'
+
+    def populate(self, execution_id):
+        self.fields['execution'].queryset = TestExecution.objects.filter(pk=execution_id)

--- a/tcms/rpc/tests/test_testexecution.py
+++ b/tcms/rpc/tests/test_testexecution.py
@@ -13,6 +13,8 @@ from tcms.core.contrib.linkreference.models import LinkReference
 from tcms.core.helpers import comments
 from tcms.rpc.tests.utils import APIPermissionsTestCase, APITestCase
 from tcms.testruns.models import TestExecutionStatus
+
+from tcms.tests import user_should_have_perm
 from tcms.tests.factories import (
     BuildFactory,
     LinkReferenceFactory,
@@ -179,6 +181,15 @@ class TestExecutionAddLink(APITestCase):
         self.assertGreater(result["id"], 0)
         self.assertEqual(result["url"], url)
 
+    def test_attach_log_with_too_long_name(self):
+        with self.assertRaisesRegex(XmlRPCFault, 'has at most 64 characters'):
+            name = 'a' * 65
+            url = "http://127.0.0.1/test/test-log.log"
+            self.rpc_client.TestExecution.add_link({
+                'execution_id': self.execution.pk,
+                'name': name,
+                'url': url})
+
 
 class TestExecutionAddLinkPermissions(APIPermissionsTestCase):
     """Test permissions of TestExecution.add_link"""
@@ -187,7 +198,6 @@ class TestExecutionAddLinkPermissions(APIPermissionsTestCase):
 
     def _fixture_setup(self):
         super()._fixture_setup()
-
         self.execution = TestExecutionFactory()
 
     def verify_api_with_permission(self):


### PR DESCRIPTION
Same as #2144 but opening from a branch to get the bugtracker integration tests executed.