### PR TITLE
Add Eslint config

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -141,4 +141,4 @@ jobs:
           cd tcms/
           npm install --dev
 
-          ./node_modules/.bin/eslint .
+          ./node_modules/.bin/eslint . -c package.json

--- a/tcms/package.json
+++ b/tcms/package.json
@@ -15,5 +15,15 @@
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^4.2.1"
+  },
+  "eslintConfig": {
+    "overrides": [
+      {
+        "files": ["*.js"],
+        "rules": {
+          "no-undef": "off"
+        }
+      }
+    ]
   }
 }


### PR DESCRIPTION
this config excludes the `no-undef` rule.
Currently, a lot of the errors we get are violating this rule.
This will be fixed when we integrate Webpack in our workflow.
Until then, there is no point in showing these messages, because
they only clutter the output and prevent us from seeing the actual
warnings and errors.