### PR TITLE
Fix CSS class override for admin forms. Fixes #2404

### DIFF
--- a/tcms/static/style/patternfly_override.css
+++ b/tcms/static/style/patternfly_override.css
@@ -12,8 +12,13 @@ nav.navbar-default { border-top-color: #3C8D2C; }
 
 /* continue with styles for Kiwi TCMS */
 
-/* todo: used in form error messages, can be improved */
-.errorlist { background: #AF2B2B; border:1px solid #6F1B1B; color:#FFF; font-weight:bold; }
+/* used in regular/admin form error messages */
+.errorlist, p.errornote + ul.errorlist {
+    background: #AF2B2B;
+    border:1px solid #6F1B1B;
+    color:#FFF;
+    font-weight:bold;
+}
 
 /* typeahead.js styling for autocomplete */
 .tt-menu {

--- a/tcms/templates/admin/base_site.html
+++ b/tcms/templates/admin/base_site.html
@@ -10,7 +10,8 @@
 {% endblock %}
 
 {% block extrastyle %}
-    <link rel="stylesheet" type="text/css" href="{% static 'style/admin.css' %}" media="screen" />
+    <link rel="stylesheet" type="text/css" href="{% static 'style/admin.css' %}" media="screen">
+    <link rel="stylesheet" href="{% static 'style/patternfly_override.css' %}">
 {% endblock %}
 
 {% block javascripts %}


### PR DESCRIPTION
applies white color to error message text so that it is more visible on
the red background.