### PR TITLE
Add matrix selector when creating or cloning Test Run. Closes #1931

### DIFF
--- a/tcms/locale/en/LC_MESSAGES/django.po
+++ b/tcms/locale/en/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-12-13 18:56+0000\n"
+"POT-Creation-Date: 2022-01-12 12:28+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -134,7 +134,7 @@ msgstr ""
 #: tcms/testplans/templates/testplans/mutable.html:154
 #: tcms/testruns/templates/testruns/get.html:494
 #: tcms/testruns/templates/testruns/get.html:561
-#: tcms/testruns/templates/testruns/mutable.html:135
+#: tcms/testruns/templates/testruns/mutable.html:153
 msgid "Save"
 msgstr ""
 
@@ -155,7 +155,7 @@ msgstr ""
 #: tcms/testruns/templates/testruns/get.html:297
 #: tcms/testruns/templates/testruns/get.html:300
 #: tcms/testruns/templates/testruns/mutable.html:21
-#: tcms/testruns/templates/testruns/mutable.html:155
+#: tcms/testruns/templates/testruns/mutable.html:173
 #: tcms/testruns/templates/testruns/search.html:13
 #: tcms/testruns/templates/testruns/search.html:188
 msgid "Summary"
@@ -311,12 +311,12 @@ msgstr ""
 
 #: tcms/bugs/views.py:42 tcms/testcases/views.py:131
 #: tcms/testplans/templates/testplans/get.html:379 tcms/testplans/views.py:146
-#: tcms/testruns/views.py:154
+#: tcms/testruns/views.py:155
 msgid "Edit"
 msgstr ""
 
 #: tcms/bugs/views.py:45 tcms/testcases/views.py:144
-#: tcms/testplans/views.py:154 tcms/testruns/views.py:167
+#: tcms/testplans/views.py:154 tcms/testruns/views.py:168
 msgid "Object permissions"
 msgstr ""
 
@@ -326,7 +326,7 @@ msgstr ""
 #: tcms/testcases/templates/testcases/get.html:176 tcms/testcases/views.py:152
 #: tcms/testplans/templates/testplans/get.html:192
 #: tcms/testplans/templates/testplans/get.html:383 tcms/testplans/views.py:162
-#: tcms/testruns/templates/testruns/get.html:277 tcms/testruns/views.py:175
+#: tcms/testruns/templates/testruns/get.html:277 tcms/testruns/views.py:176
 msgid "Delete"
 msgstr ""
 
@@ -930,7 +930,7 @@ msgstr ""
 #: tcms/testruns/templates/testruns/get.html:228
 #: tcms/testruns/templates/testruns/get.html:308
 #: tcms/testruns/templates/testruns/get.html:416
-#: tcms/testruns/templates/testruns/mutable.html:158
+#: tcms/testruns/templates/testruns/mutable.html:176
 msgid "Status"
 msgstr ""
 
@@ -1216,11 +1216,11 @@ msgstr ""
 msgid "Test case statuses"
 msgstr ""
 
-#: tcms/testcases/models.py:374
+#: tcms/testcases/models.py:379
 msgid "Template"
 msgstr ""
 
-#: tcms/testcases/models.py:375
+#: tcms/testcases/models.py:380
 msgid "Templates"
 msgstr ""
 
@@ -1240,7 +1240,7 @@ msgstr ""
 #: tcms/testplans/templates/testplans/clone.html:72
 #: tcms/testplans/templates/testplans/get.html:137
 #: tcms/testplans/templates/testplans/get.html:357 tcms/testplans/views.py:147
-#: tcms/testruns/views.py:158
+#: tcms/testruns/views.py:159
 msgid "Clone"
 msgstr ""
 
@@ -1256,7 +1256,7 @@ msgstr ""
 #: tcms/testplans/templates/testplans/search.html:79
 #: tcms/testplans/templates/testplans/search.html:116
 #: tcms/testplans/templates/testplans/toolbar_dropdown.html:8
-#: tcms/testruns/templates/testruns/mutable.html:156
+#: tcms/testruns/templates/testruns/mutable.html:174
 msgid "Author"
 msgstr ""
 
@@ -1286,7 +1286,7 @@ msgstr ""
 #: tcms/testplans/templates/testplans/toolbar_dropdown.html:7
 #: tcms/testruns/templates/testruns/get.html:305
 #: tcms/testruns/templates/testruns/get.html:399
-#: tcms/testruns/templates/testruns/mutable.html:159
+#: tcms/testruns/templates/testruns/mutable.html:177
 msgid "Category"
 msgstr ""
 
@@ -1301,7 +1301,7 @@ msgstr ""
 #: tcms/testplans/templates/testplans/toolbar_dropdown.html:6
 #: tcms/testruns/templates/testruns/get.html:304
 #: tcms/testruns/templates/testruns/get.html:395
-#: tcms/testruns/templates/testruns/mutable.html:160
+#: tcms/testruns/templates/testruns/mutable.html:178
 msgid "Priority"
 msgstr ""
 
@@ -1346,7 +1346,7 @@ msgstr ""
 #: tcms/testplans/templates/testplans/get.html:432
 #: tcms/testplans/templates/testplans/get.html:433
 #: tcms/testruns/templates/testruns/get.html:431
-#: tcms/testruns/templates/testruns/mutable.html:127
+#: tcms/testruns/templates/testruns/mutable.html:145
 msgid "Notes"
 msgstr ""
 
@@ -1459,12 +1459,12 @@ msgstr ""
 
 #: tcms/testcases/templates/testcases/search.html:152
 #: tcms/testplans/templates/testplans/search.html:112
-#: tcms/testruns/templates/testruns/mutable.html:157
+#: tcms/testruns/templates/testruns/mutable.html:175
 msgid "Created on"
 msgstr ""
 
 #: tcms/testcases/views.py:139 tcms/testplans/views.py:149
