### PR TITLE
Update django-modern-rpc to 1.0.0a2

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,7 +10,7 @@ django-contrib-comments==2.2.0
 django-extensions==3.2.3
 django-grappelli==3.0.8
 django-guardian==2.4.0
-django-modern-rpc==0.12.1
+django-modern-rpc==1.0.0a2
 django-simple-history==3.4.0
 django-tree-queries==0.15.0
 django-uuslug==2.0.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,7 +10,7 @@ django-contrib-comments==2.2.0
 django-extensions==3.2.3
 django-grappelli==3.0.8
 django-guardian==2.4.0
-django-modern-rpc==1.0.0a2
+django-modern-rpc==1.0.2
 django-simple-history==3.4.0
 django-tree-queries==0.15.0
 django-uuslug==2.0.0

--- a/tcms/bugs/tests/test_api.py
+++ b/tcms/bugs/tests/test_api.py
@@ -2,7 +2,6 @@
 # pylint: disable=wrong-import-position
 import unittest
 from xmlrpc.client import Fault as XmlRPCFault
-from xmlrpc.client import ProtocolError
 
 from django.conf import settings
 
@@ -32,7 +31,9 @@ class TestAddTagPermissions(APIPermissionsTestCase):
         self.assertIn(self.tag, self.bug.tags.all())
 
     def verify_api_without_permission(self):
-        with self.assertRaisesRegex(ProtocolError, "403 Forbidden"):
+        with self.assertRaisesRegex(
+            XmlRPCFault, 'Authentication failed when calling "Bug.add_tag"'
+        ):
             self.rpc_client.Bug.add_tag(self.bug.pk, self.tag.name)
 
 
@@ -67,7 +68,9 @@ class TestRemoveTagPermissions(APIPermissionsTestCase):
         self.assertNotIn(self.tag, self.bug.tags.all())
 
     def verify_api_without_permission(self):
-        with self.assertRaisesRegex(ProtocolError, "403 Forbidden"):
+        with self.assertRaisesRegex(
+            XmlRPCFault, 'Authentication failed when calling "Bug.remove_tag"'
+        ):
             self.rpc_client.Bug.remove_tag(self.bug.pk, self.tag.name)
 
 
@@ -92,7 +95,9 @@ class TestRemovePermissions(APIPermissionsTestCase):
         self.assertIn(self.yet_another_bug, bugs)
 
     def verify_api_without_permission(self):
-        with self.assertRaisesRegex(ProtocolError, "403 Forbidden"):
+        with self.assertRaisesRegex(
+            XmlRPCFault, 'Authentication failed when calling "Bug.remove"'
+        ):
             self.rpc_client.Bug.remove({"pk__in": [self.bug.pk, self.another_bug.pk]})
 
 

--- a/tcms/handlers.py
+++ b/tcms/handlers.py
@@ -27,7 +27,6 @@ class KiwiTCMSJsonRpcHandler(JSONRPCHandler):
                 __class__.escape_dict(item)
 
     def dumps_result(self, result: JsonResult) -> str:
-
         if isinstance(result, JsonSuccessResult):
             if isinstance(result.data, str):
                 result.data = html.escape(result.data)
@@ -57,7 +56,6 @@ class KiwiTCMSXmlRpcHandler(XMLRPCHandler):
                 __class__.escape_dict(item)
 
     def dumps_result(self, result: BaseResult) -> str:
-
         if isinstance(result, SuccessResult):
             if isinstance(result.data, timedelta):
                 result.data = result.data.total_seconds()

--- a/tcms/rpc/tests/test_attachment.py
+++ b/tcms/rpc/tests/test_attachment.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=attribute-defined-outside-init, invalid-name, objects-update-used
 
-from xmlrpc.client import ProtocolError
+from xmlrpc.client import Fault as XmlRPCFault
 
 from tcms.rpc.tests.utils import APIPermissionsTestCase, APITestCase
 from tcms.tests import user_should_have_perm
@@ -57,5 +57,8 @@ class TestRemoveAttachmentPermissions(APIPermissionsTestCase):
 
         self.assertEqual(1, len(attachments))
 
-        with self.assertRaisesRegex(ProtocolError, "403 Forbidden"):
+        with self.assertRaisesRegex(
+            XmlRPCFault,
+            'Authentication failed when calling "Attachment.remove_attachment"',
+        ):
             self.rpc_client.Attachment.remove_attachment(attachments[0]["pk"])

--- a/tcms/rpc/tests/test_auth.py
+++ b/tcms/rpc/tests/test_auth.py
@@ -2,7 +2,6 @@
 # pylint: disable=attribute-defined-outside-init
 
 from xmlrpc.client import Fault as XmlRPCFault
-from xmlrpc.client import ProtocolError
 
 from tcms.rpc.tests.utils import APITestCase
 
@@ -33,6 +32,8 @@ class TestAuthLogout(APITestCase):
 
     def test_logout(self):
         self.rpc_client.Auth.logout()
-        with self.assertRaisesRegex(ProtocolError, "403 Forbidden"):
+        with self.assertRaisesRegex(
+            XmlRPCFault, 'Authentication failed when calling "Bug.details"'
+        ):
             # this method requires a logged-in user
             self.rpc_client.Bug.details("http://some.url")

--- a/tcms/rpc/tests/test_build.py
+++ b/tcms/rpc/tests/test_build.py
@@ -2,7 +2,6 @@
 # pylint: disable=invalid-name, attribute-defined-outside-init, objects-update-used
 
 from xmlrpc.client import Fault as XmlRPCFault
-from xmlrpc.client import ProtocolError
 
 from django.test import override_settings
 
@@ -19,7 +18,9 @@ class BuildCreate(APITestCase):
 
     def test_build_create_with_no_perms(self):
         self.rpc_client.Auth.logout()
-        with self.assertRaisesRegex(ProtocolError, "403 Forbidden"):
+        with self.assertRaisesRegex(
+            XmlRPCFault, 'Authentication failed when calling "Build.create"'
+        ):
             self.rpc_client.Build.create({})
 
     def test_build_create_with_no_required_fields(self):
@@ -83,7 +84,9 @@ class BuildUpdate(APITestCase):
 
     def test_build_update_with_no_perms(self):
         self.rpc_client.Auth.logout()
-        with self.assertRaisesRegex(ProtocolError, "403 Forbidden"):
+        with self.assertRaisesRegex(
+            XmlRPCFault, 'Authentication failed when calling "Build.update"'
+        ):
             self.rpc_client.Build.update(self.build_1.pk, {})
 
     def test_build_update_with_multi_id(self):

--- a/tcms/rpc/tests/test_category.py
+++ b/tcms/rpc/tests/test_category.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=attribute-defined-outside-init, invalid-name, objects-update-used
 
-from xmlrpc.client import ProtocolError
+from xmlrpc.client import Fault as XmlRPCFault
 
 from tcms.rpc.tests.utils import APIPermissionsTestCase, APITestCase
 from tcms.testcases.models import Category
