### PR TITLE
ci: Send results to Codecov.io only if we have a token defined

### DIFF
--- a/.github/workflows/integration_bugtracker.yml
+++ b/.github/workflows/integration_bugtracker.yml
@@ -58,7 +58,11 @@ jobs:
         coverage run --source='.' ./manage.py test -v2 --noinput --settings=tcms.settings.test tcms.issuetracker.tests.test_${{ matrix.tracker }}
 
     - name: Send coverage to codecov.io
+      if: env.HAS_TOKEN
       uses: codecov/codecov-action@v3
+      env:
+        HAS_TOKEN: ${{ secrets.HAS_TOKEN }}
       with:
+        token: ${{ secrets.CODECOV_TOKEN }}
         fail_ci_if_error: true
         verbose: true

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -60,8 +60,12 @@ jobs:
           coverage report -m
 
       - name: Send coverage to codecov.io
+        if: env.HAS_TOKEN
         uses: codecov/codecov-action@v3
+        env:
+          HAS_TOKEN: ${{ secrets.HAS_TOKEN }}
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
           verbose: true
 
@@ -95,8 +99,12 @@ jobs:
         coverage report -m
 
     - name: Send coverage to codecov.io
+      if: env.HAS_TOKEN
       uses: codecov/codecov-action@v3
+      env:
+        HAS_TOKEN: ${{ secrets.HAS_TOKEN }}
       with:
+        token: ${{ secrets.CODECOV_TOKEN }}
         fail_ci_if_error: true
         verbose: true
 
@@ -131,8 +139,12 @@ jobs:
           coverage report -m
 
       - name: Send coverage to codecov.io
+        if: env.HAS_TOKEN
         uses: codecov/codecov-action@v3
+        env:
+          HAS_TOKEN: ${{ secrets.HAS_TOKEN }}
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
           verbose: true
 
@@ -174,8 +186,12 @@ jobs:
           coverage report -m
 
       - name: Send coverage to codecov.io
+        if: env.HAS_TOKEN
         uses: codecov/codecov-action@v3
+        env:
+          HAS_TOKEN: ${{ secrets.HAS_TOKEN }}
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
           verbose: true
 
@@ -215,8 +231,12 @@ jobs:
           coverage report -m
 
       - name: Send coverage to codecov.io
+        if: env.HAS_TOKEN
         uses: codecov/codecov-action@v3
+        env:
+          HAS_TOKEN: ${{ secrets.HAS_TOKEN }}
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
           verbose: true
 


### PR DESCRIPTION
should get rid of constant failures of their action when using GITHUB_TOKEN

There was an error running the uploader:
    Error uploading to https://codecov.io:
    Error: There was an error fetching the storage URL during POST:
    404 - {'detail': ErrorDetail(
              string='Unable to locate build via Github Actions API.
                      Please upload with the Codecov repository upload token to resolve issue.',
              code='not_found')}