### PR TITLE
Jquery deferred: There is no length property of null object.

### DIFF
--- a/tcms/static/js/utils.js
+++ b/tcms/static/js/utils.js
@@ -53,7 +53,7 @@ function updateVersionSelectFromProduct () {
 
   let productIds = $('#id_product').val()
 
-  if (productIds.length) {
+  if (productIds !== null) {
     if (!Array.isArray(productIds)) {
       productIds = [productIds]
     }
@@ -79,7 +79,7 @@ function updateBuildSelectFromVersion (keepFirst) {
   }
 
   let versionIds = $('#id_version').val()
-  if (versionIds.length) {
+  if (versionIds !== null) {
     if (!Array.isArray(versionIds)) {
       versionIds = [versionIds]
     }

--- a/tcms/static/js/utils.js
+++ b/tcms/static/js/utils.js
@@ -53,7 +53,7 @@ function updateVersionSelectFromProduct () {
 
   let productIds = $('#id_product').val()
 
-  if (productIds !== null) {
+  if (productIds && productIds.length) {
     if (!Array.isArray(productIds)) {
       productIds = [productIds]
     }
@@ -79,7 +79,7 @@ function updateBuildSelectFromVersion (keepFirst) {
   }
 
   let versionIds = $('#id_version').val()
-  if (versionIds !== null) {
+  if (versionIds && versionIds.length) {
     if (!Array.isArray(versionIds)) {
       versionIds = [versionIds]
     }


### PR DESCRIPTION
Checking the `length` of a null object throws "Uncaught TypeError" in Chrome and "Jquery.Deferred" exception in Firefox. 

I have not observed any functional problems but IMO it would be better to be improved. 

![image](https://user-images.githubusercontent.com/8937774/147729233-24b233d7-0a6a-41fb-a2ec-d07fd64ce0dc.png)

Chrome:

![image](https://user-images.githubusercontent.com/8937774/147729604-a5ad1fc3-1bd3-4ee2-90c7-c1f8a1f438b1.png)
