### PR TITLE
Fix of #2561. Disable + when there is no parent element.

### DIFF
--- a/tcms/bugs/static/bugs/js/mutable.js
+++ b/tcms/bugs/static/bugs/js/mutable.js
@@ -35,6 +35,14 @@ $(document).ready(function () {
 function populateVersion () {
   const productId = $('#id_product').val()
 
+  if (productId === null) {
+    $('#add_id_version').addClass('disabled')
+    $('#add_id_build').addClass('disabled')
+  } else {
+    $('#add_id_version').removeClass('disabled')
+    $('#add_id_build').removeClass('disabled')
+  }
+
   const href = $('#add_id_version')[0].href
   $('#add_id_version')[0].href = href.slice(0, href.indexOf('&product'))
   $('#add_id_version')[0].href += `&product=${productId}`
@@ -43,10 +51,16 @@ function populateVersion () {
 }
 
 function populateBuild () {
-  const productId = $('#id_version').val()
+  const versionId = $('#id_version').val()
+
+  if (versionId === null) {
+    $('#add_id_build').addClass('disabled')
+  } else {
+    $('#add_id_build').removeClass('disabled')
+  }
 
   const href = $('#add_id_build')[0].href
   $('#add_id_build')[0].href = href.slice(0, href.indexOf('&version'))
-  $('#add_id_build')[0].href += `&version=${productId}`
+  $('#add_id_build')[0].href += `&version=${versionId}`
   updateBuildSelectFromVersion()
 }

--- a/tcms/static/style/patternfly_override.css
+++ b/tcms/static/style/patternfly_override.css
@@ -71,3 +71,10 @@ img {
 .property-value a {
     color: #c00; inherit !important;
 }
+
+a.disabled {
+    color: gray;
+    cursor: default;
+    pointer-events: none;
+    text-decoration: none;
+}

--- a/tcms/static/style/patternfly_override.css
+++ b/tcms/static/style/patternfly_override.css
@@ -73,7 +73,7 @@ img {
 }
 
 a.disabled {
-    color: gray;
+    color: #bbb;
     cursor: default;
     pointer-events: none;
     text-decoration: none;

--- a/tcms/testcases/static/testcases/js/mutable.js
+++ b/tcms/testcases/static/testcases/js/mutable.js
@@ -29,11 +29,17 @@ $(document).ready(function () {
 })
 
 function populateProductCategory () {
+  const productId = $('#id_product').val()
+
+  if (productId === null) {
+    $('#add_id_category').addClass('disabled')
+  } else {
+    $('#add_id_category').removeClass('disabled')
+  }
+
   const href = $('#add_id_category')[0].href
   $('#add_id_category')[0].href = href.slice(0, href.indexOf('&product'))
-  $('#add_id_category')[0].href += `&product=${$('#id_product').val()}`
-
+  $('#add_id_category')[0].href += `&product=${productId}`
   $('#id_category').find('option').remove()
-
   updateCategorySelectFromProduct()
 }

--- a/tcms/testplans/static/testplans/js/mutable.js
+++ b/tcms/testplans/static/testplans/js/mutable.js
@@ -29,11 +29,17 @@ $(document).ready(function () {
 })
 
 function populateProductVersion () {
+  const productId = $('#id_product').val()
+
+  if (productId === null) {
+    $('#add_id_version').addClass('disabled')
+  } else {
+    $('#add_id_version').removeClass('disabled')
+  }
+
   const href = $('#add_id_version')[0].href
   $('#add_id_version')[0].href = href.slice(0, href.indexOf('&product'))
-  $('#add_id_version')[0].href += `&product=${$('#id_product').val()}`
-
+  $('#add_id_version')[0].href += `&product=${productId}`
   $('#id_version').find('option').remove()
-
   updateVersionSelectFromProduct()
 }


### PR DESCRIPTION
The fix checks if there is a parent object and updates the "+" href according to it. 

- Not sure if the fixed places are correct and sufficient. It checks the existence of parent object in "New Bug", "New Test Case" and "New Test Plan" pages. 
- Not sure if it is also required to check on Admin/Management. If that is the case, please help me about the hiearchy of the objects.