### PR TITLE
Creating a TR will generate TE matrix for TC with properties. Fix #1843

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,6 @@
 -r tarballs.txt
 
+allpairspy==2.5.0
 bleach==4.1.0
 bleach-allowlist==1.0.3
 Django==3.2.9

--- a/tcms/rpc/api/testrun.py
+++ b/tcms/rpc/api/testrun.py
@@ -44,7 +44,7 @@ def add_case(run_id, case_id):
     """
     run = TestRun.objects.get(pk=run_id)
     case = TestCase.objects.get(pk=case_id)
-
+    # TODO: fix this to account for properties
     if run.executions.filter(case=case).exists():
         return model_to_dict(run.executions.filter(case=case).first())
 

--- a/tcms/rpc/tests/test_testrun.py
+++ b/tcms/rpc/tests/test_testrun.py
@@ -41,24 +41,23 @@ class TestAddCase(APITestCase):
         self.test_run = TestRunFactory(plan=self.plan)
 
     def test_add_case(self):
-        result = self.rpc_client.TestRun.add_case(self.test_run.pk, self.test_case.pk)
-        self.assertTrue(isinstance(result, dict))
-
-        execution = TestExecution.objects.get(
-            run=self.test_run.pk, case=self.test_case.pk
+        executions = self.rpc_client.TestRun.add_case(
+            self.test_run.pk, self.test_case.pk
         )
+        self.assertTrue(isinstance(executions, list))
 
-        self.assertEqual(result["id"], execution.pk)
-        self.assertIn("assignee", result)
-        self.assertEqual(result["tested_by"], None)
-        self.assertIn("case_text_version", result)
-        self.assertIn("start_date", result)
-        self.assertIn("stop_date", result)
-        self.assertIn("sortkey", result)
-        self.assertEqual(result["run"], execution.run.pk)
-        self.assertEqual(result["case"], execution.case.pk)
-        self.assertIn("build", result)
-        self.assertIn("status", result)
+        for result in executions:
+            self.assertIn("id", result)
+            self.assertIn("assignee", result)
+            self.assertEqual(result["tested_by"], None)
+            self.assertIn("case_text_version", result)
+            self.assertIn("start_date", result)
+            self.assertIn("stop_date", result)
+            self.assertIn("sortkey", result)
+            self.assertEqual(result["run"], self.test_run.pk)
+            self.assertEqual(result["case"], self.test_case.pk)
+            self.assertIn("build", result)
+            self.assertIn("status", result)
 
     def test_add_case_without_permissions(self):
         unauthorized_user = UserFactory()

--- a/tcms/rpc/tests/test_testrun.py
+++ b/tcms/rpc/tests/test_testrun.py
@@ -44,7 +44,7 @@ class TestAddCase(APITestCase):
         executions = self.rpc_client.TestRun.add_case(
             self.test_run.pk, self.test_case.pk
         )
-        self.assertTrue(isinstance(executions, list))
+        self.assertIsInstance(executions, list)
 
         for result in executions:
             self.assertIn("id", result)
@@ -58,6 +58,8 @@ class TestAddCase(APITestCase):
             self.assertEqual(result["case"], self.test_case.pk)
             self.assertIn("build", result)
             self.assertIn("status", result)
+            self.assertIn("properties", result)
+            self.assertIsInstance(result["properties"], list)
 
     def test_add_case_without_permissions(self):
         unauthorized_user = UserFactory()

--- a/tcms/testruns/templates/testruns/get.html
+++ b/tcms/testruns/templates/testruns/get.html
@@ -143,7 +143,7 @@
             <div class="card-pf card-pf-accented">
                 <h2 class="card-pf-title">
                     <span class="fa fa-envelope"></span>
-                    {% trans "Notify:" %}
+                    {% trans "Notify" %}
                 </h2>
 
                 <div class="card-pf-body">

--- a/tcms/testruns/tests/test_models.py
+++ b/tcms/testruns/tests/test_models.py
@@ -50,10 +50,9 @@ class TestRunMethods(test.TestCase):
         cls.test_case.save()
 
     def test_create_execution_without_status(self):
-        execution = self.test_run.create_execution(self.test_case)
-
-        self.assertEqual(execution.status.weight, 0)
-        self.assertEqual(execution.status.name, _("IDLE"))
+        for execution in self.test_run.create_execution(self.test_case):
+            self.assertEqual(execution.status.weight, 0)
+            self.assertEqual(execution.status.name, _("IDLE"))
 
 
 class TestExecutionActualDuration(TestCase):


### PR DESCRIPTION
Iterate over the properties matrix and add separate executions into
the newly created TestRun. Repeat for all test cases which have
properties.

The code support both full and pairwise matrices!

Pairwise is not enabled yet because it needs some UI work.