### PR TITLE
[TestRuns] Fix `removeCases` function

### DIFF
--- a/tcms/testruns/static/testruns/js/get.js
+++ b/tcms/testruns/static/testruns/js/get.js
@@ -918,17 +918,25 @@ export function bindDeleteLinkButton () {
 function removeCases (testRunId, testCaseIds) {
     for (const testCaseId of testCaseIds) {
         jsonRPC('TestRun.remove_case', [testRunId, testCaseId], () => {
-            const tePK = $(`.test-execution-case-${testCaseId}`)
-                .find('.test-execution-checkbox')
-                .data('test-execution-id')
+            const testExecutionsIds = []
+            $(`.test-execution-case-${testCaseId}`)
+                .each(
+                    function() {testExecutionsIds.push(
+                        $(this)
+                            .find('.test-execution-checkbox')
+                            .data('test-execution-id')
+                    )}
+                )
             $(`.test-execution-case-${testCaseId}`).remove()
 
-            delete expandedExecutionIds[expandedExecutionIds.indexOf(tePK)]
-            delete allExecutions[tePK]
+            testExecutionsIds.forEach(element => {
+                delete expandedExecutionIds[expandedExecutionIds.indexOf(element)]
+                delete allExecutions[element]
+            })
 
             const testExecutionCountEl = $('.test-executions-count')
             const count = parseInt(testExecutionCountEl[0].innerText)
-            testExecutionCountEl.html(count - 1)
+            testExecutionCountEl.html(count - testExecutionsIds.length)
         }, true)
     }
 

--- a/tcms/testruns/static/testruns/js/get.js
+++ b/tcms/testruns/static/testruns/js/get.js
@@ -921,11 +921,13 @@ function removeCases (testRunId, testCaseIds) {
             const testExecutionsIds = []
             $(`.test-execution-case-${testCaseId}`)
                 .each(
-                    function() {testExecutionsIds.push(
-                        $(this)
-                            .find('.test-execution-checkbox')
-                            .data('test-execution-id')
-                    )}
+                    function () {
+                        testExecutionsIds.push(
+                            $(this)
+                                .find('.test-execution-checkbox')
+                                .data('test-execution-id')
+                        )
+                    }
                 )
             $(`.test-execution-case-${testCaseId}`).remove()
 


### PR DESCRIPTION
There are cases when several TEs are created from single TC (when TC is parametrized):
<img src="https://github.com/kiwitcms/Kiwi/assets/62895232/889e7040-39af-49a3-a0e8-786bd9af5b4a" width="30%" height="30%">

`removeCases` function in `tcms/testruns/static/testruns/js/get.js` does not take it into account.
As a result, it is not possible to re-add the same test case without reloading the page. Also, the counter shows the wrong number.

See video with defect:
https://i.imgur.com/NxqHDq1.mp4