### PR TITLE
Add INFO message for User/Group pages in Admin panel

### DIFF
--- a/tcms/kiwi_auth/views.py
+++ b/tcms/kiwi_auth/views.py
@@ -157,13 +157,25 @@ class UsersRouter(View):  # pylint: disable=missing-permission-required
     http_method_names = ["get"]
 
     def get(self, request, *args, **kwargs):  # pylint: disable=no-self-use
+        is_multi_tenant = hasattr(request, "tenant")
+
         if request.user.is_superuser:
+            if is_multi_tenant:
+                messages.add_message(
+                    request,
+                    messages.INFO,
+                    _("You are viewing records from tenant '%s'") % "MAIN",
+                )
+
             return HttpResponseRedirect("/admin/auth/user/")
 
-        if (
-            hasattr(request, "tenant")
-            and request.tenant.schema_name != get_public_schema_name()
-        ):
+        if is_multi_tenant and request.tenant.schema_name != get_public_schema_name():
+            messages.add_message(
+                request,
+                messages.INFO,
+                _("You are viewing records from tenant '%s'")
+                % request.tenant.schema_name,
+            )
             return HttpResponseRedirect("/admin/tcms_tenants/tenant_authorized_users/")
 
         return HttpResponseRedirect("/admin/auth/user/")
@@ -174,13 +186,24 @@ class GroupsRouter(View):  # pylint: disable=missing-permission-required
     http_method_names = ["get"]
 
     def get(self, request, *args, **kwargs):  # pylint: disable=no-self-use
+        is_multi_tenant = hasattr(request, "tenant")
         if request.user.is_superuser:
+            if is_multi_tenant:
+                messages.add_message(
+                    request,
+                    messages.INFO,
+                    _("You are viewing records from tenant '%s'") % "MAIN",
+                )
+
             return HttpResponseRedirect("/admin/auth/group/")
 
-        if (
-            hasattr(request, "tenant")
-            and request.tenant.schema_name != get_public_schema_name()
-        ):
+        if is_multi_tenant and request.tenant.schema_name != get_public_schema_name():
+            messages.add_message(
+                request,
+                messages.INFO,
+                _("You are viewing records from tenant '%s'")
+                % request.tenant.schema_name,
+            )
             return HttpResponseRedirect("/admin/tenant_groups/group/")
 
         return HttpResponseRedirect("/admin/auth/group/")

--- a/tcms/locale/en/LC_MESSAGES/django.po
+++ b/tcms/locale/en/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-04 19:48+0000\n"
+"POT-Creation-Date: 2023-04-06 17:15+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -522,6 +522,12 @@ msgstr ""
 
 #: tcms/kiwi_auth/views.py:140
 msgid "Your account has been activated successfully"
+msgstr ""
+
+#: tcms/kiwi_auth/views.py:167 tcms/kiwi_auth/views.py:176
+#: tcms/kiwi_auth/views.py:195 tcms/kiwi_auth/views.py:204
+#, python-format
+msgid "You are viewing records from tenant '%s'"
 msgstr ""
 
 #: tcms/management/models.py:52


### PR DESCRIPTION
which indicates whether the user is viewing records from the main tenant or from an individual tenant. When clicking the menu ADMIN -> Users and ADMIN -> Groups menu as super-user you will always be redirected to the main tenant and since pages look the same that may be very confusing.