### PR TITLE
Define IssueTracker.rpc_credentials property

### DIFF
--- a/tcms/issuetracker/azure_boards.py
+++ b/tcms/issuetracker/azure_boards.py
@@ -79,10 +79,14 @@ class AzureBoards(IssueTrackerType):
     """
 
     def _rpc_connection(self):
-        return AzureBoardsAPI(self.bug_system.base_url, self.bug_system.api_password)
+        (_, api_password) = self.rpc_credentials
+
+        return AzureBoardsAPI(self.bug_system.base_url, api_password)
 
     def is_adding_testcase_to_issue_disabled(self):
-        return not (self.bug_system.base_url and self.bug_system.api_password)
+        (_, api_password) = self.rpc_credentials
+
+        return not (self.bug_system.base_url and api_password)
 
     def _report_issue(self, execution, user):
         """

--- a/tcms/issuetracker/base.py
+++ b/tcms/issuetracker/base.py
@@ -188,11 +188,9 @@ TE-{execution.pk}: {execution.case.summary}"""
         :return: True if bug system api url, username and password are provided
         :rtype: bool
         """
-        return not (
-            self.bug_system.api_url
-            and self.bug_system.api_username
-            and self.bug_system.api_password
-        )
+        (api_username, api_password) = self.rpc_credentials
+
+        return not (self.bug_system.api_url and api_username and api_password)
 
     def _rpc_connection(self):
         """
@@ -218,3 +216,15 @@ TE-{execution.pk}: {execution.case.summary}"""
             self.rpc_cache[self.bug_system.base_url] = self._rpc_connection()
 
         return self.rpc_cache[self.bug_system.base_url]
+
+    @property
+    def rpc_credentials(self):
+        """
+        Returns an tuple of (api_username, api_token_or_password) meant for connecting
+        to a 3rd party issue tracker system.
+
+        It can be overriden in order to provide more flexible integrations!
+
+        .. versionadded:: 12.6
+        """
+        return (self.bug_system.api_username, self.bug_system.api_password)

--- a/tcms/issuetracker/bitbucket.py
+++ b/tcms/issuetracker/bitbucket.py
@@ -93,18 +93,18 @@ class BitBucket(IssueTrackerType):
     """
 
     def _rpc_connection(self):
+        (api_username, api_password) = self.rpc_credentials
+
         return BitBucketAPI(
             self.bug_system.base_url,
-            api_username=self.bug_system.api_username,
-            api_password=self.bug_system.api_password,
+            api_username=api_username,
+            api_password=api_password,
         )
 
     def is_adding_testcase_to_issue_disabled(self):
-        return not (
-            self.bug_system.base_url
-            and self.bug_system.api_username
-            and self.bug_system.api_password
-        )
+        (api_username, api_password) = self.rpc_credentials
+
+        return not (self.bug_system.base_url and api_username and api_password)
 
     def _report_issue(self, execution, user):
         """

--- a/tcms/issuetracker/bugzilla_integration.py
+++ b/tcms/issuetracker/bugzilla_integration.py
@@ -39,10 +39,12 @@ class Bugzilla(base.IssueTrackerType):
         if not os.path.exists(self._bugzilla_cache_dir):
             os.makedirs(self._bugzilla_cache_dir, 0o700)
 
+        (api_username, api_password) = self.rpc_credentials
+
         return bugzilla.Bugzilla(
             self.bug_system.api_url,
-            user=self.bug_system.api_username,
-            password=self.bug_system.api_password,
+            user=api_username,
+            password=api_password,
             tokenfile=self._bugzilla_cache_dir + "token",
         )
 

--- a/tcms/issuetracker/types.py
+++ b/tcms/issuetracker/types.py
@@ -48,18 +48,18 @@ class JIRA(IssueTrackerType):
         else:
             options = None
 
+        (api_username, api_password) = self.rpc_credentials
+
         return jira.JIRA(
             self.bug_system.base_url,
-            basic_auth=(self.bug_system.api_username, self.bug_system.api_password),
+            basic_auth=(api_username, api_password),
             options=options,
         )
 
     def is_adding_testcase_to_issue_disabled(self):
-        return not (
-            self.bug_system.base_url
-            and self.bug_system.api_username
-            and self.bug_system.api_password
-        )
+        (api_username, api_password) = self.rpc_credentials
+
+        return not (self.bug_system.base_url and api_username and api_password)
 
     @classmethod
     def bug_id_from_url(cls, url):
@@ -181,11 +181,15 @@ class GitHub(IssueTrackerType):
     """
 
     def _rpc_connection(self):
+        (_, api_password) = self.rpc_credentials
+
         # NOTE: we use an access token so only the password field is required
-        return github.Github(self.bug_system.api_password)
+        return github.Github(api_password)
 
     def is_adding_testcase_to_issue_disabled(self):
-        return not (self.bug_system.base_url and self.bug_system.api_password)
+        (_, api_password) = self.rpc_credentials
+
+        return not (self.bug_system.base_url and api_password)
 
     def _report_issue(self, execution, user):
         """
@@ -262,13 +266,15 @@ class Gitlab(IssueTrackerType):
     """
 
     def _rpc_connection(self):
+        (_, api_password) = self.rpc_credentials
+
         # we use an access token so only the password field is required
-        return gitlab.Gitlab(
-            self.bug_system.api_url, private_token=self.bug_system.api_password
-        )
+        return gitlab.Gitlab(self.bug_system.api_url, private_token=api_password)
 
     def is_adding_testcase_to_issue_disabled(self):
-        return not (self.bug_system.api_url and self.bug_system.api_password)
+        (_, api_password) = self.rpc_credentials
+
+        return not (self.bug_system.api_url and api_password)
 
     def _report_issue(self, execution, user):
         project = self.rpc.projects.get(self.repo_id)
@@ -319,17 +325,17 @@ class Redmine(IssueTrackerType):
     """
 
     def is_adding_testcase_to_issue_disabled(self):
-        return not (
-            self.bug_system.base_url
-            and self.bug_system.api_username
-            and self.bug_system.api_password
-        )
+        (api_username, api_password) = self.rpc_credentials
+
+        return not (self.bug_system.base_url and api_username and api_password)
 
     def _rpc_connection(self):
+        (api_username, api_password) = self.rpc_credentials
+
         return redminelib.Redmine(
             self.bug_system.base_url,
-            username=self.bug_system.api_username,
-            password=self.bug_system.api_password,
+            username=api_username,
+            password=api_password,
         )
 
     def details(self, url):


### PR DESCRIPTION
to make it easier to override credentials for Issue Tracker integrations