### PR TITLE
Small update to HEALTHCHECK command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN microdnf -y module enable nginx:1.22 && \
     microdnf -y --nodocs update && \
     microdnf clean all
 
-HEALTHCHECK CMD curl --fail --insecure https://localhost:8443/accounts/login
+HEALTHCHECK CMD curl --fail --insecure https://127.0.0.1:8443/accounts/login/
 EXPOSE 8080
 EXPOSE 8443
 COPY ./httpd-foreground /httpd-foreground


### PR DESCRIPTION
- add trailing / to avoid redirects
- use IP address instead of hostname
- depending on ALLOWED_HOSTS this request may be blocked