### PR TITLE
Updates around IssueTrackerType.report_issue_from_testexecution()

### DIFF
--- a/tcms/issuetracker/azure_boards.py
+++ b/tcms/issuetracker/azure_boards.py
@@ -95,7 +95,7 @@ class AzureBoards(IssueTrackerType):
     def is_adding_testcase_to_issue_disabled(self):
         return not (self.bug_system.base_url and self.bug_system.api_password)
 
-    def report_issue_from_testexecution(self, execution, user):
+    def _report_issue(self, execution, user):
         """
         AzureBoards creates the Work Item with Title
         """
@@ -132,7 +132,7 @@ class AzureBoards(IssueTrackerType):
                 is_defect=True,
             )
 
-            return issue_url
+            return (issue, issue_url)
         except Exception:  # pylint: disable=broad-except
             # something above didn't work so return a link for manually
             # entering issue details with info pre-filled
@@ -140,7 +140,7 @@ class AzureBoards(IssueTrackerType):
             if not url.endswith("/"):
                 url += "/"
 
-            return url + "_workitems/create/Issue"
+            return (None, url + "_workitems/create/Issue")
 
     def details(self, url):
         """

--- a/tcms/issuetracker/base.py
+++ b/tcms/issuetracker/base.py
@@ -144,6 +144,17 @@ class IssueTrackerType:
 """
         return comment
 
+    def _report_issue(self, execution, user):
+        """
+        Used internally to perform the actual report! If you want to override behavior
+        this is the appropriate method!
+
+        :return: (object, str) - returns the newly created issue represented as
+                 an object that is understood by the internal RPC integration code
+                 and the URL to the newly created issue.
+        """
+        raise NotImplementedError()
+
     def report_issue_from_testexecution(self, execution, user):
         """
         When marking TestExecution results inside a Test Run there is a
@@ -158,7 +169,8 @@ class IssueTrackerType:
         :user: User object
         :return: - string - URL
         """
-        raise NotImplementedError()
+        (new_issue, url) = self._report_issue(execution, user)
+        return url
 
     def add_testexecution_to_issue(self, executions, issue_url):
         """

--- a/tcms/issuetracker/bitbucket.py
+++ b/tcms/issuetracker/bitbucket.py
@@ -119,7 +119,7 @@ class BitBucket(IssueTrackerType):
             and self.bug_system.api_password
         )
 
-    def report_issue_from_testexecution(self, execution, user):
+    def _report_issue(self, execution, user):
         """
         BitBucket creates the Issue with Title and Description
         """
@@ -144,7 +144,7 @@ class BitBucket(IssueTrackerType):
                 is_defect=True,
             )
 
-            return issue_url
+            return (issue, issue_url)
         except Exception:  # pylint: disable=broad-except
             # something above didn't work so return a link for manually
             # entering issue details with info pre-filled
@@ -152,7 +152,7 @@ class BitBucket(IssueTrackerType):
             if not url.endswith("/"):
                 url += "/"
 
-            return url + "issues/new"
+            return (None, url + "issues/new")
 
     def details(self, url):
         """

--- a/tcms/issuetracker/kiwitcms.py
+++ b/tcms/issuetracker/kiwitcms.py
@@ -73,7 +73,7 @@ class KiwiTCMS(IssueTrackerType):
         for execution in executions:
             bug.executions.add(execution)
 
