### PR TITLE
ci: No python3-pydot-ng in Ubuntu 22.04.01

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -20,7 +20,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: check-docs-source-in-git
       run: |
-        sudo apt install python3-pydot python3-pydot-ng graphviz
+        sudo apt install python3-pydot graphviz
         pip install -r requirements/readthedocs.txt
         make check-docs-source-in-git
 


### PR DESCRIPTION
vs Ubuntu 20.04.5 LTS in older jobs