### PR TITLE
Revert "Bump django from 4.0.7 to 4.1"

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -3,7 +3,7 @@
 allpairspy==2.5.0
 bleach==5.0.1
 bleach-allowlist==1.0.3
-Django==4.1
+Django==4.0.7
 django-attachments==1.9.1
 django-colorfield==0.7.2
 django-contrib-comments==2.2.0


### PR DESCRIPTION
This reverts commit 7a5c4a6c579802ee888eda246b3ed6388fdac8fe.

because it causes failures for kiwitcms-tenants when testing:

Debugging in here https://github.com/kiwitcms/tenants/pull/181
Upstream issue -> https://github.com/django-tenants/django-tenants/issues/802