@@ -73,7 +73,9 @@ class TestCategoryCreatePermissions(APIPermissionsTestCase):
         self.assertEqual(category.product_id, self.product.pk)
 
     def verify_api_without_permission(self):
-        with self.assertRaisesRegex(ProtocolError, "403 Forbidden"):
+        with self.assertRaisesRegex(
+            XmlRPCFault, 'Authentication failed when calling "Category.create"'
+        ):
             self.rpc_client.Category.create(
                 {"product": self.product.pk, "name": "Category without Permissions"}
             )

--- a/tcms/rpc/tests/test_classification.py
+++ b/tcms/rpc/tests/test_classification.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=attribute-defined-outside-init
 
-from xmlrpc.client import ProtocolError
+from xmlrpc.client import Fault as XmlRPCFault
 
 from tcms.management.models import Classification
 from tcms.rpc.tests.utils import APIPermissionsTestCase, APITestCase
@@ -44,7 +44,9 @@ class TestClassificationFilterPermissions(APIPermissionsTestCase):
         self.assertGreater(len(classifications), 0)
 
     def verify_api_without_permission(self):
-        with self.assertRaisesRegex(ProtocolError, "403 Forbidden"):
+        with self.assertRaisesRegex(
+            XmlRPCFault, 'Authentication failed when calling "Classification.filter"'
+        ):
             self.rpc_client.Classification.filter({})
 
 
@@ -61,5 +63,7 @@ class TestClassificationCreate(APIPermissionsTestCase):
         self.assertEqual(result["name"], obj_from_db.name)
 
     def verify_api_without_permission(self):
-        with self.assertRaisesRegex(ProtocolError, "403 Forbidden"):
+        with self.assertRaisesRegex(
+            XmlRPCFault, 'Authentication failed when calling "Classification.create"'
+        ):
             self.rpc_client.Classification.create({"name": "API-CLASSIFICATION"})

--- a/tcms/rpc/tests/test_component.py
+++ b/tcms/rpc/tests/test_component.py
@@ -2,7 +2,6 @@
 # pylint: disable=attribute-defined-outside-init, invalid-name
 
 from xmlrpc.client import Fault as XmlRPCFault
-from xmlrpc.client import ProtocolError
 
 from tcms.rpc.tests.utils import APITestCase
 from tcms.tests.factories import ComponentFactory, ProductFactory
@@ -65,7 +64,9 @@ class TestCreateComponent(APITestCase):
 
     def test_add_component_with_no_perms(self):
         self.rpc_client.Auth.logout()
-        with self.assertRaisesRegex(ProtocolError, "403 Forbidden"):
+        with self.assertRaisesRegex(
+            XmlRPCFault, 'Authentication failed when calling "Component.create"'
+        ):
             self.rpc_client.Component.create(self.product.pk, "MyComponent")
 
 
@@ -95,5 +96,7 @@ class TestUpdateComponent(APITestCase):
 
     def test_update_component_with_no_perms(self):
         self.rpc_client.Auth.logout()
-        with self.assertRaisesRegex(ProtocolError, "403 Forbidden"):
+        with self.assertRaisesRegex(
+            XmlRPCFault, 'Authentication failed when calling "Component.update"'
+        ):
             self.rpc_client.Component.update(self.component.pk, {})

--- a/tcms/rpc/tests/test_environment.py
+++ b/tcms/rpc/tests/test_environment.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 from xmlrpc.client import Fault as XmlRPCFault
-from xmlrpc.client import ProtocolError
 
 from django.test import override_settings
 
@@ -16,7 +15,9 @@ class TestFilterPermission(APIPermissionsTestCase):
         self.assertTrue(isinstance(result, list))
 
     def verify_api_without_permission(self):
-        with self.assertRaisesRegex(ProtocolError, "403 Forbidden"):
+        with self.assertRaisesRegex(
+            XmlRPCFault, 'Authentication failed when calling "Environment.filter"'
+        ):
             self.rpc_client.Environment.filter(None)
 
 
@@ -60,7 +61,9 @@ class TestEnvironmentCreatePermissions(APIPermissionsTestCase):
         self.assertEqual(environment.description, description)
 
     def verify_api_without_permission(self):
-        with self.assertRaisesRegex(ProtocolError, "403 Forbidden"):
+        with self.assertRaisesRegex(
+            XmlRPCFault, 'Authentication failed when calling "Environment.create"'
+        ):
             self.rpc_client.Environment.create(
                 {"name": "E8", "description": "Environment without Permissions"}
             )

--- a/tcms/rpc/tests/test_plantype.py
+++ b/tcms/rpc/tests/test_plantype.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=attribute-defined-outside-init
 
-from xmlrpc.client import ProtocolError
+from xmlrpc.client import Fault as XmlRPCFault
 
 from tcms.rpc.tests.utils import APIPermissionsTestCase
 from tcms.testplans.models import PlanType
@@ -22,7 +22,9 @@ class TestPlanTypeFilter(APIPermissionsTestCase):
         self.assertEqual(self.plan_type.pk, result["id"])
 
     def verify_api_without_permission(self):
-        with self.assertRaisesRegex(ProtocolError, "403 Forbidden"):
+        with self.assertRaisesRegex(
+            XmlRPCFault, 'Authentication failed when calling "PlanType.filter"'
+        ):
             self.rpc_client.PlanType.filter({"name": self.plan_type.name})
 
 
@@ -39,5 +41,7 @@ class TestPlanTypeCreate(APIPermissionsTestCase):
         self.assertEqual(result["name"], obj_from_db.name)
 
     def verify_api_without_permission(self):
-        with self.assertRaisesRegex(ProtocolError, "403 Forbidden"):
+        with self.assertRaisesRegex(
+            XmlRPCFault, 'Authentication failed when calling "PlanType.create"'
+        ):
             self.rpc_client.PlanType.create({"name": "API-TP"})

--- a/tcms/rpc/tests/test_priority.py
+++ b/tcms/rpc/tests/test_priority.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=attribute-defined-outside-init
 
-from xmlrpc.client import ProtocolError
+from xmlrpc.client import Fault as XmlRPCFault
 
 from tcms.rpc.tests.utils import APIPermissionsTestCase, APITestCase
 
@@ -29,5 +29,7 @@ class TestPriorityFilterPermissions(APIPermissionsTestCase):
         self.assertGreater(len(priorities), 0)
 
     def verify_api_without_permission(self):
-        with self.assertRaisesRegex(ProtocolError, "403 Forbidden"):
+        with self.assertRaisesRegex(
+            XmlRPCFault, 'Authentication failed when calling "Priority.filter"'
+        ):
             self.rpc_client.Priority.filter({})

--- a/tcms/rpc/tests/test_product.py
+++ b/tcms/rpc/tests/test_product.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=attribute-defined-outside-init
 
