### PR TITLE
Properly initialize Product value on TestRun Edit page. Closes #2514

### DIFF
--- a/tcms/testruns/templates/testruns/mutable.html
+++ b/tcms/testruns/templates/testruns/mutable.html
@@ -49,7 +49,7 @@
                     {% endif %}
 
                     {% for option in form.product.field.queryset %}
-                        <option value="{{ option.pk }}" {% if option.pk|escape == form.product.value|escape %}selected{% endif %}>{{ option.name }}</option>
+                        <option value="{{ option.pk }}" {% if option.pk|escape == form.plan.field.queryset.0.product_id|escape %}selected{% endif %}>{{ option.name }}</option>
                     {% endfor %}
                 </select>
 

--- a/tcms/testruns/views.py
+++ b/tcms/testruns/views.py
@@ -202,6 +202,11 @@ class EditTestRunView(UpdateView):
 
         return form
 
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["plan_id"] = self.object.plan
+        return context
+
     def get_initial(self):
         return {
             "manager": self.object.manager,


### PR DESCRIPTION
when the page was loaded it didn't properly display the current product
which lead to errors when selecting it.