### PR TITLE
Replace django-recaptcha with django-simple-captcha

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -125,28 +125,6 @@ Also modify ``Dockerfile`` to include the following lines::
     RUN pip install django_ses
 
 
-Use reCAPTCHA during registration
----------------------------------
-
-.. versionadded:: 8.7
-
-If you want to use `Google reCAPTCHA <https://www.google.com/recaptcha/admin/>`_
-on the registration page then add the following to your settings::
-
-    if 'captcha' not in INSTALLED_APPS:
-        INSTALLED_APPS.append('captcha')
-
-        RECAPTCHA_PUBLIC_KEY = '......'
-        RECAPTCHA_PRIVATE_KEY = '.....'
-        RECAPTCHA_USE_SSL = True
-
-.. important::
-
-    This is not enabled by default because the ``django-recaptcha`` library
-    will cause Kiwi TCMS to stop working if the appropriate keys are not
-    provided!
-
-
 Kerberos authentication
 -----------------------
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,7 +9,7 @@ django-contrib-comments==2.1.0
 django-extensions==3.1.5
 django-guardian==2.4.0
 django-modern-rpc==0.12.1
-django-recaptcha==2.0.6
+django-simple-captcha==0.5.14
 django-simple-history==3.0.0
 django-tree-queries==0.7.0
 jira==3.1.1

--- a/tcms/kiwi_auth/forms.py
+++ b/tcms/kiwi_auth/forms.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from captcha import fields
 from django import forms
 from django.conf import settings
 from django.contrib.auth import get_user_model
@@ -17,16 +18,20 @@ from tcms.utils.permissions import initiate_user_with_default_setups
 
 User = get_user_model()  # pylint: disable=invalid-name
 
-# actually enable only if app is configured
-if "captcha" in settings.INSTALLED_APPS:
-    from captcha.fields import ReCaptchaField
-else:
-    ReCaptchaField = None.__class__  # pylint: disable=invalid-name
+
+class CustomCaptchaTextInput(fields.CaptchaTextInput):
+    template_name = "captcha_field.html"
 
 
 class RegistrationForm(UserCreationForm):
     email = forms.EmailField()
-    captcha = ReCaptchaField()
+    captcha = (
+        fields.CaptchaField(
+            widget=CustomCaptchaTextInput(attrs={"class": "form-control"})
+        )
+        if settings.USE_CAPTCHA
+        else None
+    )
 
     class Meta:
         model = User

--- a/tcms/kiwi_auth/templates/captcha_field.html
+++ b/tcms/kiwi_auth/templates/captcha_field.html
@@ -1,0 +1,10 @@
+{% load i18n %}
+<div class="form-group">
+    <div class="col-sm-2 col-md-2">
+        <img src="{{ image }}" alt="captcha" class="captcha" />
+    </div>
+
+    <div class="col-sm-10 col-md-10">
+        {% include "django/forms/widgets/multiwidget.html" %}
+    </div>
+</div>

--- a/tcms/kiwi_auth/tests/test_forms.py
+++ b/tcms/kiwi_auth/tests/test_forms.py
@@ -1,13 +1,12 @@
 import importlib
 
-from django.conf import settings
 from django.test import TestCase, override_settings
 from django.utils.translation import gettext_lazy as _
 
 from tcms.kiwi_auth import forms
 
 
-class TestRecaptchaField(TestCase):
+class TestCaptchaField(TestCase):
     def setUp(self):
         self.data = {
             "username": "test_user",
@@ -16,30 +15,36 @@ class TestRecaptchaField(TestCase):
             "email": "new-tester@example.com",
         }
 
-    @override_settings(INSTALLED_APPS=settings.INSTALLED_APPS + ["captcha"])
     def test_captcha_required_when_enabled(self):
         importlib.reload(forms)
-
         form = forms.RegistrationForm(data=self.data)
 
         self.assertFalse(form.is_valid())
-
         self.assertIn("captcha", form.errors.keys())
-
         self.assertIn(_("This field is required."), form.errors["captcha"])
 
-    def test_captcha_not_required_when_disabled(self):
+    def test_captcha_fails_when_wrong(self):
+        data = self.data.copy()
+        data["captcha_0"] = "correct"
+        data["captcha_1"] = "WRONG"
 
+        importlib.reload(forms)
+        form = forms.RegistrationForm(data=data)
+
+        self.assertFalse(form.is_valid())
+        self.assertIn("captcha", form.errors.keys())
+        self.assertIn(_("Invalid CAPTCHA"), form.errors["captcha"])
+
+    @override_settings(USE_CAPTCHA=False)
+    def test_captcha_not_required_when_disabled(self):
+        importlib.reload(forms)
         form = forms.RegistrationForm(data=self.data)
 
         self.assertTrue(form.is_valid())
-
         self.assertNotIn("captcha", form.errors.keys())
 
-    def tearDown(self):
-        importlib.reload(forms)
 
