### PR TITLE
Show message instead of empty list

### DIFF
--- a/tcms/templates/include/menu_items.html
+++ b/tcms/templates/include/menu_items.html
@@ -1,4 +1,5 @@
 {% load extra_filters %}
+{% load i18n %}
 {% for item in menu_items %}
     {% if not item.1|is_list %}
         {% if item.0 == '-' %}
@@ -22,7 +23,11 @@
             {% endif %}
         </a>
         <ul class="dropdown-menu">
-            {% include "include/menu_items.html" with menu_items=item.1 dropdown_class="-submenu" %}
+            {% if item.1|length == 0 %}
+                <li>{% trans "No items" %}</li>
+            {% else %}
+                {% include "include/menu_items.html" with menu_items=item.1 dropdown_class="-submenu" %}
+            {% endif %}
         </ul>
     </li>
     {% endif %}


### PR DESCRIPTION
When no plugins are installed we show empty < ul > element that looks broken.

![navbar](https://user-images.githubusercontent.com/8727922/156944724-c61fabf7-f152-4f49-bb81-8f59b97c65f1.png)
![navbar1](https://user-images.githubusercontent.com/8727922/156944725-a12e891d-990f-480b-8137-f5d05497ba3e.png)
