### PR TITLE
Allow overriding of Azure Boards API version. Closes #2717

### DIFF
--- a/tcms/issuetracker/azure_boards.py
+++ b/tcms/issuetracker/azure_boards.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import requests
+from django.conf import settings
 from requests.auth import HTTPBasicAuth
 
 from tcms.core.contrib.linkreference.models import LinkReference
@@ -13,7 +14,7 @@ class AzureBoardsAPI:
     """
 
     def __init__(self, base_url=None, password=None):
-        self.api_version = "?api-version=6.0"
+        self.api_version = f"?api-version={settings.AZURE_BOARDS_API_VERSION}"
         self.headers = {
             "Accept": "application/json-patch+json",
             "Content-type": "application/json-patch+json",

--- a/tcms/settings/common.py
+++ b/tcms/settings/common.py
@@ -154,6 +154,11 @@ MIDDLEWARE = [
 ]
 
 
+# See https://github.com/kiwitcms/Kiwi/issues/2717
+# and tcms/issuetracker/azure_boards.py
+AZURE_BOARDS_API_VERSION = os.environ.get("AZURE_BOARDS_API_VERSION", "6.0")
+
+
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # ~~ DANGER: Don't change the settings below!
 


### PR DESCRIPTION
- new setting AZURE_BOARDS_API_VERSION, defaults to 6.0
- also allows to be overriden via environment variable AZURE_BOARDS_API_VERSION