### PR TITLE
WIP: Quick POC for #2823

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -12,6 +12,7 @@ django-grappelli==3.0.3
 django-guardian==2.4.0
 django-modern-rpc==0.12.1
 django-simple-history==3.0.0
+django-tabular-permissions==2.9.1
 django-tree-queries==0.11.0
 django-uuslug==2.0.0
 jira==3.4.1

--- a/tcms/bugs/apps.py
+++ b/tcms/bugs/apps.py
@@ -4,7 +4,10 @@ from django.db.models.signals import post_migrate, post_save, pre_delete
 
 
 class AppConfig(DjangoAppConfig):
+    " a doc-string on the AppConfig class"
+
     name = "tcms.bugs"
+    admin_docs = "a custom defined attribute"
 
     def ready(self):
         from tcms import signals

--- a/tcms/bugs/apps.py
+++ b/tcms/bugs/apps.py
@@ -4,7 +4,7 @@ from django.db.models.signals import post_migrate, post_save, pre_delete
 
 
 class AppConfig(DjangoAppConfig):
-    " a doc-string on the AppConfig class"
+    "a doc-string on the AppConfig class"
 
     name = "tcms.bugs"
     admin_docs = "a custom defined attribute"

--- a/tcms/bugs/models.py
+++ b/tcms/bugs/models.py
@@ -22,7 +22,7 @@ class Severity(models.Model):
         return self.name
 
     class Meta:
-        " docstring on meta class"
+        "docstring on meta class"
         verbose_name_plural = _("Severity")
         _custom_defined = ""
 

--- a/tcms/bugs/models.py
+++ b/tcms/bugs/models.py
@@ -12,6 +12,7 @@ from tcms.core.models.base import UrlMixin
 
 
 class Severity(models.Model):
+    "doc-string on model class"
     name = models.CharField(max_length=64, unique=True)
     weight = models.IntegerField(default=0)
     icon = models.CharField(max_length=64)
@@ -21,7 +22,9 @@ class Severity(models.Model):
         return self.name
 
     class Meta:
+        " docstring on meta class"
         verbose_name_plural = _("Severity")
+        _custom_defined = ""
 
 
 class Bug(models.Model, UrlMixin):

--- a/tcms/kiwi_auth/admin.py
+++ b/tcms/kiwi_auth/admin.py
@@ -13,7 +13,10 @@ from django.urls import reverse
 from django.utils.text import capfirst
 from django.utils.translation import gettext_lazy as _
 
-from tabular_permissions.admin import UserTabularPermissionsMixin, GroupTabularPermissionsMixin
+from tabular_permissions.admin import (
+    UserTabularPermissionsMixin,
+    GroupTabularPermissionsMixin,
+)
 
 from tcms.utils.user import delete_user
 

--- a/tcms/kiwi_auth/admin.py
+++ b/tcms/kiwi_auth/admin.py
@@ -13,6 +13,8 @@ from django.urls import reverse
 from django.utils.text import capfirst
 from django.utils.translation import gettext_lazy as _
 
+from tabular_permissions.admin import UserTabularPermissionsMixin, GroupTabularPermissionsMixin
+
 from tcms.utils.user import delete_user
 
 User = get_user_model()  # pylint: disable=invalid-name
@@ -66,7 +68,7 @@ class GroupAdminForm(forms.ModelForm):
         return instance
 
 
-class KiwiUserAdmin(UserAdmin):
+class KiwiUserAdmin(UserTabularPermissionsMixin, UserAdmin):
     list_display = UserAdmin.list_display + (
         "is_active",
         "is_superuser",
@@ -216,7 +218,7 @@ class KiwiUserAdmin(UserAdmin):
         delete_user(obj)
 
 
-class KiwiGroupAdmin(GroupAdmin):
+class KiwiGroupAdmin(GroupTabularPermissionsMixin, GroupAdmin):
     form = GroupAdminForm
 
     def has_delete_permission(self, request, obj=None):

--- a/tcms/settings/common.py
+++ b/tcms/settings/common.py
@@ -304,6 +304,7 @@ INSTALLED_APPS = TENANT_APPS + [
     "captcha",
     "colorfield",
     "django_extensions",
+    "tabular_permissions",
     "tree_queries",
     "vinaigrette",
     "tcms.core",


### PR DESCRIPTION
Upstream todo:

- [ ] Enable testing with GitHub Actions in django-tabular-permissions
- [ ] Add tests for their Demo app, make sure that it works with latest Django
- [ ] Fix anything that needs fixing

Then:

- Extend django-tabular-permissions to display additional text from apps/models. For AppConfig we can use doc-string or custom attribute. For models we can only use doc-string b/c it seems custom attributes on the Meta class aren't suported! Nor is a Meta doc-string!

Then:

- Update to the appropriate django-tabular-permissions version and
- Document each app & model

Also TODO:
- Some models aren't needed, filter them out of the query set
- Do the same for TenantGroup model