### PR TITLE
Redirect ADMIN -> Users and groups according to tenancy

### DIFF
--- a/tcms/kiwi_auth/urls.py
+++ b/tcms/kiwi_auth/urls.py
@@ -45,4 +45,9 @@ urlpatterns = [
         contrib_auth_views.PasswordResetCompleteView.as_view(),
         name="password_reset_complete",
     ),
+    re_path(
+        r"^users-and-groups/$",
+        views.UsersAndGroupsRouter.as_view(),
+        name="users-and-groups-router",
+    ),
 ]

--- a/tcms/settings/common.py
+++ b/tcms/settings/common.py
@@ -335,7 +335,7 @@ MENU_ITEMS = [
     (
         _("ADMIN"),
         [
-            (_("Users and groups"), "/admin/auth/"),
+            (_("Users and groups"), reverse_lazy("users-and-groups-router")),
             ("-", "-"),
             (_("Everything else"), "/admin/"),
         ],


### PR DESCRIPTION
if the request is made from a tenant then redirect to the Tenant
authorized users page b/c tenant accounts can't manage users & groups
anyway.