### PR TITLE
Return translations for API methods. Closes #1966

### DIFF
--- a/tcms/testruns/static/testruns/js/get.js
+++ b/tcms/testruns/static/testruns/js/get.js
@@ -632,6 +632,7 @@ function renderHistoryEntry (historyEntry) {
 function renderTestExecutionRow (testExecution) {
   // refresh the internal data structure b/c some fields are used
   // to render the expand area and may have changed via bulk-update meanwhile
+  testExecution.status__name = $('#test_run_pk').data(`trans-execution-status-${testExecution.status}`)
   allExecutions[testExecution.id] = testExecution
 
   const testExecutionRowTemplate = $('#test-execution-row')[0].content
@@ -649,7 +650,7 @@ function renderTestExecutionRow (testExecution) {
 
   const testExecutionStatus = allExecutionStatuses[testExecution.status]
   template.find('.test-execution-status-icon').addClass(testExecutionStatus.icon).css('color', testExecutionStatus.color)
-  template.find('.test-execution-status-name').html(testExecutionStatus.name).css('color', testExecutionStatus.color)
+  template.find('.test-execution-status-name').html(testExecution.status__name).css('color', testExecutionStatus.color)
 
   template.find('.add-link-button').click(() => addLinkToExecutions([testExecution.id]))
   template.find('.one-click-bug-report-button').click(() => fileBugFromExecution(testExecution))

--- a/tcms/testruns/templates/testruns/get.html
+++ b/tcms/testruns/templates/testruns/get.html
@@ -24,6 +24,9 @@
             data-trans-error-adding-cases="{% trans 'Unconfirmed test cases were not added' %}"
             data-trans-bool-value-required="{% trans 'Type 0 or 1' %}"
             data-trans-comment="{% trans 'Comment' %}:"
+        {% for status in execution_statuses %}
+            data-trans-execution-status-{{ status.pk }}="{{ status.name }}"
+        {% endfor %}
         >TR-{{ object.pk }}:</span> {{ object.summary }}
     </h1>
 


### PR DESCRIPTION
API methods TestExecutionStatus.filter() and TestCaseStatus.filter()
will now return translated values depending on the Accept-Language
header sent as part of the API request!

Related: https://github.com/ecometrica/django-vinaigrette/issues/47