### PR TITLE
Don't crash if a comment user has been removed. Fixes KIWI-TCMS-HZ

### DIFF
--- a/tcms/bugs/templates/bugs/get.html
+++ b/tcms/bugs/templates/bugs/get.html
@@ -93,7 +93,11 @@
         <div class="col-xs-12 col-sm-12 col-md-12">
             <div class="card-pf card-pf-accented">
                 <h2 class="card-pf-title">
-                    <a href="{% url "tcms-profile" comment.user.username %}">{{ comment.user }}</a>
+                    {% if comment.user %}
+                        <a href="{% url "tcms-profile" comment.user.username %}">{{ comment.user }}</a>
+                    {% else %}
+                        {{ comment.name }}
+                    {% endif %}
                     {% trans 'commented on' %}
                     {{ comment.submit_date }}
                 </h2>


### PR DESCRIPTION
https://sentry.io/organizations/kiwitcms/issues/3086416250/.

Instead display a textual representation of the user name as it has been
saved in the database at the time the comment was made.