### PR TITLE
Don't send duplicate emails when editting bugs. Fixes #2782

### DIFF
--- a/tcms/core/helpers/comments.py
+++ b/tcms/core/helpers/comments.py
@@ -51,7 +51,12 @@ def add_comment(objs, comments, user, submit_date=None):
             user_name=user.username,
         )
         created.append(comment)
-        post_save.send(created=False, instance=obj, sender=obj.__class__)
+        post_save.send(
+            created=False,
+            instance=obj,
+            sender=obj.__class__,
+            called_from_add_comment=True,
+        )
 
     return created
 

--- a/tcms/signals.py
+++ b/tcms/signals.py
@@ -207,6 +207,9 @@ def handle_comments_pre_delete(sender, **kwargs):
 
 
 def handle_emails_post_bug_save(sender, instance, created=False, **kwargs):
+    if not kwargs.get("called_from_add_comment"):
+        return
+
     from tcms.core.helpers.comments import get_comments
     from tcms.core.utils.mailto import mailto
 


### PR DESCRIPTION
the root cause here is that the post-save signal is called multiple
times from various triggers. The trigger which we're interested in is
when post-save signal is triggered by the add_comment() function b/c
that's where the important information about bugs is stored.