### PR TITLE
Fix a test failing b/c of French locale

### DIFF
--- a/tcms/kiwi_auth/tests/test_admin.py
+++ b/tcms/kiwi_auth/tests/test_admin.py
@@ -1,4 +1,5 @@
 # pylint: disable=invalid-name
+import html
 from http import HTTPStatus
 
 from django.conf import settings
@@ -182,8 +183,12 @@ class TestUserAdmin(LoggedInTestCase):  # pylint: disable=too-many-public-method
         )
         self.assertEqual(HTTPStatus.OK, response.status_code)
         self.assertRedirects(response, f"/admin/auth/user/{self.admin.pk}/change/")
-        self.assertContains(
-            response, _("This is the last superuser, it cannot be deleted!")
+
+        response_text = html.unescape(
+            str(response.content, encoding=settings.DEFAULT_CHARSET)
+        )
+        self.assertIn(
+            str(_("This is the last superuser, it cannot be deleted!")), response_text
         )
         self.assertTrue(get_user_model().objects.filter(pk=self.admin.pk).exists())
 


### PR DESCRIPTION
IIRC the accented characters in some French translations render as HTML utf-8 codes which breaks the assertions. Last time this happened was in f74c3c16b352ada088cb0b34133e7703391c3a3c