### PR TITLE
Don't show all builds on Search Test Runs page

### DIFF
--- a/tcms/testruns/views.py
+++ b/tcms/testruns/views.py
@@ -159,7 +159,7 @@ class SearchTestRunView(TemplateView):
 
     def get_context_data(self, **kwargs):
         form = SearchRunForm(self.request.GET)
-        form.populate(product_id=self.request.GET.get("product"))
+        form.populate(product_id=self.request.GET.get("product", -1))
 
         return {
             "form": form,


### PR DESCRIPTION
before Product and Version fields are initialized when loading the page directly