### PR TITLE
Make testcase filtering on the API side aware of the duration fields

### DIFF
--- a/tcms/rpc/api/utils.py
+++ b/tcms/rpc/api/utils.py
@@ -18,3 +18,11 @@ def tracker_from_url(url, request):
             return import_string(bug_system.tracker_type)(bug_system, request)
 
     return None
+
+
+def stringify_values(d, keys=None):
+    keys = keys or []
+    return {
+        key: (str(val) if (key in keys and val is not None) else val)
+        for (key, val) in d.items()
+    }

--- a/tcms/rpc/tests/test_testcase.py
+++ b/tcms/rpc/tests/test_testcase.py
@@ -173,9 +173,33 @@ class TestCaseFilter(APITestCase):
         self.assertIn("author", result[0])
         self.assertIn("default_tester", result[0])
         self.assertIn("reviewer", result[0])
+        self.assertIn("setup_duration", result[0])
+        self.assertIn("testing_duration", result[0])
+        self.assertIn("expected_duration", result[0])
 
     def test_filter_by_product_id(self):
         cases = self.rpc_client.TestCase.filter({"category__product": self.product.pk})
+        self.assertIsNotNone(cases)
+        self.assertEqual(len(cases), self.cases_count)
+
+    def test_filter_by_setup_duration(self):
+        TestCaseFactory(setup_duration=timedelta(seconds=30))
+        cases = self.rpc_client.TestCase.filter({"setup_duration": "00:00:30"})
+        self.assertIsNotNone(cases)
+        self.assertEqual(len(cases), 1)
+
+    def test_filter_by_testing_duration(self):
+        TestCaseFactory(testing_duration=timedelta(minutes=5, seconds=1))
+        cases = self.rpc_client.TestCase.filter({"testing_duration__gt": "00:05:00"})
+        self.assertIsNotNone(cases)
+        self.assertEqual(len(cases), 1)
+
+    def test_filter_by_expected_duration(self):
+        TestCaseFactory(
+            setup_duration=timedelta(seconds=30),
+            testing_duration=timedelta(minutes=5, seconds=1),
+        )
+        cases = self.rpc_client.TestCase.filter({"expected_duration__lt": "00:5:31"})
         self.assertIsNotNone(cases)
         self.assertEqual(len(cases), self.cases_count)
 


### PR DESCRIPTION
The API method `TestCase.filter` is extended to work for queries that contain lookups on the fields `setup_duration`, `testing_duration` and `expected_duration`.
It also returns the values of all three fields in its result.

Refs #1923