### PR TITLE
Update Django to 3.2.10

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -3,7 +3,7 @@
 allpairspy==2.5.0
 bleach==4.1.0
 bleach-allowlist==1.0.3
-Django==3.2.9
+Django==3.2.10
 django-attachments==1.9.1
 django-contrib-comments==2.1.0
 django-extensions==3.1.5


### PR DESCRIPTION
broken dependencies prevent us from migrating to 4.0