### PR TITLE
Add Kiwi TCMS reporter to 1-click bug reports. Closes #2591

### DIFF
--- a/tcms/issuetracker/azure_boards.py
+++ b/tcms/issuetracker/azure_boards.py
@@ -114,7 +114,7 @@ class AzureBoards(IssueTrackerType):
                 "op": "replace",
                 "path": "/fields/System.Description",
                 "from": "null",
-                "value": markdown2html(self._report_comment(execution)),
+                "value": markdown2html(self._report_comment(execution, user)),
             }
         ]
 

--- a/tcms/issuetracker/base.py
+++ b/tcms/issuetracker/base.py
@@ -110,13 +110,20 @@ class IssueTrackerType:
 
         return result
 
-    def _report_comment(self, execution):  # pylint: disable=no-self-use
+    def _report_comment(self, execution, user=None):  # pylint: disable=no-self-use
         """
         Returns the comment which is used in the original defect report.
         """
         txt = execution.case.get_text_with_version(execution.case_text_version)
 
+        reporter = "Unknown"
+        if user:
+            reporter = user.get_full_name() or user.username
+
         comment = f"""Filed from execution {execution.get_full_url()}
+
+**Reporter:**
+{reporter}
 
 **Product:**
 {execution.run.plan.product.name}

--- a/tcms/issuetracker/bitbucket.py
+++ b/tcms/issuetracker/bitbucket.py
@@ -128,7 +128,9 @@ class BitBucket(IssueTrackerType):
             "title": f"Failed test: {execution.case.summary}",
             "kind": "bug",
             "priority": "major",
-            "content": {"raw": self._report_comment(execution).replace("\n", "\r\n")},
+            "content": {
+                "raw": self._report_comment(execution, user).replace("\n", "\r\n")
+            },
         }
 
         try:

--- a/tcms/issuetracker/bugzilla_integration.py
+++ b/tcms/issuetracker/bugzilla_integration.py
@@ -95,7 +95,7 @@ class Bugzilla(base.IssueTrackerType):
             "component": self.get_case_components(execution.case),
             "version": execution.run.plan.product_version.value,
             "short_desc": f"Test case failure: {execution.case.summary}",
-            "comment": self._report_comment(execution),
+            "comment": self._report_comment(execution, user),
         }
 
         try:

--- a/tcms/issuetracker/kiwitcms.py
+++ b/tcms/issuetracker/kiwitcms.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2021 Alexander Todorov <atodorov@MrSenko.com>
+# Copyright (c) 2019-2022 Alexander Todorov <atodorov@MrSenko.com>
 
 # Licensed under the GPL 2.0: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 
@@ -84,7 +84,7 @@ class KiwiTCMS(IssueTrackerType):
             "product": execution.run.plan.product,
             "version": execution.run.plan.product_version,
             "build": execution.build,
-            "text": self._report_comment(execution),
+            "text": self._report_comment(execution, user),
             "_execution": execution,
         }
 

--- a/tcms/issuetracker/tests/test_azureboards.py
+++ b/tcms/issuetracker/tests/test_azureboards.py
@@ -121,6 +121,7 @@ class TestAzureIntegration(APITestCase):
         )
         for expected_string in [
             f"Filed from execution {self.execution_1.get_full_url()}",
+            "Reporter",
             self.execution_1.run.plan.product.name,
             self.component.name,
             "Steps to reproduce",

--- a/tcms/issuetracker/tests/test_bitbucket.py
+++ b/tcms/issuetracker/tests/test_bitbucket.py
@@ -110,6 +110,7 @@ class TestBitBucketIntegration(APITestCase):
         )
         for expected_string in [
             f"Filed from execution {self.execution_1.get_full_url()}",
+            "Reporter",
             self.execution_1.run.plan.product.name,
             self.component.name,
             "Steps to reproduce",

--- a/tcms/issuetracker/tests/test_bugzilla.py
+++ b/tcms/issuetracker/tests/test_bugzilla.py
@@ -170,6 +170,7 @@ class TestBugzillaIntegration(APITestCase):
         last_comment = bug.getcomments()[-1]
         for expected_string in [
             f"Filed from execution {execution2.get_full_url()}",
+            "Reporter",
             product.name,
             component.name,
             test_case.text,

--- a/tcms/issuetracker/tests/test_github.py
+++ b/tcms/issuetracker/tests/test_github.py
@@ -150,6 +150,7 @@ class TestGitHubIntegration(APITestCase):
         self.assertEqual(f"Failed test: {self.execution_1.case.summary}", issue.title)
         for expected_string in [
             f"Filed from execution {self.execution_1.get_full_url()}",
+            "Reporter",
             self.execution_1.run.plan.product.name,
             self.component.name,
             "Steps to reproduce",

--- a/tcms/issuetracker/tests/test_gitlab_com.py
+++ b/tcms/issuetracker/tests/test_gitlab_com.py
@@ -135,6 +135,7 @@ class TestGitlabIntegration(APITestCase):
         self.assertEqual(f"Failed test: {self.execution_1.case.summary}", issue.title)
         for expected_string in [
             f"Filed from execution {self.execution_1.get_full_url()}",
+            "Reporter",
             self.execution_1.run.plan.product.name,
             self.component.name,
             "Steps to reproduce",

--- a/tcms/issuetracker/tests/test_gitlab_ee.py
+++ b/tcms/issuetracker/tests/test_gitlab_ee.py
@@ -174,6 +174,7 @@ class TestGitlabIntegration(APITestCase):
         self.assertEqual(f"Failed test: {self.execution_1.case.summary}", issue.title)
         for expected_string in [
             f"Filed from execution {self.execution_1.get_full_url()}",
+            "Reporter",
             self.execution_1.run.plan.product.name,
             self.component.name,
             "Steps to reproduce",

--- a/tcms/issuetracker/tests/test_jira.py
+++ b/tcms/issuetracker/tests/test_jira.py
@@ -128,6 +128,7 @@ class TestJIRAIntegration(APITestCase):
         )
         for expected_string in [
             f"Filed from execution {self.execution_1.get_full_url()}",
+            "Reporter",
             self.execution_1.run.plan.product.name,
             self.component.name,
             "Steps to reproduce",

--- a/tcms/issuetracker/tests/test_kiwitcms.py
+++ b/tcms/issuetracker/tests/test_kiwitcms.py
@@ -105,6 +105,7 @@ class TestKiwiTCMSIntegration(APITestCase):
         first_comment = get_comments(bug).first()
         for expected_string in [
             f"Filed from execution {self.execution_1.get_full_url()}",
+            "Reporter",
             self.execution_1.run.plan.product.name,
             self.component.name,
             "Steps to reproduce",

--- a/tcms/issuetracker/tests/test_redmine.py
+++ b/tcms/issuetracker/tests/test_redmine.py
@@ -117,6 +117,7 @@ class TestRedmineIntegration(APITestCase):
         self.assertEqual(f"Failed test: {self.execution_1.case.summary}", issue.subject)
         for expected_string in [
             f"Filed from execution {self.execution_1.get_full_url()}",
+            "Reporter",
             self.execution_1.run.plan.product.name,
             self.component.name,
             "Steps to reproduce",

--- a/tcms/issuetracker/types.py
+++ b/tcms/issuetracker/types.py
@@ -114,7 +114,7 @@ class JIRA(IssueTrackerType):
                 project=project.id,
                 issuetype={"name": issue_type.name},
                 summary=f"Failed test: {execution.case.summary}",
-                description=self._report_comment(execution),
+                description=self._report_comment(execution, user),
             )
             new_url = self.bug_system.base_url + "/browse/" + new_issue.key
 
@@ -133,7 +133,7 @@ class JIRA(IssueTrackerType):
             "pid": project.id,
             "issuetype": issue_type.id,
             "summary": f"Failed test: {execution.case.summary}",
-            "description": self._report_comment(execution),
+            "description": self._report_comment(execution, user),
         }
 
         url = self.bug_system.base_url
@@ -171,7 +171,7 @@ class GitHub(IssueTrackerType):
         """
         args = {
             "title": f"Failed test: {execution.case.summary}",
-            "body": self._report_comment(execution),
+            "body": self._report_comment(execution, user),
         }
 
         try:
@@ -243,7 +243,7 @@ class Gitlab(IssueTrackerType):
         new_issue = project.issues.create(
             {
                 "title": f"Failed test: {execution.case.summary}",
-                "description": self._report_comment(execution),
+                "description": self._report_comment(execution, user),
             }
         )
 
@@ -351,7 +351,7 @@ class Redmine(IssueTrackerType):
 
         new_issue = self.rpc.issue.create(
             subject=f"Failed test: {execution.case.summary}",
-            description=self._report_comment(execution),
+            description=self._report_comment(execution, user),
             project_id=project.id,
             tracker_id=tracker.id,
             status_id=status.id,


### PR DESCRIPTION
this is a quick solution for the situations where an integration account
is used and all bugs get assigned to it.