### PR TITLE
[DataTable] Detach click to prevent request multiplication

### DIFF
--- a/tcms/static/js/tags.js
+++ b/tcms/static/js/tags.js
@@ -69,6 +69,7 @@ export function tagsCard (model, objectId, displayFilter, permRemove) {
 
     // remove tags button
     tagsTable.on('draw', function () {
+        $('.remove-tag').off('click')
         $('.remove-tag').click(function () {
             const tr = $(this).parents('tr')
 

--- a/tcms/testcases/static/testcases/js/get.js
+++ b/tcms/testcases/static/testcases/js/get.js
@@ -130,6 +130,7 @@ export function pageTestcasesGetReadyHandler () {
 
     // remove component button
     componentsTable.on('draw', function () {
+        $('.remove-component').off('click')
         $('.remove-component').click(function () {
             const tr = $(this).parents('tr')
 
@@ -208,6 +209,7 @@ export function pageTestcasesGetReadyHandler () {
 
     // remove plan button
     plansTable.on('draw', function () {
+        $('.remove-plan').off('click')
         $('.remove-plan').click(function () {
             const tr = $(this).parents('tr')
 


### PR DESCRIPTION
It was noticed when trying to delete test plans.
If you delete several at a time, then there is a multiplication of requests for deletion.

See video with defect:
https://i.imgur.com/hSGW8ed.mp4
