### PR TITLE
[Testruns] Improve loading time on pages with large number of executions

### DIFF
--- a/tcms/testruns/static/testruns/js/get.js
+++ b/tcms/testruns/static/testruns/js/get.js
@@ -596,9 +596,9 @@ function renderAdditionalInformation (testRunId, execution) {
                 propString += `${name}: ${propsPerTe[teId][name]}; `
             }
 
-            let properties = row.find('.js-row-properties')
-            properties.toggleClass('hidden')
-            properties.html(properties.html() + ' ' + propString + '<br>')
+            let propertiesRow = row.find('.js-row-properties')
+            propertiesRow.toggleClass('hidden')
+            propertiesRow.html(propertiesRow.html() + propString + '<br>')
         }
     })
 
@@ -642,8 +642,9 @@ function renderAdditionalInformation (testRunId, execution) {
                             }
                         }
                         if (testCase.tagNames.length) {
-                            row.find('.js-row-tags').toggleClass('hidden')
-                            row.find('.js-row-tags').append(testCase.tagNames.join(', '))
+                            let tagsRow = row.find('.js-row-tags')
+                            tagsRow.toggleClass('hidden')
+                            tagsRow.html(tagsRow.html() + testCase.tagNames.join(', '))
                         }
 
                         testCase.componentNames = []
@@ -655,8 +656,9 @@ function renderAdditionalInformation (testRunId, execution) {
                             }
                         }
                         if (testCase.componentNames.length) {
-                            row.find('.js-row-components').toggleClass('hidden')
-                            row.find('.js-row-components').append(testCase.componentNames.join(', '))
+                            let componentsRow = row.find('.js-row-components')
+                            componentsRow.toggleClass('hidden')
+                            componentsRow.html(componentsRow.html() + testCase.componentNames.join(', '))
                         }
 
                         // update internal data structure

--- a/tcms/testruns/static/testruns/js/get.js
+++ b/tcms/testruns/static/testruns/js/get.js
@@ -596,7 +596,7 @@ function renderAdditionalInformation (testRunId, execution) {
                 propString += `${name}: ${propsPerTe[teId][name]}; `
             }
 
-            let propertiesRow = row.find('.js-row-properties')
+            const propertiesRow = row.find('.js-row-properties')
             propertiesRow.toggleClass('hidden')
             propertiesRow.html(propertiesRow.html() + propString + '<br>')
         }
@@ -642,7 +642,7 @@ function renderAdditionalInformation (testRunId, execution) {
                             }
                         }
                         if (testCase.tagNames.length) {
-                            let tagsRow = row.find('.js-row-tags')
+                            const tagsRow = row.find('.js-row-tags')
                             tagsRow.toggleClass('hidden')
                             tagsRow.html(tagsRow.html() + testCase.tagNames.join(', '))
                         }
@@ -656,7 +656,7 @@ function renderAdditionalInformation (testRunId, execution) {
                             }
                         }
                         if (testCase.componentNames.length) {
-                            let componentsRow = row.find('.js-row-components')
+                            const componentsRow = row.find('.js-row-components')
                             componentsRow.toggleClass('hidden')
                             componentsRow.html(componentsRow.html() + testCase.componentNames.join(', '))
                         }

--- a/tcms/testruns/static/testruns/js/get.js
+++ b/tcms/testruns/static/testruns/js/get.js
@@ -596,8 +596,9 @@ function renderAdditionalInformation (testRunId, execution) {
                 propString += `${name}: ${propsPerTe[teId][name]}; `
             }
 
-            row.find('.js-row-properties').toggleClass('hidden')
-            row.find('.js-row-properties').append(propString + '<br>')
+            let properties = row.find('.js-row-properties')
+            properties.toggleClass('hidden')
+            properties.html(properties.html() + ' ' + propString + '<br>')
         }
     })
 


### PR DESCRIPTION
Loading testrun page takes too long for a large number of test executions with parameters.
This is taking so long because of the jQuery append function, which is called every iteration when adding parameters to test execution.
With each iteration, its execution takes more and more time, as the DOM tree grows.
For example, on test run with 2128 test executions, append from beginning takes 4ms, last append takes 154ms:
![image](https://user-images.githubusercontent.com/62895232/220568793-ef565bd8-244e-41e8-9155-9b7243dfc719.png)
![image](https://user-images.githubusercontent.com/62895232/220568839-4f5d23c0-3f92-45bc-b1dc-b0d8242e7bbc.png)

The fix for this is to use an `.html()` function instead of `.append()`.
Without fix full load takes ~94 seconds:
![image](https://user-images.githubusercontent.com/62895232/220569628-84d36452-95dd-4ad8-bac0-99622a1d9b72.png)

With fix full load takes ~17 seconds, with each test execution parameters set around 7-10ms (this is the time of the command to get the execution row ```const row = $(`.test-execution-${teId}`)```, there is hardly anything that can be improved here):
![image](https://user-images.githubusercontent.com/62895232/220569780-c9eb4228-da66-436c-a693-d292dddddc1f.png)

~5.5 times improvement. It's not perfect, but not so bad anymore.

Update:
Done same for tags and components, removed space from properties `.html()`