### PR TITLE
New feature: Ability to create TR from selected TCs inside TR

### DIFF
--- a/tcms/testruns/static/testruns/js/get.js
+++ b/tcms/testruns/static/testruns/js/get.js
@@ -41,6 +41,20 @@ $(document).ready(() => {
     })
   })
 
+  $('.js-bulk-create-testrun').click(function () {
+    $(this).parents('.dropdown').toggleClass('open')
+
+    const selected = selectedCheckboxes()
+    if ($.isEmptyObject(selected)) {
+      return false
+    }
+
+    const planId = Number($('#test_run_pk').data('plan-pk'))
+    window.location.assign(`/runs/new?p=${planId}&c=${selected.caseIds.join('&c=')}`)
+
+    return false
+  })
+
   $('.add-comment-bulk').click(function () {
     $(this).parents('.dropdown').toggleClass('open')
 

--- a/tcms/testruns/templates/testruns/get.html
+++ b/tcms/testruns/templates/testruns/get.html
@@ -201,6 +201,16 @@
                                         </button>
 
                                         <ul class="dropdown-menu" aria-labelledby="toolbarActions">
+                                        {% if perms.testruns.add_testrun %}
+                                            <li>
+                                                <a class="js-bulk-create-testrun" href="#">
+                                                    <span class="fa fa-file-text-o"></span>
+                                                    {% trans 'New TestRun' %}
+                                                </a>
+                                            </li>
+                                            <li class="divider"></li>
+                                        {% endif %}
+
                                         {% if perms.testruns.change_testexecution %}
                                             <li>
                                                 <a href="#" class="update-case-text-bulk">


### PR DESCRIPTION
Inside the TestRun page users can filter & select the test cases they
want, e.g. ones which are currently failing, and using the toolbar menu
create a new TestRun, for example to track re-testing results,
presumably against a different build!