-    def report_issue_from_testexecution(self, execution, user):
+    def _report_issue(self, execution, user):
         """
         Create the new bug using internal API instead of
         going through the RPC layer and return its URL
@@ -100,7 +100,7 @@ class KiwiTCMS(IssueTrackerType):
             is_defect=True,
         )
 
-        return bug.get_full_url()
+        return (bug, bug.get_full_url())
 
     @classmethod
     def bug_id_from_url(cls, url):

--- a/tcms/issuetracker/tests/redmine_post_processing.py
+++ b/tcms/issuetracker/tests/redmine_post_processing.py
@@ -1,0 +1,22 @@
+# pylint: disable=unused-argument, objects-update-used
+
+
+def change_assignee(rpc, new_issue, execution, user):
+    """
+    Note: user is the Kiwi TCMS user currently logged in,
+          who is reporting the issue.
+          Redmine integration is done via the "admin" account.
+
+    We'll reasign to "atodorov" account in Redmine. In practice you will
+    probably want to match user.username with your Redmine DB.
+
+    :raises RuntimeError: when user not found in Redmine.
+    """
+    try:
+        atodorov = rpc.user.filter(name="atodorov")[0]
+    except Exception as err:
+        raise RuntimeError("User 'atodorov' not found in Redmine") from err
+
+    # Note: assignee needs to be a member of the project where issues are created
+    # and needs to have a role with the `assignable` flag set to 1.
+    rpc.issue.update(new_issue.id, assigned_to_id=atodorov.id)

--- a/tcms/settings/common.py
+++ b/tcms/settings/common.py
@@ -158,6 +158,13 @@ MIDDLEWARE = [
 # and tcms/issuetracker/azure_boards.py
 AZURE_BOARDS_API_VERSION = os.environ.get("AZURE_BOARDS_API_VERSION", "6.0")
 
+# A list of fully qualified dotted paths to functions which will be executed after
+# a new issue has been automatically opened in an external bug tracker via the
+# 1-click bug report integration!
+# See tcms.issuetracker.base.IssueTrackerType.post_process_new_issue() and
+# tcms.issuetracker.tests.redmine_post_processing for hints!
+EXTERNAL_ISSUE_POST_PROCESSORS = []
+
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # ~~ DANGER: Don't change the settings below!

--- a/tests/redmine/initialize-data.py
+++ b/tests/redmine/initialize-data.py
@@ -11,6 +11,14 @@ rpc = redminelib.Redmine(
 )
 
 
+atodorov = rpc.user.create(
+    login="atodorov",
+    password="very-big-secret",
+    firstname="Alex",
+    lastname="Todorov",
+    mail="atodorov@example.org",
+)
+
 # tracker & issue statuses must be configured before hand b/c
 # Redmine API doesn't support creating them!
 tracker = rpc.tracker.all()[0]
@@ -25,6 +33,18 @@ project = rpc.project.create(
     name="Integration with Kiwi TCMS",
     identifier="kiwitcms",
     tracker_ids=[tracker.id],
+)
+
+# b/c rpc.role doesn't have a .filter() method
+for tester_role in rpc.role.all():
+    if tester_role.name == "Tester":
+        break
+
+# make atodorov a member of the project so that we can assign issues to him
+membership = rpc.project_membership.create(
+    project_id=project.id,
+    user_id=atodorov.id,
+    role_ids=[tester_role.id],
 )
 
 # http://bugtracker.kiwitcms.org:3000/issues/1

--- a/tests/redmine/seeds.rb
+++ b/tests/redmine/seeds.rb
@@ -3,6 +3,10 @@ User.where(login: "admin", last_login_on: nil, must_change_passwd: true).update_
 IssueStatus.create :name => "OPEN", :is_closed => false
 IssueStatus.create :name => "CLOSED", :is_closed => true
 
+tester_role = Role.create :name => "Tester", :assignable => 1
+tester_role.add_permission!(:view_issues)
+tester_role.add_permission!(:add_issues)
+
 Tracker.create :name => "Bugs", :default_status_id => 1
 
 Enumeration.create :type => "IssuePriority", :name => "P1", :active => true, :is_default => true


### PR DESCRIPTION
- Rename to _report_issue() which returns tuple of (object, str)
- In case new issue was not created automatically and the method falls
  back to manual creation the return value will be (None, str)

- report_issue_from_testexecution() will call _report_issue()
  internally and handle the change in return type

NOTES:

- This change is backwards compatible!
- For customized issue tracker integration you will have to apply
  the same changes to your custmized code if you wish new functionality,
  like post-processing of new issues to work.