-from xmlrpc.client import ProtocolError
+from xmlrpc.client import Fault as XmlRPCFault
 
 from tcms.management.models import Product
 from tcms.rpc.tests.utils import APIPermissionsTestCase, APITestCase
@@ -52,7 +52,9 @@ class TestProductCreatePermissions(APIPermissionsTestCase):
         self.assertEqual(product.name, "Product with Permissions")
 
     def verify_api_without_permission(self):
-        with self.assertRaisesRegex(ProtocolError, "403 Forbidden"):
+        with self.assertRaisesRegex(
+            XmlRPCFault, 'Authentication failed when calling "Product.create"'
+        ):
             self.rpc_client.Product.create(
                 {
                     "name": "Product with Permissions",

--- a/tcms/rpc/tests/test_testcase.py
+++ b/tcms/rpc/tests/test_testcase.py
@@ -3,7 +3,7 @@
 
 import unittest
 from datetime import timedelta
-from xmlrpc.client import Fault, ProtocolError
+from xmlrpc.client import Fault as XmlRPCFault
 
 from attachments.models import Attachment
 from django.contrib.auth.models import Permission
@@ -59,7 +59,10 @@ class TestAddNotificationCCPermission(APIPermissionsTestCase):
         self.assertEqual(self.testcase.emailing.get_cc_list(), [self.default_cc])
 
     def verify_api_without_permission(self):
-        with self.assertRaisesRegex(ProtocolError, "403 Forbidden"):
+        with self.assertRaisesRegex(
+            XmlRPCFault,
+            'Authentication failed when calling "TestCase.add_notification_cc"',
+        ):
             self.rpc_client.TestCase.add_notification_cc(
                 self.testcase.pk, [self.default_cc]
             )
@@ -67,7 +70,9 @@ class TestAddNotificationCCPermission(APIPermissionsTestCase):
 
 class TestAddNotificationCC(APITestCase):
     def test_invalid_testcase_id(self):
-        with self.assertRaisesRegex(Fault, "TestCase matching query does not exist"):
+        with self.assertRaisesRegex(
+            XmlRPCFault, "TestCase matching query does not exist"
+        ):
             self.rpc_client.TestCase.add_notification_cc(-1, ["example@example.com"])
 
 
@@ -86,13 +91,18 @@ class TestGetNotificationCCPermission(APIPermissionsTestCase):
         self.assertListEqual(result, [self.default_cc])
 
     def verify_api_without_permission(self):
-        with self.assertRaisesRegex(ProtocolError, "403 Forbidden"):
+        with self.assertRaisesRegex(
+            XmlRPCFault,
+            'Authentication failed when calling "TestCase.get_notification_cc"',
+        ):
             self.rpc_client.TestCase.get_notification_cc(self.testcase.pk)
 
 
 class TestGetNotificationCC(APITestCase):
     def test_invalid_testcase_id(self):
-        with self.assertRaisesRegex(Fault, "TestCase matching query does not exist"):
+        with self.assertRaisesRegex(
+            XmlRPCFault, "TestCase matching query does not exist"
+        ):
             self.rpc_client.TestCase.get_notification_cc(-1)
 
 
@@ -114,7 +124,10 @@ class TestRemoveNotificationCCPermission(APIPermissionsTestCase):
         self.assertEqual([], self.testcase.emailing.get_cc_list())
 
     def verify_api_without_permission(self):
-        with self.assertRaisesRegex(ProtocolError, "403 Forbidden"):
+        with self.assertRaisesRegex(
+            XmlRPCFault,
+            'Authentication failed when calling "TestCase.remove_notification_cc"',
+        ):
             self.rpc_client.TestCase.remove_notification_cc(
                 self.testcase.pk, [self.default_cc]
             )
@@ -122,7 +135,9 @@ class TestRemoveNotificationCCPermission(APIPermissionsTestCase):
 
 class TestRemoveNotificationCC(APITestCase):
     def test_invalid_testcase_id(self):
-        with self.assertRaisesRegex(Fault, "TestCase matching query does not exist"):
+        with self.assertRaisesRegex(
+            XmlRPCFault, "TestCase matching query does not exist"
+        ):
             self.rpc_client.TestCase.remove_notification_cc(-1, ["example@example.com"])
 
 
@@ -300,7 +315,7 @@ class TestUpdate(APITestCase):
 
     def test_update_author_should_fail_for_non_existing_user_id(self):
         initial_author_id = self.testcase.author.pk
-        with self.assertRaises(Fault):
+        with self.assertRaises(XmlRPCFault):
             self.rpc_client.TestCase.update(  # pylint: disable=objects-update-used
                 self.testcase.pk,
                 {
@@ -330,7 +345,7 @@ class TestUpdate(APITestCase):
 
     def test_update_author_should_fail_for_non_existing_username(self):
         initial_author_username = self.testcase.author.username
-        with self.assertRaises(Fault):
+        with self.assertRaises(XmlRPCFault):
             self.rpc_client.TestCase.update(  # pylint: disable=objects-update-used
                 self.testcase.pk,
                 {
@@ -360,7 +375,7 @@ class TestUpdate(APITestCase):
 
     def test_update_author_should_fail_for_non_existing_email(self):
         initial_author_email = self.testcase.author.email
-        with self.assertRaises(Fault):
+        with self.assertRaises(XmlRPCFault):
             self.rpc_client.TestCase.update(  # pylint: disable=objects-update-used
                 self.testcase.pk,
                 {
@@ -414,7 +429,7 @@ class TestUpdate(APITestCase):
     def test_update_default_tester_should_fail_with_non_existing_user_id(self):
         self.assertIsNone(self.testcase.default_tester)
 
-        with self.assertRaises(Fault):
+        with self.assertRaises(XmlRPCFault):
             self.rpc_client.TestCase.update(  # pylint: disable=objects-update-used
                 self.testcase.pk,
                 {
@@ -443,7 +458,7 @@ class TestUpdate(APITestCase):
     def test_update_default_tester_should_fail_with_non_existing_username(self):
         self.assertIsNone(self.testcase.default_tester)
 
-        with self.assertRaises(Fault):
+        with self.assertRaises(XmlRPCFault):
             self.rpc_client.TestCase.update(  # pylint: disable=objects-update-used
                 self.testcase.pk,
                 {
@@ -471,7 +486,7 @@ class TestUpdate(APITestCase):
     def test_update_default_tester_should_fail_with_non_existing_email(self):
         self.assertIsNone(self.testcase.default_tester)
 
-        with self.assertRaises(Fault):
+        with self.assertRaises(XmlRPCFault):
             self.rpc_client.TestCase.update(  # pylint: disable=objects-update-used
                 self.testcase.pk,
                 {
@@ -499,7 +514,7 @@ class TestUpdate(APITestCase):
 
     def test_update_reviewer_should_fail_with_non_existing_user_id(self):
         initial_reviewer_id = self.testcase.reviewer.pk
-        with self.assertRaises(Fault):
+        with self.assertRaises(XmlRPCFault):
             self.rpc_client.TestCase.update(  # pylint: disable=objects-update-used
                 self.testcase.pk,
                 {
@@ -525,7 +540,7 @@ class TestUpdate(APITestCase):
 
     def test_update_reviewer_should_fail_for_non_existing_username(self):
         initial_reviewer_username = self.testcase.reviewer.username
-        with self.assertRaises(Fault):
+        with self.assertRaises(XmlRPCFault):
             self.rpc_client.TestCase.update(  # pylint: disable=objects-update-used
                 self.testcase.pk,
                 {
@@ -551,7 +566,7 @@ class TestUpdate(APITestCase):
 
     def test_update_reviewer_should_fail_for_non_existing_email(self):
         initial_reviewer_email = self.testcase.reviewer.email
-        with self.assertRaises(Fault):
+        with self.assertRaises(XmlRPCFault):
             self.rpc_client.TestCase.update(  # pylint: disable=objects-update-used
                 self.testcase.pk,
                 {
@@ -629,7 +644,7 @@ class TestCreate(APITestCase):
         self.assertEqual(new_author, tc_from_db.author)
 
     def test_fails_when_mandatory_fields_not_specified(self):
-        with self.assertRaises(Fault):
+        with self.assertRaises(XmlRPCFault):
             self.rpc_client.TestCase.create(
                 {
                     "summary": "TC via API without mandatory FK fields",
@@ -654,7 +669,9 @@ class TestRemovePermissions(APIPermissionsTestCase):
         self.assertEqual(num_deleted, 3)
 
     def verify_api_without_permission(self):
-        with self.assertRaisesRegex(ProtocolError, "403 Forbidden"):
+        with self.assertRaisesRegex(
+            XmlRPCFault, 'Authentication failed when calling "TestCase.remove"'
+        ):
             self.rpc_client.TestCase.remove(self.query)
 
 
@@ -688,7 +705,9 @@ class TestAddTag(APITestCase):
             f"{self.live_server_url}/xml-rpc/",
         ).server
 
-        with self.assertRaisesRegex(ProtocolError, "403 Forbidden"):
+        with self.assertRaisesRegex(
+            XmlRPCFault, 'Authentication failed when calling "TestCase.add_tag"'
+        ):
             rpc_client.TestCase.add_tag(self.testcase.pk, self.tag1.name)
 
         # tags were not modified
@@ -729,7 +748,9 @@ class TestRemoveTag(APITestCase):
             f"{self.live_server_url}/xml-rpc/",
         ).server
 
-        with self.assertRaisesRegex(ProtocolError, "403 Forbidden"):
+        with self.assertRaisesRegex(
+            XmlRPCFault, 'Authentication failed when calling "TestCase.remove_tag"'
+        ):
             rpc_client.TestCase.remove_tag(self.testcase.pk, self.tag0.name)
 
         # tags were not modified
@@ -759,7 +780,9 @@ class TestAddComponent(APITestCase):
         self.assertEqual(result["name"], self.good_component.name)
 
     def test_add_component_from_another_product_is_not_allowed(self):
-        with self.assertRaisesRegex(Fault, "Component matching query does not exist"):
+        with self.assertRaisesRegex(
+            XmlRPCFault, "Component matching query does not exist"
+        ):
             self.rpc_client.TestCase.add_component(
                 self.test_case.pk, self.bad_component.name
             )
@@ -785,7 +808,10 @@ class TestRemoveComponentPermission(APIPermissionsTestCase):
         self.assertEqual(result.first(), self.good_component)
 
     def verify_api_without_permission(self):
-        with self.assertRaisesRegex(ProtocolError, "403 Forbidden"):
+        with self.assertRaisesRegex(
+            XmlRPCFault,
+            'Authentication failed when calling "TestCase.remove_component"',
+        ):
             self.rpc_client.TestCase.remove_component(
                 self.test_case.pk, self.good_component.pk
             )
@@ -793,7 +819,9 @@ class TestRemoveComponentPermission(APIPermissionsTestCase):
 
 class TestRemoveComponent(APITestCase):
     def test_invalid_testcase_id(self):
-        with self.assertRaisesRegex(Fault, "TestCase matching query does not exist"):
+        with self.assertRaisesRegex(
+            XmlRPCFault, "TestCase matching query does not exist"
+        ):
             self.rpc_client.TestCase.remove_component(-1, -1)
 
 
@@ -818,13 +846,17 @@ class TestAddCommentPermissions(APIPermissionsTestCase):
         self.assertEqual("Hello World!", created_comment["comment"])
 
     def verify_api_without_permission(self):
-        with self.assertRaisesRegex(ProtocolError, "403 Forbidden"):
+        with self.assertRaisesRegex(
+            XmlRPCFault, 'Authentication failed when calling "TestCase.add_comment"'
+        ):
             self.rpc_client.TestCase.add_comment(self.case.pk, "Hello World!")
 
 
 class TestAddComment(APITestCase):
     def test_invalid_testcase_id(self):
-        with self.assertRaisesRegex(Fault, "TestCase matching query does not exist"):
+        with self.assertRaisesRegex(
+            XmlRPCFault, "TestCase matching query does not exist"
+        ):
             self.rpc_client.TestCase.add_comment(-1, "Hello World!")
 
 
@@ -849,13 +881,17 @@ class TestRemoveCommentPermissions(APIPermissionsTestCase):
         self.assertEqual(len(comments.get_comments(self.case)), 0)
 
     def verify_api_without_permission(self):
-        with self.assertRaisesRegex(ProtocolError, "403 Forbidden"):
+        with self.assertRaisesRegex(
+            XmlRPCFault, 'Authentication failed when calling "TestCase.remove_comment"'
+        ):
             self.rpc_client.TestCase.remove_comment(self.case.pk)
 
 
 class TestRemoveComment(APITestCase):
     def test_invalid_testcase_id(self):
-        with self.assertRaisesRegex(Fault, "TestCase matching query does not exist"):
+        with self.assertRaisesRegex(
+            XmlRPCFault, "TestCase matching query does not exist"
+        ):
             self.rpc_client.TestCase.remove_comment(-1)
 
 
@@ -895,7 +931,9 @@ class TestCaseSortkeysPermissions(APIPermissionsTestCase):
         self.assertGreater(len(result), 0)
 
     def verify_api_without_permission(self):
-        with self.assertRaisesRegex(ProtocolError, "403 Forbidden"):
+        with self.assertRaisesRegex(
+            XmlRPCFault, 'Authentication failed when calling "TestCase.sortkeys"'
+        ):
             self.rpc_client.TestCase.sortkeys(
                 {
                     "plan": self.plan.pk,
@@ -928,7 +966,9 @@ class TestCaseCommentPermissions(APIPermissionsTestCase):
             self.assertEqual(entry["user_name"], self.tester.username)
 
     def verify_api_without_permission(self):
-        with self.assertRaisesRegex(ProtocolError, "403 Forbidden"):
+        with self.assertRaisesRegex(
+            XmlRPCFault, 'Authentication failed when calling "TestCase.comments"'
+        ):
             self.rpc_client.TestCase.comments(self.case.pk)
 
 
@@ -949,7 +989,9 @@ class TestAddAttachmentPermissions(APIPermissionsTestCase):
         self.assertEqual(attachments[0].object_id, str(self.case.pk))
 
     def verify_api_without_permission(self):
-        with self.assertRaisesRegex(ProtocolError, "403 Forbidden"):
+        with self.assertRaisesRegex(
+            XmlRPCFault, 'Authentication failed when calling "TestCase.add_attachment"'
+        ):
             self.rpc_client.TestCase.add_attachment(
                 self.case.pk, "test.txt", "a2l3aXRjbXM="
             )
@@ -969,7 +1011,9 @@ class TestListAttachments(APITestCase):
         self.assertEqual(len(attachments), 1)
 
     def test_invalid_testcase_id(self):
-        with self.assertRaisesRegex(Fault, "TestCase matching query does not exist"):
+        with self.assertRaisesRegex(
+            XmlRPCFault, "TestCase matching query does not exist"
+        ):
             self.rpc_client.TestCase.list_attachments(-1)
 
 
@@ -986,5 +1030,8 @@ class TestListAttachmentPermissions(APIPermissionsTestCase):
         self.assertEqual(len(attachments), 0)
 
     def verify_api_without_permission(self):
-        with self.assertRaisesRegex(ProtocolError, "403 Forbidden"):
+        with self.assertRaisesRegex(
+            XmlRPCFault,
+            'Authentication failed when calling "TestCase.list_attachments"',
+        ):
             self.rpc_client.TestCase.list_attachments(self.case.pk)

--- a/tcms/rpc/tests/test_testcase.py
+++ b/tcms/rpc/tests/test_testcase.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# pylint: disable=attribute-defined-outside-init
+# pylint: disable=attribute-defined-outside-init,too-many-lines
 
 import unittest
 from datetime import timedelta

--- a/tcms/rpc/tests/test_testcasestatus.py
+++ b/tcms/rpc/tests/test_testcasestatus.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=attribute-defined-outside-init
 
-from xmlrpc.client import ProtocolError
+from xmlrpc.client import Fault as XmlRPCFault
 
 from tcms.rpc.tests.utils import APIPermissionsTestCase, APITestCase
 
@@ -30,5 +30,7 @@ class TestCaseStatusFilterPermissions(APIPermissionsTestCase):
         self.assertGreater(len(case_status), 0)
 
     def verify_api_without_permission(self):
-        with self.assertRaisesRegex(ProtocolError, "403 Forbidden"):
+        with self.assertRaisesRegex(
+            XmlRPCFault, 'Authentication failed when calling "TestCaseStatus.filter"'
+        ):
             self.rpc_client.TestCaseStatus.filter({})

--- a/tcms/rpc/tests/test_testexecution.py
+++ b/tcms/rpc/tests/test_testexecution.py
@@ -3,7 +3,6 @@
 
 import time
 from xmlrpc.client import Fault as XmlRPCFault
-from xmlrpc.client import ProtocolError
 
 from django.forms.models import model_to_dict
 from django.test import override_settings
@@ -73,7 +72,10 @@ class TestExecutionGetCommentsPermissions(APIPermissionsTestCase):
             self.assertIn(comment["comment"], self.comments)
 
     def verify_api_without_permission(self):
-        with self.assertRaisesRegex(ProtocolError, "403 Forbidden"):
+        with self.assertRaisesRegex(
+            XmlRPCFault,
+            'Authentication failed when calling "TestExecution.get_comments"',
+        ):
             self.rpc_client.TestExecution.get_comments(self.execution.pk)
 
 
@@ -149,7 +151,10 @@ class TestExecutionRemoveCommentPermissions(APIPermissionsTestCase):
     def verify_api_without_permission(self):
         comments.add_comment([self.execution], "Hello World!", self.user)
 
-        with self.assertRaisesRegex(ProtocolError, "403 Forbidden"):
+        with self.assertRaisesRegex(
+            XmlRPCFault,
+            'Authentication failed when calling "TestExecution.remove_comment"',
+        ):
             self.rpc_client.TestExecution.remove_comment(self.execution.pk)
 
 
@@ -214,7 +219,9 @@ class TestExecutionAddLinkPermissions(APIPermissionsTestCase):
 
     def verify_api_without_permission(self):
         url = "http://127.0.0.1/test/test-log.log"
-        with self.assertRaisesRegex(ProtocolError, "403 Forbidden"):
+        with self.assertRaisesRegex(
+            XmlRPCFault, 'Authentication failed when calling "TestExecution.add_link"'
+        ):
             self.rpc_client.TestExecution.add_link(
                 {"execution_id": self.execution.pk, "name": "UT test logs", "url": url}
             )
@@ -287,7 +294,10 @@ class TestExecutionRemoveLinkPermissions(APIPermissionsTestCase):
         self.assertNotIn(self.link, links)
 
     def verify_api_without_permission(self):
-        with self.assertRaisesRegex(ProtocolError, "403 Forbidden"):
+        with self.assertRaisesRegex(
+            XmlRPCFault,
+            'Authentication failed when calling "TestExecution.remove_link"',
+        ):
             self.rpc_client.TestExecution.remove_link({"pk": self.another_link.pk})
 
 
@@ -474,7 +484,9 @@ class TestExecutionHistoryPermissions(APIPermissionsTestCase):
         self.assertEqual(1, len(history))
 
     def verify_api_without_permission(self):
-        with self.assertRaisesRegex(ProtocolError, "403 Forbidden"):
+        with self.assertRaisesRegex(
+            XmlRPCFault, 'Authentication failed when calling "TestExecution.history"'
+        ):
             self.rpc_client.TestExecution.history(self.execution.pk)
 
 
@@ -663,7 +675,9 @@ class TestExecutionUpdate(APITestCase):
 
     def test_update_with_no_perm(self):
         self.rpc_client.Auth.logout()
-        with self.assertRaisesRegex(ProtocolError, "403 Forbidden"):
+        with self.assertRaisesRegex(
+            XmlRPCFault, 'Authentication failed when calling "TestExecution.update"'
+        ):
             self.rpc_client.TestExecution.update(
                 self.execution_1.pk, {"stop_date": timezone.now()}
             )

--- a/tcms/rpc/tests/test_testexecutionstatus.py
+++ b/tcms/rpc/tests/test_testexecutionstatus.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=attribute-defined-outside-init, invalid-name, objects-update-used
 
-from xmlrpc.client import ProtocolError
+from xmlrpc.client import Fault as XmlRPCFault
 
 from tcms.rpc.tests.utils import APIPermissionsTestCase, APITestCase
 
@@ -35,5 +35,8 @@ class TestFilterPermission(APIPermissionsTestCase):
         self.assertGreater(len(execution_statuses), 0)
 
     def verify_api_without_permission(self):
-        with self.assertRaisesRegex(ProtocolError, "403 Forbidden"):
+        with self.assertRaisesRegex(
+            XmlRPCFault,
+            'Authentication failed when calling "TestExecutionStatus.filter"',
+        ):
             self.rpc_client.TestExecutionStatus.filter({"weight__lt": 0})

--- a/tcms/rpc/tests/test_testplan.py
+++ b/tcms/rpc/tests/test_testplan.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=attribute-defined-outside-init, invalid-name, objects-update-used
+
 from xmlrpc.client import Fault as XmlRPCFault
-from xmlrpc.client import ProtocolError
 
 from attachments.models import Attachment
 from django.contrib.auth.models import Permission
@@ -102,7 +102,9 @@ class TestAddTag(APITestCase):
             f"{self.live_server_url}/xml-rpc/",
         ).server
 
-        with self.assertRaisesRegex(ProtocolError, "403 Forbidden"):
+        with self.assertRaisesRegex(
+            XmlRPCFault, 'Authentication failed when calling "TestPlan.add_tag"'
+        ):
             rpc_client.TestPlan.add_tag(self.plans[0].pk, self.tag1.name)
 
         # tags were not modified
@@ -149,7 +151,9 @@ class TestRemoveTag(APITestCase):
             f"{self.live_server_url}/xml-rpc/",
         ).server
 
-        with self.assertRaisesRegex(ProtocolError, "403 Forbidden"):
+        with self.assertRaisesRegex(
+            XmlRPCFault, 'Authentication failed when calling "TestPlan.remove_tag"'
+        ):
             rpc_client.TestPlan.remove_tag(self.plans[0].pk, self.tag0.name)
 
         # tags were not modified
@@ -215,7 +219,9 @@ class TestUpdatePermission(APIPermissionsTestCase):
         self.assertEqual("This has been updated", self.plan.text)
 
     def verify_api_without_permission(self):
-        with self.assertRaisesRegex(ProtocolError, "403 Forbidden"):
+        with self.assertRaisesRegex(
+            XmlRPCFault, 'Authentication failed when calling "TestPlan.update"'
+        ):
             self.rpc_client.TestPlan.update(
                 self.plan.pk, {"text": "This has been updated"}
             )
@@ -389,7 +395,9 @@ class TestCreatePermission(APIPermissionsTestCase):
         self.assertEqual(testplan.pk, result["id"])
 
     def verify_api_without_permission(self):
-        with self.assertRaisesRegex(ProtocolError, "403 Forbidden"):
+        with self.assertRaisesRegex(
+            XmlRPCFault, 'Authentication failed when calling "TestPlan.create"'
+        ):
             self.rpc_client.TestPlan.create(self.params)
 
 
@@ -426,7 +434,10 @@ class TestListAttachmentsPermissions(APIPermissionsTestCase):
         self.assertEqual(0, len(attachments))
 
     def verify_api_without_permission(self):
-        with self.assertRaisesRegex(ProtocolError, "403 Forbidden"):
+        with self.assertRaisesRegex(
+            XmlRPCFault,
+            'Authentication failed when calling "TestPlan.list_attachments"',
+        ):
             self.rpc_client.TestPlan.list_attachments(self.plan.pk)
 
 
@@ -450,7 +461,9 @@ class TestAddAttachmentPermissions(APIPermissionsTestCase):
         self.assertTrue(file_url.endswith(file_name))
 
     def verify_api_without_permission(self):
-        with self.assertRaisesRegex(ProtocolError, "403 Forbidden"):
+        with self.assertRaisesRegex(
+            XmlRPCFault, 'Authentication failed when calling "TestPlan.add_attachment"'
+        ):
             self.rpc_client.TestPlan.add_attachment(
                 self.plan.pk, "attachment.txt", "a2l3aXRjbXM="
             )
@@ -475,7 +488,9 @@ class TestTreePermission(APIPermissionsTestCase):
         self.assertIn("url", result[0])
 
     def verify_api_without_permission(self):
-        with self.assertRaisesRegex(ProtocolError, "403 Forbidden"):
+        with self.assertRaisesRegex(
+            XmlRPCFault, 'Authentication failed when calling "TestPlan.tree"'
+        ):
             self.rpc_client.TestPlan.tree(self.plan.pk)
 
 

--- a/tcms/rpc/tests/test_testrun.py
+++ b/tcms/rpc/tests/test_testrun.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=attribute-defined-outside-init, objects-update-used
+
 from datetime import datetime
 from xmlrpc.client import Fault as XmlRPCFault
-from xmlrpc.client import ProtocolError
 
 from attachments.models import Attachment
 from django.contrib.auth.models import Permission
@@ -76,7 +76,9 @@ class TestAddCase(APITestCase):
             f"{self.live_server_url}/xml-rpc/",
         ).server
 
-        with self.assertRaisesRegex(ProtocolError, "403 Forbidden"):
+        with self.assertRaisesRegex(
+            XmlRPCFault, 'Authentication failed when calling "TestRun.add_case"'
+        ):
             rpc_client.TestRun.add_case(self.test_run.pk, self.test_case.pk)
 
         exists = TestExecution.objects.filter(
@@ -131,7 +133,9 @@ class TestRemovesCase(APITestCase):
             f"{self.live_server_url}/xml-rpc/",
         ).server
 
-        with self.assertRaisesRegex(ProtocolError, "403 Forbidden"):
+        with self.assertRaisesRegex(
+            XmlRPCFault, 'Authentication failed when calling "TestRun.remove_case"'
+        ):
             rpc_client.TestRun.remove_case(self.test_run.pk, self.test_case.pk)
 
         exists = TestExecution.objects.filter(
@@ -202,7 +206,9 @@ class TestGetCasesPermission(APIPermissionsTestCase):
         self.assertTrue(isinstance(result, list))
 
     def verify_api_without_permission(self):
-        with self.assertRaisesRegex(ProtocolError, "403 Forbidden"):
+        with self.assertRaisesRegex(
+            XmlRPCFault, 'Authentication failed when calling "TestRun.get_cases"'
+        ):
             self.rpc_client.TestRun.get_cases(self.test_run.pk)
 
 
@@ -254,7 +260,9 @@ class TestAddTag(APITestCase):
             f"{self.live_server_url}/xml-rpc/",
         ).server
 
-        with self.assertRaisesRegex(ProtocolError, "403 Forbidden"):
+        with self.assertRaisesRegex(
+            XmlRPCFault, 'Authentication failed when calling "TestRun.add_tag"'
+        ):
             rpc_client.TestRun.add_tag(self.test_runs[0].pk, self.tag0.name)
 
         # tags were not modified
@@ -325,7 +333,9 @@ class TestRemoveTag(APITestCase):
             f"{self.live_server_url}/xml-rpc/",
         ).server
 
-        with self.assertRaisesRegex(ProtocolError, "403 Forbidden"):
+        with self.assertRaisesRegex(
+            XmlRPCFault, 'Authentication failed when calling "TestRun.remove_tag"'
+        ):
             rpc_client.TestRun.remove_tag(self.test_runs[0].pk, self.tag0.name)
 
         # tags were not modified
@@ -400,7 +410,9 @@ class TestCreatePermission(APIPermissionsTestCase):
         self.assertIn("default_tester", result)
 
     def verify_api_without_permission(self):
-        with self.assertRaisesRegex(ProtocolError, "403 Forbidden"):
+        with self.assertRaisesRegex(
+            XmlRPCFault, 'Authentication failed when calling "TestRun.create"'
+        ):
             self.rpc_client.TestRun.create(self.test_run_fields)
 
 
@@ -457,7 +469,9 @@ class TestFilterPermission(APIPermissionsTestCase):
         self.assertTrue(isinstance(result, list))
 
     def verify_api_without_permission(self):
-        with self.assertRaisesRegex(ProtocolError, "403 Forbidden"):
+        with self.assertRaisesRegex(
+            XmlRPCFault, 'Authentication failed when calling "TestRun.filter"'
+        ):
             self.rpc_client.TestRun.filter(None)
 
 
@@ -590,7 +604,9 @@ class TestUpdatePermission(APIPermissionsTestCase):
         self.assertEqual(updated_test_run["stop_date"], self.test_run.stop_date)
 
     def verify_api_without_permission(self):
-        with self.assertRaisesRegex(ProtocolError, "403 Forbidden"):
+        with self.assertRaisesRegex(
+            XmlRPCFault, 'Authentication failed when calling "TestRun.update"'
+        ):
             self.rpc_client.TestRun.update(self.test_run.pk, self.update_fields)
 
 

--- a/tcms/rpc/tests/test_testrun.py
+++ b/tcms/rpc/tests/test_testrun.py
@@ -627,7 +627,9 @@ class TestAddAttachmentPermissions(APIPermissionsTestCase):
         self.assertEqual(attachments[0].object_id, str(self.test_run.pk))
 
     def verify_api_without_permission(self):
-        with self.assertRaisesRegex(ProtocolError, "403 Forbidden"):
+        with self.assertRaisesRegex(
+            XmlRPCFault, 'Authentication failed when calling "TestRun.add_attachment"'
+        ):
             self.rpc_client.TestRun.add_attachment(
                 self.test_run.pk, "test.txt", "a2l3aXRjbXM="
             )

--- a/tcms/rpc/tests/test_version.py
+++ b/tcms/rpc/tests/test_version.py
@@ -2,7 +2,6 @@
 # pylint: disable=attribute-defined-outside-init, invalid-name, avoid-list-comprehension
 
 from xmlrpc.client import Fault as XmlRPCFault
-from xmlrpc.client import ProtocolError
 
 from django.test import override_settings
 
@@ -106,7 +105,9 @@ class TestVersionCreatePermissions(APIPermissionsTestCase):
         self.assertEqual(version.product_id, self.product.pk)
 
     def verify_api_without_permission(self):
-        with self.assertRaisesRegex(ProtocolError, "403 Forbidden"):
+        with self.assertRaisesRegex(
+            XmlRPCFault, 'Authentication failed when calling "Version.create"'
+        ):
             self.rpc_client.Version.create(
                 {"product": self.product.pk, "value": "Version without Permissions"}
             )

--- a/tcms/tests/test_handlers.py
+++ b/tcms/tests/test_handlers.py
@@ -11,9 +11,10 @@ from tcms.handlers import KiwiTCMSJsonRpcHandler, KiwiTCMSXmlRpcHandler
 class TestKiwiTCMSJsonRpcHandler(TestCase):
     @classmethod
     def setUpClass(cls):
-        base_result = JsonSuccessResult(None)
-        base_result.set_jsonrpc_data(request_id=1, version="2.0", is_notification=False)
-        cls.base_result = base_result
+        cls.base_result = JsonSuccessResult(None)
+        cls.base_result.set_jsonrpc_data(
+            request_id=1, version="2.0", is_notification=False
+        )
         cls.rpc_handler = KiwiTCMSJsonRpcHandler(entry_point="/json-rpc/")
 
     def test_html_escape(self):

--- a/tcms/tests/test_handlers.py
+++ b/tcms/tests/test_handlers.py
@@ -1,9 +1,9 @@
 import html
 from datetime import timedelta
 from unittest import TestCase
-from unittest.mock import patch
 
-from django.test import RequestFactory
+from modernrpc.handlers.jsonhandler import JsonSuccessResult
+from modernrpc.handlers.xmlhandler import XmlSuccessResult
 
 from tcms.handlers import KiwiTCMSJsonRpcHandler, KiwiTCMSXmlRpcHandler
 
@@ -11,99 +11,103 @@ from tcms.handlers import KiwiTCMSJsonRpcHandler, KiwiTCMSXmlRpcHandler
 class TestKiwiTCMSJsonRpcHandler(TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.base_exec_procedure = "modernrpc.handlers.JSONRPCHandler.execute_procedure"
-        cls.rpc_handler = KiwiTCMSJsonRpcHandler(
-            RequestFactory(), entry_point="/json-rpc/"
-        )
+        base_result = JsonSuccessResult(None)
+        base_result.set_jsonrpc_data(request_id=1, version="2.0", is_notification=False)
+        cls.base_result = base_result
+        cls.rpc_handler = KiwiTCMSJsonRpcHandler(entry_point="/json-rpc/")
 
     def test_html_escape(self):
         payload = "<html></html>"
-        with patch(self.base_exec_procedure, return_value=payload):
-            self.assertEqual(
-                self.rpc_handler.execute_procedure("method_name"), html.escape(payload)
-            )
+        self.base_result.data = payload
+        self.assertEqual(
+            self.rpc_handler.dumps_result(self.base_result),
+            '{"id": 1, "jsonrpc": "2.0", "result": "%s"}' % html.escape(payload),
+        )
 
     def test_timedelta_to_seconds(self):
-        with patch(self.base_exec_procedure, return_value=timedelta(hours=1)):
-            self.assertEqual(self.rpc_handler.execute_procedure("method_name"), 3600.0)
+        self.base_result.data = timedelta(hours=1)
+        self.assertEqual(
+            self.rpc_handler.dumps_result(self.base_result),
+            '{"id": 1, "jsonrpc": "2.0", "result": 3600.0}',
+        )
 
     def test_dict_escape(self):
-        with patch(self.base_exec_procedure, return_value={"html": "<html></html>"}):
-            self.assertDictEqual(
-                self.rpc_handler.execute_procedure("method_name"),
-                {"html": html.escape("<html></html>")},
-            )
+        self.base_result.data = {"html": "<html></html>"}
+        self.assertEqual(
+            self.rpc_handler.dumps_result(self.base_result),
+            '{"id": 1, "jsonrpc": "2.0", "result": {"html": "%s"}}'
+            % html.escape("<html></html>"),
+        )
 
     def test_dict_with_timedelta(self):
-        with patch(
-            self.base_exec_procedure, return_value={"duration": timedelta(hours=1)}
-        ):
-            self.assertDictEqual(
-                self.rpc_handler.execute_procedure("method_name"),
-                {"duration": 3600.0},
-            )
+        self.base_result.data = {"duration": timedelta(hours=1)}
+        self.assertEqual(
+            self.rpc_handler.dumps_result(self.base_result),
+            '{"id": 1, "jsonrpc": "2.0", "result": {"duration": 3600.0}}',
+        )
 
     def test_list_escape(self):
-        with patch(self.base_exec_procedure, return_value=["<html></html>"]):
-            self.assertListEqual(
-                self.rpc_handler.execute_procedure("method_name"),
-                [html.escape("<html></html>")],
-            )
-
-        with patch(self.base_exec_procedure, return_value=[{"html": "<html></html>"}]):
-            self.assertListEqual(
-                self.rpc_handler.execute_procedure("method_name"),
-                [{"html": html.escape("<html></html>")}],
-            )
+        self.base_result.data = ["<html></html>"]
+        self.assertEqual(
+            self.rpc_handler.dumps_result(self.base_result),
+            '{"id": 1, "jsonrpc": "2.0", "result": ["%s"]}'
+            % html.escape("<html></html>"),
+        )
+        self.base_result.data = [{"html": "<html></html>"}]
+        self.assertEqual(
+            self.rpc_handler.dumps_result(self.base_result),
+            '{"id": 1, "jsonrpc": "2.0", "result": [{"html": "%s"}]}'
+            % html.escape("<html></html>"),
+        )
 
     def test_list_with_timedelta(self):
-        with patch(self.base_exec_procedure, return_value=[timedelta(hours=1)]):
-            self.assertListEqual(
-                self.rpc_handler.execute_procedure("method_name"),
-                [3600.0],
-            )
+        self.base_result.data = [timedelta(hours=1)]
+        self.assertEqual(
+            self.rpc_handler.dumps_result(self.base_result),
+            '{"id": 1, "jsonrpc": "2.0", "result": [3600.0]}',
+        )
 
-        with patch(
-            self.base_exec_procedure, return_value=[{"duration": timedelta(hours=1)}]
-        ):
-            self.assertListEqual(
-                self.rpc_handler.execute_procedure("method_name"),
-                [{"duration": 3600.0}],
-            )
+        self.base_result.data = [{"duration": timedelta(hours=1)}]
+        self.assertEqual(
+            self.rpc_handler.dumps_result(self.base_result),
+            '{"id": 1, "jsonrpc": "2.0", "result": [{"duration": 3600.0}]}',
+        )
 
 
 class TestKiwiTCMSXmlRpcHandler(TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.base_exec_procedure = "modernrpc.handlers.XMLRPCHandler.execute_procedure"
-        cls.rpc_handler = KiwiTCMSXmlRpcHandler(
-            RequestFactory(), entry_point="/xml-rpc/"
-        )
+        cls.rpc_handler = KiwiTCMSXmlRpcHandler(entry_point="/xml-rpc/")
 
     def test_timedelta_to_seconds(self):
-        with patch(self.base_exec_procedure, return_value=timedelta(hours=1)):
-            self.assertEqual(self.rpc_handler.execute_procedure("method_name"), 3600.0)
+        result = XmlSuccessResult(data=timedelta(hours=1))
+        self.assertIn(
+            "<param>\n<value><double>3600.0</double></value>\n</param>",
+            self.rpc_handler.dumps_result(result),
+        )
 
     def test_dict_with_timedelta(self):
-        with patch(
-            self.base_exec_procedure, return_value={"duration": timedelta(hours=1)}
-        ):
-            self.assertDictEqual(
-                self.rpc_handler.execute_procedure("method_name"),
-                {"duration": 3600.0},
-            )
+        result = XmlSuccessResult(data={"duration": timedelta(hours=1)})
+        self.assertIn(
+            "<param>\n<value><struct>\n<member>\n<name>duration</name>\n"
+            "<value><double>3600.0</double></value>\n"
+            "</member>\n</struct></value>\n</param>",
+            self.rpc_handler.dumps_result(result),
+        )
 
     def test_list_with_timedelta(self):
-        with patch(self.base_exec_procedure, return_value=[timedelta(hours=1)]):
-            self.assertListEqual(
-                self.rpc_handler.execute_procedure("method_name"),
-                [3600.0],
-            )
+        result = XmlSuccessResult(data=[timedelta(hours=1)])
+        self.assertIn(
+            "<params>\n<param>\n<value><array><data>\n"
+            "<value><double>3600.0</double></value>\n"
+            "</data></array></value>\n</param>",
+            self.rpc_handler.dumps_result(result),
+        )
 
-        with patch(
-            self.base_exec_procedure, return_value=[{"duration": timedelta(hours=1)}]
-        ):
-            self.assertListEqual(
-                self.rpc_handler.execute_procedure("method_name"),
-                [{"duration": 3600.0}],
-            )
+        result = XmlSuccessResult(data=[{"duration": timedelta(hours=1)}])
+        self.assertIn(
+            "<param>\n<value><array><data>\n<value><struct>\n<member>\n<name>duration</name>\n"
+            "<value><double>3600.0</double></value>\n</member>\n</struct></value>\n"
+            "</data></array></value>\n</param>",
+            self.rpc_handler.dumps_result(result),
+        )

--- a/tcms/urls.py
+++ b/tcms/urls.py
@@ -12,7 +12,7 @@ from django.urls import re_path
 from django.views.generic import TemplateView
 from django.views.i18n import JavaScriptCatalog
 from grappelli import urls as grappelli_urls
-from modernrpc.core import JSONRPC_PROTOCOL, XMLRPC_PROTOCOL
+from modernrpc.core import Protocol
 from modernrpc.views import RPCEntryPoint
 
 from tcms.core import views as core_views
@@ -25,8 +25,8 @@ from tcms.testruns import urls as testruns_urls
 urlpatterns = [
     re_path(r"^$", core_views.DashboardView.as_view(), name="core-views-index"),
     re_path(r"^captcha/", include(captcha_urls)),
-    re_path(r"^xml-rpc/", RPCEntryPoint.as_view(protocol=XMLRPC_PROTOCOL)),
-    re_path(r"^json-rpc/$", RPCEntryPoint.as_view(protocol=JSONRPC_PROTOCOL)),
+    re_path(r"^xml-rpc/", RPCEntryPoint.as_view(protocol=Protocol.XML_RPC)),
+    re_path(r"^json-rpc/$", RPCEntryPoint.as_view(protocol=Protocol.JSON_RPC)),
     re_path(r"^init-db/$", core_views.InitDBView.as_view(), name="init-db"),
     re_path(
         r"^translation-mode/",


### PR DESCRIPTION
The goal is to test the current alpha with Kiwi and confirm the future 1.0.0 release won't introduce any regression