### PR TITLE
[TestPlans] Hide all expanded children, fixes #3245

### DIFF
--- a/tcms/testplans/static/testplans/js/search.js
+++ b/tcms/testplans/static/testplans/js/search.js
@@ -153,9 +153,7 @@ export function pageTestplansSearchReadyHandler () {
         const row = table.row(tr)
 
         if (row.child.isShown()) {
-            // TODO: hide all expanded children. When closing a top-level parent row
-            // its immediate children are removed, however their descendants aren't.
-            // This leads to dangling rows in situations of multi-tier parent-child TPs
+            hideExpandedChildren(table, row)
             row.child.hide()
             bracket.removeClass('fa-angle-down')
         } else {
@@ -170,6 +168,24 @@ export function pageTestplansSearchReadyHandler () {
     })
 
     $('#id_product').change(updateVersionSelectFromProduct)
+}
+
+function hideExpandedChildren (table, parentRow) {
+    const children = hiddenChildRows[parentRow.data().id]
+    if (!children){
+        return;
+    }
+    children.forEach(
+        function(element) {
+            const row = table.row($(element))
+            if (row.child.isShown()){
+                row.child.hide()
+            }
+            if (hiddenChildRows[row.data().id]) {
+                hideExpandedChildren(table, row)
+            }
+        }
+    )
 }
 
 function renderChildrenOf (parentRow, data) {

--- a/tcms/testplans/static/testplans/js/search.js
+++ b/tcms/testplans/static/testplans/js/search.js
@@ -172,9 +172,6 @@ export function pageTestplansSearchReadyHandler () {
 
 function hideExpandedChildren (table, parentRow) {
     const children = hiddenChildRows[parentRow.data().id]
-    if (!children) {
-        return
-    }
     children.forEach(
         function (element) {
             const row = table.row($(element))

--- a/tcms/testplans/static/testplans/js/search.js
+++ b/tcms/testplans/static/testplans/js/search.js
@@ -172,13 +172,13 @@ export function pageTestplansSearchReadyHandler () {
 
 function hideExpandedChildren (table, parentRow) {
     const children = hiddenChildRows[parentRow.data().id]
-    if (!children){
-        return;
+    if (!children) {
+        return
     }
     children.forEach(
-        function(element) {
+        function (element) {
             const row = table.row($(element))
-            if (row.child.isShown()){
+            if (row.child.isShown()) {
                 row.child.hide()
             }
             if (hiddenChildRows[row.data().id]) {


### PR DESCRIPTION
Recursively find all expanded children of parentRow and hide them.