### PR TITLE
[TestCase] Fix for `#id_run` field query

### DIFF
--- a/tcms/testcases/static/testcases/js/search.js
+++ b/tcms/testcases/static/testcases/js/search.js
@@ -106,7 +106,7 @@ export function pageTestcasesSearchReadyHandler () {
             };
 
             if ($('#id_run').val()) {
-                params.executions__run__in = $('#id_run').val()
+                params.executions__run__in = [$('#id_run').val()]
             };
 
             const testPlanIds = selectedPlanIds()


### PR DESCRIPTION
Filter by Test Run does not work on Search Test Cases view.

The issue is that `#id_run` is simple text field, but query uses `__in` and expects array.

Second way is simply change `params.executions__run__in` to `params.executions__run`.
Improvement can be made with `params.executions__run__in = $('#id_run').val().split(',')`, so you would be able to search by several test runs separated with comma (like Tag field)