### PR TITLE
Fix test cases order when cloning TP

### DIFF
--- a/tcms/testcases/models.py
+++ b/tcms/testcases/models.py
@@ -162,6 +162,7 @@ class TestCase(models.Model, UrlMixin):
         values = self.__dict__.copy()
         del values["_state"]
         del values["id"]
+        sortkey = values.pop("sortkey") if "sortkey" in values else None
         values["case_status_id"] = (
             TestCaseStatus.objects.filter(is_confirmed=False).first().pk
         )
@@ -174,7 +175,7 @@ class TestCase(models.Model, UrlMixin):
             new_tc.add_tag(tag)
 
         for plan in test_plans:
-            plan.add_case(new_tc)
+            plan.add_case(new_tc, sortkey)
 
             # clone TC category b/c we may be cloning a 'linked'
             # TC which has a different Product that doesn't have the

--- a/tcms/testplans/models.py
+++ b/tcms/testplans/models.py
@@ -144,14 +144,15 @@ class TestPlan(TreeNode, UrlMixin):
             tp_dest.add_tag(tag=tp_tag_src)
 
         # include TCs inside cloned TP
-        for tc_src in self.cases.all():
+        qs = self.cases.all().annotate(sortkey=models.F("testcaseplan__sortkey"))
+        for tc_src in qs:
             # this parameter should really be named clone_testcases b/c if set
             # it clones the source TC and then adds it to the new TP
             if copy_testcases:
                 tc_src.clone(new_author, [tp_dest])
             else:
                 # otherwise just link the existing TC to the new TP
-                tp_dest.add_case(tc_src)
+                tp_dest.add_case(tc_src, sortkey=tc_src.sortkey)
 
         return tp_dest
 

--- a/tcms/testplans/tests/tests.py
+++ b/tcms/testplans/tests/tests.py
@@ -4,6 +4,7 @@
 from http import HTTPStatus
 
 from django import test
+from django.db.models import F
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 
@@ -280,13 +281,20 @@ class TestCloneView(BasePlanCase):
             else:
                 self.assertTrue(is_case_linked)
 
+            cases_from_original_plan = original_plan.cases.all().annotate(
+                sortkey=F("testcaseplan__sortkey")
+            )
+            cases_from_cloned_plan = cloned_plan.cases.all().annotate(
+                sortkey=F("testcaseplan__sortkey")
+            )
             for original_case, copied_case in zip(
-                original_plan.cases.all(), cloned_plan.cases.all()
+                cases_from_original_plan, cases_from_cloned_plan
             ):
                 # default tester is always kept
                 self.assertEqual(
                     original_case.default_tester, copied_case.default_tester
                 )
+                self.assertEqual(original_case.sortkey, copied_case.sortkey)
 
                 if not copy_cases:
                     # when linking TCs author doesn't change


### PR DESCRIPTION
filter query is used to return None on first call if no test case is found.

Close: #2218
