### PR TITLE
Templates fixes

### DIFF
--- a/tcms/core/templates/dashboard.html
+++ b/tcms/core/templates/dashboard.html
@@ -76,7 +76,7 @@ Here are the latest {{ count }}.{% endblocktrans %}
 {% blocktrans with total_count=test_plans_count disabled_count=test_plans_disable_count count=last_15_test_plans|length %}You manage {{ total_count }} TestPlan(s), {{ disabled_count }} are disabled.
 Here are the latest {{ count }}.{% endblocktrans %}
 
-                <a href="{% url "plans-search" %}?author__username__startswith={{ user.username }}">
+                <a href="{% url "plans-search" %}?author={{ user.username }}">
                     {% trans "SEE ALL" %}
                 </a>
             {% else %}

--- a/tcms/templates/navbar.html
+++ b/tcms/templates/navbar.html
@@ -40,7 +40,7 @@
                         </li>
 
                         <li>
-                            <a href="{% url "plans-search" %}?author__username__startswith={{ user.username }}" target="_parent">{% trans "My Test Plans" %}</a>
+                            <a href="{% url "plans-search" %}?author={{ user.username }}" target="_parent">{% trans "My Test Plans" %}</a>
                         </li>
 
                         <li class="divider"></li>

--- a/tcms/testcases/templates/testcases/search.html
+++ b/tcms/testcases/templates/testcases/search.html
@@ -128,7 +128,7 @@
         <div class="form-group">
             <label class="col-md-1 col-lg-1" for="id_tag">{% trans "Tag" %}</label>
             <div class="col-md-3 col-lg-3">
-                <input id="id_tag" type="text" class="form-control" value="{{ form.tag.value|default:'' }}">
+                <input id="id_tag" type="text" class="form-control" value="{{ form.tag.value.0|default:'' }}">
                 <p class="help-block">{% trans "Separate multiple values with comma (,)" %}</p>
             </div>
 

--- a/tcms/testplans/templates/testplans/search.html
+++ b/tcms/testplans/templates/testplans/search.html
@@ -89,7 +89,7 @@
 
             <label class="col-md-1 col-lg-1" for="id_tag">{% trans "Tag" %}</label>
             <div class="col-md-3 col-lg-3">
-                <input id="id_tag" type="text" class="form-control" value="{{ form.tag.value|default:'' }}">
+                <input id="id_tag" type="text" class="form-control" value="{{ form.tag.value.0|default:'' }}">
                 <p class="help-block">{% trans "Separate multiple values with comma (,)" %}</p>
             </div>
         </div>

--- a/tcms/testruns/templates/testruns/search.html
+++ b/tcms/testruns/templates/testruns/search.html
@@ -26,7 +26,7 @@
 
             <label class="col-md-1 col-lg-1" for="id_tag">{% trans "Tag" %}</label>
                 <div class="col-md-3 col-lg-3">
-                    <input id="id_tag" type="text" class="form-control" value="{{ form.tag.value|default:'' }}">
+                    <input id="id_tag" type="text" class="form-control" value="{{ form.tag.value.0|default:'' }}">
                     <p class="help-block">{% trans "Separate multiple values with comma (,)" %}</p>
                 </div>
         </div>


### PR DESCRIPTION
There are 2 fixes in this PR:

1. Fix for tag. You can see the problem with this URL: https://public.tenant.kiwitcms.org/runs/search/?tag=some_tag
In form we see:
![image](https://github.com/kiwitcms/Kiwi/assets/62895232/adfa9e45-b901-46d3-a8d7-d75ff168d51e)
2. Fix for `My Test Plans` query param. `author__username__startswith` is not correct form variable, `author` is correct. You can check it with 2 URLs:
  * **Wrong**: https://public.tenant.kiwitcms.org/plan/search/?author__username__startswith=somebody
  * **Correct**: https://public.tenant.kiwitcms.org/plan/search/?author=somebody