### PR TITLE
Remove the __all__ attribute in RPC modules

### DIFF
--- a/tcms/rpc/api/attachment.py
+++ b/tcms/rpc/api/attachment.py
@@ -5,8 +5,6 @@ from modernrpc.core import REQUEST_KEY, rpc_method
 
 from tcms.rpc.decorators import permissions_required
 
-__all__ = ("remove_attachment",)
-
 
 @permissions_required("attachments.delete_attachment")
 @rpc_method(name="Attachment.remove_attachment")

--- a/tcms/rpc/api/auth.py
+++ b/tcms/rpc/api/auth.py
@@ -4,11 +4,6 @@ import django.contrib.auth
 from django.core.exceptions import PermissionDenied
 from modernrpc.core import REQUEST_KEY, rpc_method
 
-__all__ = (
-    "login",
-    "logout",
-)
-
 
 @rpc_method(name="Auth.login")
 def login(

--- a/tcms/rpc/api/bug.py
+++ b/tcms/rpc/api/bug.py
@@ -10,11 +10,6 @@ from tcms.rpc.decorators import permissions_required
 from tcms.testcases.models import BugSystem
 from tcms.testruns.models import TestExecution
 
-__all__ = (
-    "details",
-    "report",
-)
-
 
 @http_basic_auth_login_required
 @rpc_method(name="Bug.details")

--- a/tcms/rpc/api/build.py
+++ b/tcms/rpc/api/build.py
@@ -8,12 +8,6 @@ from tcms.management.models import Build
 from tcms.rpc.api.forms.management import BuildForm, BuildUpdateForm
 from tcms.rpc.decorators import permissions_required
 
-__all__ = (
-    "create",
-    "update",
-    "filter",
-)
-
 
 @permissions_required("management.view_build")
 @rpc_method(name="Build.filter")

--- a/tcms/rpc/api/component.py
+++ b/tcms/rpc/api/component.py
@@ -12,13 +12,6 @@ from tcms.rpc.decorators import permissions_required
 User = get_user_model()  # pylint: disable=invalid-name
 
 
-__all__ = (
-    "create",
-    "update",
-    "filter",
-)
-
-
 @permissions_required("management.view_component")
 @rpc_method(name="Component.filter")
 def filter(query):  # pylint: disable=redefined-builtin

--- a/tcms/rpc/api/environment.py
+++ b/tcms/rpc/api/environment.py
@@ -8,14 +8,6 @@ from tcms.rpc.api.forms.testrun import EnvironmentForm
 from tcms.rpc.decorators import permissions_required
 from tcms.testruns.models import Environment, EnvironmentProperty
 
-__all__ = (
-    "properties",
-    "remove_property",
-    "add_property",
-    "filter",
-    "create",
-)
-
 
 @permissions_required("testruns.view_environmentproperty")
 @rpc_method(name="Environment.properties")

--- a/tcms/rpc/api/kiwitcms.py
+++ b/tcms/rpc/api/kiwitcms.py
@@ -5,8 +5,6 @@ from modernrpc.core import rpc_method
 
 from tcms import __version__
 
-__all__ = ("version",)
-
 
 @http_basic_auth_login_required
 @rpc_method(name="KiwiTCMS.version")

--- a/tcms/rpc/api/markdown.py
+++ b/tcms/rpc/api/markdown.py
@@ -5,8 +5,6 @@ from modernrpc.core import rpc_method
 
 from tcms.core.templatetags.extra_filters import markdown2html
 
-__all__ = ("render",)
-
 
 @http_basic_auth_login_required
 @rpc_method(name="Markdown.render")

--- a/tcms/rpc/api/plantype.py
+++ b/tcms/rpc/api/plantype.py
@@ -8,11 +8,6 @@ from tcms.rpc.api.forms.testplan import PlanTypeForm
 from tcms.rpc.decorators import permissions_required
 from tcms.testplans.models import PlanType
 
-__all__ = (
-    "create",
-    "filter",
-)
-
 
 @rpc_method(name="PlanType.create")
 @permissions_required("testplans.add_plantype")

--- a/tcms/rpc/api/product.py
+++ b/tcms/rpc/api/product.py
@@ -8,11 +8,6 @@ from tcms.management.models import Product
 from tcms.rpc.api.forms.management import ProductForm
 from tcms.rpc.decorators import permissions_required
 
-__all__ = (
-    "create",
-    "filter",
-)
-
 
 @rpc_method(name="Product.create")
 @permissions_required("management.add_product")

--- a/tcms/rpc/api/testcase.py
+++ b/tcms/rpc/api/testcase.py
@@ -15,30 +15,6 @@ from tcms.rpc.api.forms.testcase import NewForm, UpdateForm
 from tcms.rpc.decorators import permissions_required
 from tcms.testcases.models import Property, TestCase, TestCasePlan
 
-__all__ = (
-    "create",
-    "update",
-    "filter",
-    "history",
-    "sortkeys",
-    "remove",
-    "add_comment",
-    "remove_comment",
-    "add_component",
-    "comments",
-    "remove_component",
-    "add_notification_cc",
-    "get_notification_cc",
-    "remove_notification_cc",
-    "add_tag",
-    "remove_tag",
-    "add_attachment",
-    "list_attachments",
-    "properties",
-    "remove_property",
-    "add_property",
-)
-
 
 @permissions_required("testcases.add_testcasecomponent")
 @rpc_method(name="TestCase.add_component")

--- a/tcms/rpc/api/testexecution.py
+++ b/tcms/rpc/api/testexecution.py
@@ -27,19 +27,6 @@ else:
         pass
 
 
-__all__ = (
-    "update",
-    "filter",
-    "history",
-    "add_comment",
-    "remove_comment",
-    "add_link",
-    "get_links",
-    "remove_link",
-    "properties",
-)
-
-
 @permissions_required("django_comments.add_comment")
 @rpc_method(name="TestExecution.add_comment")
 def add_comment(execution_id, comment, **kwargs):

--- a/tcms/rpc/api/testplan.py
+++ b/tcms/rpc/api/testplan.py
@@ -11,20 +11,6 @@ from tcms.rpc.decorators import permissions_required
 from tcms.testcases.models import TestCase, TestCasePlan
 from tcms.testplans.models import TestPlan
 
-__all__ = (
-    "create",
-    "update",
-    "filter",
-    "add_case",
-    "remove_case",
-    "update_case_order",
-    "add_tag",
-    "remove_tag",
-    "add_attachment",
-    "list_attachments",
-    "tree",
-)
-
 
 @permissions_required("testplans.add_testplan")
 @rpc_method(name="TestPlan.create")

--- a/tcms/rpc/api/testrun.py
+++ b/tcms/rpc/api/testrun.py
@@ -11,21 +11,6 @@ from tcms.testcases.models import TestCase
 from tcms.testruns.forms import NewRunForm
 from tcms.testruns.models import Property, TestExecution, TestRun
 
-__all__ = (
-    "create",
-    "update",
-    "filter",
-    "add_case",
-    "get_cases",
-    "remove_case",
-    "add_tag",
-    "remove_tag",
-    "add_cc",
-    "remove_cc",
-    "properties",
-    "add_attachment",
-)
-
 
 @permissions_required("testruns.add_testexecution")
 @rpc_method(name="TestRun.add_case")

--- a/tcms/rpc/api/user.py
+++ b/tcms/rpc/api/user.py
@@ -14,14 +14,6 @@ from tcms.rpc.decorators import permissions_required
 User = get_user_model()  # pylint: disable=invalid-name
 
 
-__all__ = (
-    "update",
-    "filter",
-    "join_group",
-    "add_attachment",
-)
-
-
 def _get_user_dict(user):
     user_dict = model_to_dict(user)
 

--- a/tcms/rpc/api/version.py
+++ b/tcms/rpc/api/version.py
@@ -8,11 +8,6 @@ from tcms.management.forms import VersionForm
 from tcms.management.models import Version
 from tcms.rpc.decorators import permissions_required
 
-__all__ = (
-    "create",
-    "filter",
-)
-
 
 @permissions_required("management.view_version")
 @rpc_method(name="Version.filter")


### PR DESCRIPTION
b/c it is only used to determine which methods are exposed in the documentation. Currently there are methods which have doc-strings but were not exposed on ReadTheDocs.