### PR TITLE
Adjust field name when rendering test execution on TestRun page. Fixe…

### DIFF
--- a/tcms/testruns/static/testruns/js/get.js
+++ b/tcms/testruns/static/testruns/js/get.js
@@ -402,7 +402,7 @@ function bindEvents (selector) {
 function getExpandArea (testExecution) {
   const container = $(`.test-execution-${testExecution.id}`)
 
-  container.find('.test-execution-information .run-date').html(testExecution.close_date || '-')
+  container.find('.test-execution-information .run-date').html(testExecution.stop_date || '-')
   container.find('.test-execution-information .build').html(testExecution.build__name)
   container.find('.test-execution-information .text-version').html(testExecution.case_text_version)
 


### PR DESCRIPTION
…s #2794

Refs #1924, `close_date` renamed to `stop_date` in 22c6ff7