### PR TITLE
[TestRun] Fix tags when use `reloadRowFor` on multiple executions

### DIFF
--- a/tcms/testruns/static/testruns/js/get.js
+++ b/tcms/testruns/static/testruns/js/get.js
@@ -627,7 +627,11 @@ function renderAdditionalInformation (testRunId, execution) {
                     casesInPlan = Object.keys(casesInPlan).map(id => parseInt(id))
 
                     for (const testCase of testCases) {
-                        const row = $(`.test-execution-case-${testCase.id}`)
+                        let rowSelector = `.test-execution-case-${testCase.id}`
+                        if (execution) {
+                            rowSelector += `.test-execution-${execution.id}`
+                        }
+                        const row = $(rowSelector)
 
                         // when loading this page filtered by status some TCs do not exist
                         // but we don't know about it b/c the above queries are overzealous

--- a/tcms/testruns/static/testruns/js/get.js
+++ b/tcms/testruns/static/testruns/js/get.js
@@ -628,6 +628,13 @@ function renderAdditionalInformation (testRunId, execution) {
 
                     for (const testCase of testCases) {
                         let rowSelector = `.test-execution-case-${testCase.id}`
+                        // Preferably operate over the exact execution row to prevent
+                        // appending new HTML onto existing values, e.g. Tags. See #3367
+                        //
+                        // Root cause of the bug in #3367 is that some fields contain icons
+                        // and pre-existing HTML coming from the template and we can't call .empty()
+                        // on them. When such TE is parametrized then there are multiple HTML rows
+                        // matching `rowSelector`/`testCase.id`, therefore the UI is appended to many times!
                         if (execution) {
                             rowSelector += `.test-execution-${execution.id}`
                         }


### PR DESCRIPTION
There are some problems with tags when you change multiple executions of one case.

1. We have parametrized case with tag:
<img src="https://github.com/kiwitcms/Kiwi/assets/62895232/c3e4feaf-5b27-41e0-97f7-efc6ab8852e9" width=50% height=50%>

3. Change status of any 3 executions -- tags multiply:
<img src="https://github.com/kiwitcms/Kiwi/assets/62895232/f987d23e-5591-4035-af69-373b04d06ddf" width=50% height=50%>

5. Change status of any 2 executions -- tags disappear:
<img src="https://github.com/kiwitcms/Kiwi/assets/62895232/3cae03b6-b283-46b2-9c9e-00fa923ffd6c" width=50% height=50%>
