### PR TITLE
[TestRun] Fix row reload on `add_comment`

### DIFF
--- a/tcms/static/js/utils.js
+++ b/tcms/static/js/utils.js
@@ -287,6 +287,7 @@ export function bindDeleteCommentButton (objId, deleteMethod, canDelete, parentN
 }
 
 export function renderCommentsForObject (objId, getMethod, deleteMethod, canDelete, parentNode) {
+    parentNode.empty()
     const commentTemplate = $('template#comment-template')[0]
 
     jsonRPC(getMethod, [objId], comments => {

--- a/tcms/testruns/static/testruns/js/get.js
+++ b/tcms/testruns/static/testruns/js/get.js
@@ -83,10 +83,7 @@ export function pageTestrunsGetReadyHandler () {
 
         selected.executionIds.forEach(executionId => {
             jsonRPC('TestExecution.add_comment', [executionId, comment], () => {
-                const testExecutionRow = $(`.test-execution-${executionId}`)
-                animate(testExecutionRow, () => {
-                    expandedExecutionIds.splice(expandedExecutionIds.indexOf(executionId), 1)
-                })
+                reloadRowFor(allExecutions[executionId])
             })
         })
 


### PR DESCRIPTION
There are case when rendering after bulk add comment is wrong.
1. Expand test execution:
![image](https://github.com/kiwitcms/Kiwi/assets/62895232/de9abcc1-0237-4cce-8ca9-d4042f532a2d)

2. Add comment from toolbar (bulk comment):
![image](https://github.com/kiwitcms/Kiwi/assets/62895232/a2c8f654-89db-4667-b575-d964b3a8c837)

3. Previous comments and attachments duplicated:
![image](https://github.com/kiwitcms/Kiwi/assets/62895232/c5e1abf9-a1f0-4d4b-b11b-9a55ab60fba2)
