### PR TITLE
Apply size constraints for uploaded images. Fixes #2220

### DIFF
--- a/tcms/static/style/patternfly_override.css
+++ b/tcms/static/style/patternfly_override.css
@@ -12,6 +12,11 @@ nav.navbar-default { border-top-color: #3C8D2C; }
 
 /* continue with styles for Kiwi TCMS */
 
+img {
+    height: auto;
+    max-width: 100%;
+}
+
 /* used in regular/admin form error messages */
 .errorlist, p.errornote + ul.errorlist {
     background: #AF2B2B;


### PR DESCRIPTION
this change will cause large images to fit into the available space on
the screen, e.g. inside test case description cards.