### PR TITLE
Don't specify custom redhat-catalog container registry

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,5 @@
 version: 2
 
-registries:
-  redhat-catalog:
-    type: docker-registry
-    url: https://registry.access.redhat.com
-
 updates:
   - package-ecosystem: pip
     directory: "/"
@@ -29,8 +24,6 @@ updates:
 
   - package-ecosystem: "docker"
     directory: "/"
-    registries:
-      - redhat-catalog
     schedule:
       interval: "weekly"
       time: "04:00"


### PR DESCRIPTION
this is a public registry but Dependabot insists on us specifying username & password fields which we don't have and don't need.

Also with the switch to RHEL 9 UBI we're once again using the latest version of the base image.