-#: tcms/testruns/templates/testruns/get.html:472 tcms/testruns/views.py:162
+#: tcms/testruns/templates/testruns/get.html:472 tcms/testruns/views.py:163
 msgid "History"
 msgstr ""
 
@@ -1644,7 +1644,15 @@ msgstr ""
 msgid "1 negative, 1 neutral & 1 positive status required!"
 msgstr ""
 
-#: tcms/testruns/models.py:224
+#: tcms/testruns/forms.py:39
+msgid "Full"
+msgstr ""
+
+#: tcms/testruns/forms.py:40
+msgid "Pairwise"
+msgstr ""
+
+#: tcms/testruns/models.py:225
 msgid "Test execution statuses"
 msgstr ""
 
@@ -1761,11 +1769,19 @@ msgstr ""
 msgid "Clone TestRun"
 msgstr ""
 
-#: tcms/testruns/templates/testruns/mutable.html:144
+#: tcms/testruns/templates/testruns/mutable.html:127
+msgid "Matrix"
+msgstr ""
+
+#: tcms/testruns/templates/testruns/mutable.html:130
+msgid "Affects only test cases with properties"
+msgstr ""
+
+#: tcms/testruns/templates/testruns/mutable.html:162
 msgid "Selected TestCase(s):"
 msgstr ""
 
-#: tcms/testruns/templates/testruns/mutable.html:147
+#: tcms/testruns/templates/testruns/mutable.html:165
 #, python-format
 msgid ""
 "%(count)s of the pre-selected test cases is not CONFIRMED and will not be "
@@ -1801,7 +1817,7 @@ msgstr ""
 msgid "Stop date"
 msgstr ""
 
-#: tcms/testruns/views.py:233
+#: tcms/testruns/views.py:234
 msgid "Clone of "
 msgstr ""
 

--- a/tcms/testruns/forms.py
+++ b/tcms/testruns/forms.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from django import forms
 from django.contrib.auth import get_user_model
+from django.utils.translation import gettext_lazy as _
 
 from tcms.core.forms.fields import UserField
 from tcms.management.models import Build, Product, Version
@@ -30,6 +31,14 @@ class NewRunForm(forms.ModelForm):
 
     product = forms.ModelChoiceField(
         queryset=Product.objects.all(),
+        required=False,
+    )
+
+    matrix_type = forms.ChoiceField(
+        choices=(
+            ("full", _("Full")),
+            ("pairwise", _("Pairwise")),
+        ),
         required=False,
     )
 

--- a/tcms/testruns/models.py
+++ b/tcms/testruns/models.py
@@ -112,12 +112,13 @@ class TestRun(models.Model, UrlMixin):
             start_date=None,
         )
 
-    def create_execution(
+    def create_execution(  # pylint: disable=too-many-arguments
         self,
         case,
         assignee=None,
         build=None,
         sortkey=0,
+        matrix_type="full",
     ):
         from tcms.testcases.models import (  # pylint: disable=import-outside-toplevel
             Property,
@@ -133,7 +134,7 @@ class TestRun(models.Model, UrlMixin):
         properties = Property.objects.filter(case=case)
 
         if properties.count():
-            for prop_tuple in self.property_matrix(properties):
+            for prop_tuple in self.property_matrix(properties, matrix_type):
                 execution = self._create_single_execution(
                     case, assignee, build, sortkey
                 )

--- a/tcms/testruns/static/testruns/js/mutable.js
+++ b/tcms/testruns/static/testruns/js/mutable.js
@@ -1,4 +1,6 @@
 $(document).ready(function () {
+  $('[data-toggle="tooltip"]').tooltip()
+
   document.getElementById('id_product').onchange = () => {
     $('#id_product').selectpicker('refresh')
     updateTestPlanSelectFromProduct(() => {})

--- a/tcms/testruns/templates/testruns/mutable.html
+++ b/tcms/testruns/templates/testruns/mutable.html
@@ -121,6 +121,24 @@
                 {{  form.planned_stop.errors }}
                 {% include "include/datetimepicker_script.html" with selector="#id_planned_stop" %}
             </div>
+
+            {% if test_cases %}
+            <div class="col-md-1 col-lg-1">
+                <label for="id_build">{% trans "Matrix" %}</label>
+                <span class="fa pficon-help help-tooltip"
+                    data-toggle="tooltip" data-placement="bottom"
+                    title="{% trans 'Affects only test cases with properties' %}">
+                </span>
+            </div>
+
+            <div class="col-md-3 col-lg-3">
+                <select class="form-control selectpicker" id="id_matrix_type" name="matrix_type">
+                    {% for option in form.matrix_type.field.choices %}
+                        <option value="{{ option.0 }}" {% if option.0 == form.matrix_type.value %}selected{% endif %}>{{ option.1 }}</option>
+                    {% endfor %}
+                </select>
+            </div>
+            {% endif %}
         </div>
 
         <div class="form-group">

--- a/tcms/testruns/views.py
+++ b/tcms/testruns/views.py
@@ -81,8 +81,9 @@ class NewTestRunView(View):
 
                 test_run.create_execution(
                     case=case,
-                    sortkey=sortkey,
                     assignee=form.cleaned_data["default_tester"],
+                    sortkey=sortkey,
+                    matrix_type=form.cleaned_data["matrix_type"],
                 )
                 loop += 1
 


### PR DESCRIPTION
- Selection is between Full or Pairwise combinations
- Feature is enabled for test runs which contain test cases. This
  feature is not shown when creating an empty test run
- This feature isn't supported when subsequently adding new test cases
  to test run

The UI mockup proposed in #1931 is much harder to implement currently so
we'll leave it out of scope for now.