### PR TITLE
Enable password validators to avoid users chosing weak passwords

### DIFF
--- a/tcms/kiwi_auth/tests/__init__.py
+++ b/tcms/kiwi_auth/tests/__init__.py
@@ -1,0 +1,1 @@
+__FOR_TESTING__ = "5a5b6e17f9c34025a75b052fc06c50ab"

--- a/tcms/kiwi_auth/tests/test_admin.py
+++ b/tcms/kiwi_auth/tests/test_admin.py
@@ -11,6 +11,8 @@ from tcms.kiwi_auth.admin import Group
 from tcms.tests import LoggedInTestCase, user_should_have_perm
 from tcms.tests.factories import GroupFactory, UserFactory
 
+from . import __FOR_TESTING__
+
 
 class TestUserAdmin(LoggedInTestCase):  # pylint: disable=too-many-public-methods
     @classmethod
@@ -65,8 +67,8 @@ class TestUserAdmin(LoggedInTestCase):  # pylint: disable=too-many-public-method
             "/admin/auth/user/add/",
             {
                 "username": "added-by-admin",
-                "password1": "xo-xo-xo",
-                "password2": "xo-xo-xo",
+                "password1": __FOR_TESTING__,
+                "password2": __FOR_TESTING__,
             },
             follow=True,
         )
@@ -225,8 +227,8 @@ class TestUserAdmin(LoggedInTestCase):  # pylint: disable=too-many-public-method
             "/admin/auth/user/add/",
             {
                 "username": "added-by-moderator",
-                "password1": "xo-xo-xo",
-                "password2": "xo-xo-xo",
+                "password1": __FOR_TESTING__,
+                "password2": __FOR_TESTING__,
             },
             follow=True,
         )
@@ -373,8 +375,8 @@ class TestUserAdmin(LoggedInTestCase):  # pylint: disable=too-many-public-method
             "/admin/auth/user/add/",
             {
                 "username": "added-by-regular-user",
-                "password1": "xo-xo-xo",
-                "password2": "xo-xo-xo",
+                "password1": __FOR_TESTING__,
+                "password2": __FOR_TESTING__,
             },
             follow=True,
         )

--- a/tcms/kiwi_auth/tests/test_forms.py
+++ b/tcms/kiwi_auth/tests/test_forms.py
@@ -5,13 +5,15 @@ from django.utils.translation import gettext_lazy as _
 
 from tcms.kiwi_auth import forms
 
+from . import __FOR_TESTING__
+
 
 class TestCaptchaField(TestCase):
     def setUp(self):
         self.data = {
             "username": "test_user",
-            "password1": "password",
-            "password2": "password",
+            "password1": __FOR_TESTING__,
+            "password2": __FOR_TESTING__,
             "email": "new-tester@example.com",
         }
 
@@ -49,8 +51,8 @@ class TestRegistrationForm(TestCase):
     def setUp(self):
         self.data = {
             "username": "test_user",
-            "password1": "password",
-            "password2": "password",
+            "password1": __FOR_TESTING__,
+            "password2": __FOR_TESTING__,
             "email": "new-tester@example.com",
         }
 

--- a/tcms/kiwi_auth/tests/test_views.py
+++ b/tcms/kiwi_auth/tests/test_views.py
@@ -17,6 +17,8 @@ from tcms.kiwi_auth import forms
 from tcms.kiwi_auth.models import UserActivationKey
 from tcms.tests.factories import UserFactory
 
+from . import __FOR_TESTING__
+
 User = get_user_model()  # pylint: disable=invalid-name
 
 
@@ -117,8 +119,8 @@ class TestRegistration(TestCase):
                     self.register_url,
                     {
                         "username": username,
-                        "password1": "password",
-                        "password2": "password",
+                        "password1": __FOR_TESTING__,
+                        "password2": __FOR_TESTING__,
                         "email": "new-tester@example.com",
                         "captcha_0": "PASSED",
                         "captcha_1": "PASSED",
@@ -254,8 +256,8 @@ To activate your account, click this link:
             self.register_url,
             {
                 "username": "kiwi-tester",
-                "password1": "password-1",
-                "password2": "password-2",
+                "password1": __FOR_TESTING__,
+                "password2": f"000-{__FOR_TESTING__}",
                 "email": "new-tester@example.com",
             },
             follow=False,
@@ -272,8 +274,8 @@ To activate your account, click this link:
             self.register_url,
             {
                 "username": "test_user",
-                "password1": "password",
-                "password2": "password",
+                "password1": __FOR_TESTING__,
+                "password2": __FOR_TESTING__,
                 "email": "new-tester@example.com",
             },
             follow=False,

--- a/tcms/settings/common.py
+++ b/tcms/settings/common.py
@@ -92,6 +92,25 @@ DEFAULT_GROUPS = ["Tester"]
 # handler!
 AUTO_APPROVE_NEW_USERS = True
 
+# Password validation rules, see
+# https://docs.djangoproject.com/en/4.1/topics/auth/passwords/#enabling-password-validation
+AUTH_PASSWORD_VALIDATORS = [
+    {
+        "NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator",
+    },
+    {
+        "NAME": "django.contrib.auth.password_validation.MinimumLengthValidator",
+        "OPTIONS": {
+            "min_length": 10,
+        },
+    },
+    {
+        "NAME": "django.contrib.auth.password_validation.CommonPasswordValidator",
+    },
+    {
+        "NAME": "django.contrib.auth.password_validation.NumericPasswordValidator",
+    },
+]
 
 # Set to False if you want to enforce account creation by admins.
 REGISTRATION_ENABLED = (


### PR DESCRIPTION
- password can’t be too similar to your other personal information.
- password must contain at least 10 characters.
- password can’t be a commonly used password.
- password can’t be entirely numeric.

Existing users are advised to reset their passwords!