### PR TITLE
Run docker tests on aarch64 in Circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,31 @@
+# Use the latest 2.1 version of CircleCI pipeline process engine.
+# See: https://circleci.com/docs/2.0/configuration-reference
+version: 2.1
+
+# Define a job to be invoked later in a workflow.
+# See: https://circleci.com/docs/2.0/configuration-reference/#jobs
+jobs:
+  aarch64-test-docker-image:
+    machine:
+      # https://circleci.com/docs/2.0/configuration-reference/#available-machine-images
+      image: ubuntu-2004:202111-02
+    resource_class: arm.medium
+    # Add steps to the job
+    # See: https://circleci.com/docs/2.0/configuration-reference/#steps
+    steps:
+      - checkout
+      - run: uname -a
+      - run: python3 --version
+      # fail if not using Python 3
+      - run: python3 --version | grep "3\."
+      - run: pip3 install tcms-api
+      - run: make test-docker-image
+
+# Invoke jobs via workflows
+# See: https://circleci.com/docs/2.0/configuration-reference/#workflows
+workflows:
+  aarch64-docker:
+    when:
+      matches: { pattern: "^prepare/v.+$", value: << pipeline.git.branch >> }
+    jobs:
+      - aarch64-test-docker-image

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,32 @@
+name: changelog
+
+on:
+  pull_request:
+
+jobs:
+  acceptance:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: check-source-branch-and-modified-files
+      run: |
+        # fail if curl fails
+        set -e
+
+        echo "INFO: source branch is: ${{ github.head_ref }}"
+        echo "INFO: modified files"
+        curl -o- -L "${{ github.event.pull_request.diff_url }}" 2>/dev/null | grep "^diff --git"
+
+        set +e
+
+        # if this PR modifies the CHANGELOG file it needs to come from a branch
+        # that follows the pattern 'prepare/vX.Y' b/c we want to run some extra jobs for such branches!
+        if curl -o- -L "${{ github.event.pull_request.diff_url }}" 2>/dev/null | grep "^diff --git" | grep "CHANGELOG"; then
+            if [[ ! "${{ github.head_ref }}" =~ "^prepare/v.+$" ]]; then
+                echo "FAIL: Modifications to CHANGELOG are only accepted from 'prepate/vX.Y' branches!"
+                echo "INFO: Otherwise aarch64 jobs in Circle CI will not be executed."
+                exit 1
+            fi
+        fi


### PR DESCRIPTION
only when the target branch is of the form `prepare/vX.Y`

And make sure we fail CHANGELOG modifications if the branch name doesn't
match the pattern