### PR TITLE
Fixes #2232 - E-mail notification for comment updates.

### DIFF
--- a/tcms/bugs/tests/test_models.py
+++ b/tcms/bugs/tests/test_models.py
@@ -8,11 +8,15 @@ if "tcms.bugs.apps.AppConfig" not in settings.INSTALLED_APPS:
 
 from django.template.loader import render_to_string  # noqa: E402
 from django.test import TestCase  # noqa: E402
+from django.urls import reverse  # noqa: E402
 from django.utils.translation import gettext_lazy as _  # noqa: E402
 from mock import patch  # noqa: E402
 
 from tcms.bugs.tests.factory import BugFactory  # noqa: E402
+from tcms.core.helpers.comments import add_comment, get_comments  # noqa: E402
+from tcms.tests import BaseCaseRun, user_should_have_perm  # noqa: E402
 from tcms.tests.factories import UserFactory  # noqa: E402
+from tcms.utils.permissions import initiate_user_with_default_setups  # noqa: E402
 
 
 class TestSendMailOnAssigneeChange(TestCase):
@@ -28,24 +32,142 @@ class TestSendMailOnAssigneeChange(TestCase):
         assignee = UserFactory()
         bug = BugFactory(assignee=assignee)
 
-        expected_subject = _("NEW: Bug #%(pk)d - %(summary)s") % {
+        expected_subject = _("Bug #%(pk)d - %(summary)s") % {
             "pk": bug.pk,
             "summary": bug.summary,
         }
-        expected_body = render_to_string("email/post_bug_save/email.txt", {"bug": bug})
-        expected_recipients = [assignee.email]
-
-        send_mail.assert_called_once_with(
-            settings.EMAIL_SUBJECT_PREFIX + expected_subject,
-            expected_body,
-            settings.DEFAULT_FROM_EMAIL,
-            expected_recipients,
-            fail_silently=False,
+        expected_body = render_to_string(
+            "email/post_bug_save/email.txt",
+            {"bug": bug, "comment": get_comments(bug).last()},
         )
+        expected_recipients = [assignee.email, bug.reporter.email]
+
         self.assertTrue(send_mail.called)
+        self.assertEqual(
+            settings.EMAIL_SUBJECT_PREFIX + expected_subject,
+            send_mail.call_args.args[0],
+        )
+        self.assertEqual(expected_body, send_mail.call_args.args[1])
+        self.assertEqual(settings.DEFAULT_FROM_EMAIL, send_mail.call_args.args[2])
+        self.assertTrue(len(send_mail.call_args.args[3]) == len(expected_recipients))
+        self.assertIn(expected_recipients[0], send_mail.call_args.args[3])
+        self.assertIn(expected_recipients[1], send_mail.call_args.args[3])
 
     @patch("tcms.core.utils.mailto.send_mail")
-    def test_no_notification_if_assignee_not_set(self, send_mail):
+    def test_notification_even_there_is_no_assignee(self, send_mail):
         BugFactory(assignee=None)
 
-        self.assertFalse(send_mail.called)
+        self.assertTrue(send_mail.called)
+
+
+class TestSendMailOnNewComment(BaseCaseRun):
+    """Test that assignee and reporter are notified by mail each time a comment is added.
+
+    Ideally, notifications are sent out when:
+    * A new comment is added to the bug.
+    * Bug is closed.
+    * Bug is reopened.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+
+        initiate_user_with_default_setups(cls.tester)
+        cls.comment_bug_url = reverse("bugs-comment")
+        user_should_have_perm(cls.tester, "bugs.change_bug")
+
+        cls.assignee = UserFactory()
+        cls.url = reverse("bugs-comment")
+
+    @patch("tcms.core.utils.mailto.send_mail")
+    def test_email_sent_when_bug_closed(self, send_mail):
+        bug = BugFactory(assignee=self.assignee, reporter=self.tester)
+        self.client.post(
+            self.url, {"bug": bug.pk, "text": "", "action": "close"}, follow=True
+        )
+
+        expected_body = render_to_string(
+            "email/post_bug_save/email.txt",
+            {"bug": bug, "comment": get_comments(bug).last()},
+        )
+        expected_recipients = [self.assignee.email, self.tester.email]
+        expected_subject = _("Bug #%(pk)d - %(summary)s") % {
+            "pk": bug.pk,
+            "summary": bug.summary,
+        }
+
+        self.assertTrue(send_mail.called)
+        self.assertEqual(
+            settings.EMAIL_SUBJECT_PREFIX + expected_subject,
+            send_mail.call_args.args[0],
+        )
+        self.assertEqual(expected_body, send_mail.call_args.args[1])
+        self.assertEqual(settings.DEFAULT_FROM_EMAIL, send_mail.call_args.args[2])
+        self.assertTrue(len(send_mail.call_args.args[3]) == len(expected_recipients))
+        self.assertIn(expected_recipients[0], send_mail.call_args.args[3])
+        self.assertIn(expected_recipients[1], send_mail.call_args.args[3])
+
+    @patch("tcms.core.utils.mailto.send_mail")
+    def test_email_sent_when_bug_reopened(self, send_mail):
+        bug = BugFactory(assignee=self.assignee, reporter=self.tester)
+        bug.status = False
+        bug.save()
+        self.client.post(
+            self.url, {"bug": bug.pk, "text": "", "action": "reopen"}, follow=True
+        )
+
+        expected_body = render_to_string(
+            "email/post_bug_save/email.txt",
+            {"bug": bug, "comment": get_comments(bug).last()},
+        )
+        expected_recipients = [self.assignee.email, self.tester.email]
+        expected_subject = _("Bug #%(pk)d - %(summary)s") % {
+            "pk": bug.pk,
+            "summary": bug.summary,
+        }
+
+        self.assertTrue(send_mail.called)
+        self.assertEqual(
+            settings.EMAIL_SUBJECT_PREFIX + expected_subject,
+            send_mail.call_args.args[0],
+        )
+        self.assertEqual(expected_body, send_mail.call_args.args[1])
+        self.assertEqual(settings.DEFAULT_FROM_EMAIL, send_mail.call_args.args[2])
+        self.assertTrue(len(send_mail.call_args.args[3]) == len(expected_recipients))
+        self.assertIn(expected_recipients[0], send_mail.call_args.args[3])
+        self.assertIn(expected_recipients[1], send_mail.call_args.args[3])
+
+    @patch("tcms.core.utils.mailto.send_mail")
+    def test_email_sent_to_all_commenters(self, send_mail):
+        bug = BugFactory(assignee=self.assignee, reporter=self.tester)
+        commenter = UserFactory()
+        tracker = UserFactory()
+        add_comment([bug], _("*bug created*"), tracker)
+        add_comment([bug], _("*bug created*"), commenter)
+
+        expected_body = render_to_string(
+            "email/post_bug_save/email.txt",
+            {"bug": bug, "comment": get_comments(bug).last()},
+        )
+        expected_recipients = [
+            self.assignee.email,
+            self.tester.email,
+            commenter.email,
+            tracker.email,
+        ]
+        expected_subject = _("Bug #%(pk)d - %(summary)s") % {
+            "pk": bug.pk,
+            "summary": bug.summary,
+        }
+
+        self.assertTrue(send_mail.called)
+        self.assertEqual(
+            settings.EMAIL_SUBJECT_PREFIX + expected_subject,
+            send_mail.call_args.args[0],
+        )
+        self.assertEqual(expected_body, send_mail.call_args.args[1])
+        self.assertEqual(settings.DEFAULT_FROM_EMAIL, send_mail.call_args.args[2])
+        self.assertTrue(len(send_mail.call_args.args[3]) == len(expected_recipients))
+        self.assertIn(expected_recipients[0], send_mail.call_args.args[3])
+        self.assertIn(expected_recipients[1], send_mail.call_args.args[3])

--- a/tcms/templates/email/post_bug_save/email.txt
+++ b/tcms/templates/email/post_bug_save/email.txt
@@ -1,5 +1,5 @@
 {% load i18n %}
-{% blocktrans with pk=bug.pk bug_url=bug.get_full_url summary=bug.summary creation_date=bug.created_at reporter=bug.reporter assignee=bug.assignee product=bug.product version=bug.version build=bug.build %}Bug {{ pk }} has been assigned to you.
+{% blocktrans with pk=bug.pk bug_url=bug.get_full_url summary=bug.summary creation_date=bug.created_at reporter=bug.reporter assignee=bug.assignee product=bug.product version=bug.version build=bug.build last_comment=comment.comment %}Bug {{ pk }} has been updated.
 
 Link: {{ bug_url }}
 
@@ -9,4 +9,6 @@ Reporter: {{ reporter }}
 Assignee: {{ assignee }}
 Product: {{ product }}
 Version: {{ version }}
-Build: {{ build }}{% endblocktrans %}
+Build: {{ build }}
+Last comment: 
+{{ last_comment }}{% endblocktrans %}


### PR DESCRIPTION
This definitely requires a review :)

- ~~Added the "mailto" call to Bugs/Views.py, not sure if that is the right place.~~
- ~~Changed the email template as "email_create.txt" to distinguish the update and create notification templates.~~
- ~~Not sure how tests will behave in GH Actions.~~
 

Accepted behaviour: 

- Mails are sent two times, one during `bug.save()` and one during `add_comment()` where both triggers the `post_save `signals for a Bug.