-
+@override_settings(USE_CAPTCHA=False)
 class TestRegistrationForm(TestCase):
     def setUp(self):
         self.data = {
@@ -50,14 +55,14 @@ class TestRegistrationForm(TestCase):
         }
 
     def test_user_not_created_when_commit(self):
-
+        importlib.reload(forms)
         form = forms.RegistrationForm(data=self.data)
 
         user = form.save(commit=False)
         self.assertIsNone(user.pk)
 
     def test_user_created_when_commit(self):
-
+        importlib.reload(forms)
         form = forms.RegistrationForm(data=self.data)
 
         user = form.save()

--- a/tcms/settings/common.py
+++ b/tcms/settings/common.py
@@ -98,6 +98,10 @@ REGISTRATION_ENABLED = (
 )
 
 
+# By default a simple CAPTCHA challenge is enabled in registration page
+USE_CAPTCHA = True
+
+
 # How often will session cookies expire? We set this to 24hrs by default.
 # You may override based on your security policies
 # https://docs.djangoproject.com/en/2.1/ref/settings/#session-cookie-age
@@ -279,6 +283,8 @@ INSTALLED_APPS = TENANT_APPS + [
     "django.contrib.messages",
     "django.contrib.sessions",
     "django.contrib.staticfiles",
+    "django.forms",
+    "captcha",
     "colorfield",
     "django_extensions",
     "tree_queries",

--- a/tcms/templates/registration/registration_form.html
+++ b/tcms/templates/registration/registration_form.html
@@ -6,7 +6,7 @@
 {% block contents %}
 <div class="container">
   <div class="row">
-    <div class="col-sm-7 col-md-6 col-lg-5 login">
+    <div class="col-sm-12 col-md-8 col-lg-8 login">
       {{ form.non_field_errors }}
       <form class="form-horizontal" role="form" action="{% url "tcms-register" %}" method="POST">
         {% csrf_token %}
@@ -43,15 +43,10 @@
           </div>
         </div>
 
-    {% if 'captcha' in form.fields %}
-        <div class="form-group">
-
-          <label class="col-sm-2 col-md-2"></label>
-          <div class="col-sm-10 col-md-10">
+        {% if 'captcha' in form.fields %}
+            {{ form.captcha.errors }}
             {{ form.captcha }}
-          </div>
-        </div>
-    {% endif %}
+        {% endif %}
 
         <div class="form-group">
           <div class="col-xs-12 col-sm-offset-2 col-sm-10 col-md-offset-2 col-md-10 submit">

--- a/tcms/urls.py
+++ b/tcms/urls.py
@@ -3,6 +3,7 @@ from importlib import import_module
 
 import pkg_resources
 from attachments import urls as attachments_urls
+from captcha import urls as captcha_urls
 from django.conf import settings
 from django.conf.urls import include
 from django.conf.urls.static import static
@@ -23,6 +24,7 @@ from tcms.testruns import urls as testruns_urls
 
 urlpatterns = [
     re_path(r"^$", core_views.DashboardView.as_view(), name="core-views-index"),
+    re_path(r"^captcha/", include(captcha_urls)),
     re_path(r"^xml-rpc/", RPCEntryPoint.as_view(protocol=XMLRPC_PROTOCOL)),
     re_path(r"^json-rpc/$", RPCEntryPoint.as_view(protocol=JSONRPC_PROTOCOL)),
     re_path(r"^init-db/$", core_views.InitDBView.as_view(), name="init-db"),

--- a/tests/check-build
+++ b/tests/check-build
@@ -83,8 +83,6 @@ $(which python) -m venv .venv/test-tarball
 source .venv/test-tarball/bin/activate
 # workaround https://github.com/django-extensions/django-extensions/issues/1694
 pip install --upgrade setuptools==59.6.0 pip
-# https://github.com/praekelt/django-recaptcha/issues/222
-pip install django-recaptcha  # workaround missing tar.gz
 pip install --no-binary :all: dist/kiwitcms*.tar.gz
 pip freeze | grep kiwitcms
 deactivate
@@ -96,6 +94,8 @@ source .venv/test-wheel/bin/activate
 pip install --upgrade setuptools pip
 pip install -r requirements/tarballs.txt
 pip install pycparser
+# https://github.com/mbi/django-simple-captcha/issues/207
+pip install django-simple-captcha # workaround missing wheel
 pip install --only-binary :all: dist/kiwitcms*.whl
 pip freeze | grep kiwitcms
 deactivate


### PR DESCRIPTION
- self-contained implementation
- does not depend on Google services
- will unblock migration to Django 4
- enabled by default

Settings RECAPTCHA_PUBLIC_KEY, RECAPTCHA_PRIVATE_KEY, RECAPTCHA_USE_SSL
are no longer in use!

New setting: USE_CAPTCHA

"captcha" added to INSTALLED_APPS

New database migration.