### PR TITLE
Fall-back to credentials from DB if settings.EXTERNAL_ISSUE_RPC_CREDE…

### DIFF
--- a/tcms/issuetracker/base.py
+++ b/tcms/issuetracker/base.py
@@ -240,6 +240,10 @@ TE-{execution.pk}: {execution.case.summary}"""
             credentials_function = _function_from_path(
                 settings.EXTERNAL_ISSUE_RPC_CREDENTIALS
             )
-            return credentials_function(self)
+            result = credentials_function(self)
+
+            # if result is None or not a tuple then fallback
+            if result and isinstance(result, tuple):
+                return result
 
         return (self.bug_system.api_username, self.bug_system.api_password)

--- a/tcms/issuetracker/tests/redmine_post_processing.py
+++ b/tcms/issuetracker/tests/redmine_post_processing.py
@@ -24,3 +24,7 @@ def change_assignee(rpc, new_issue, execution, user):
 
 def rpc_creds(issue_tracker):
     return ("tester", "test-me")
+
+
+def rpc_no_creds(issue_tracker):
+    return None

--- a/tcms/issuetracker/tests/test_redmine.py
+++ b/tcms/issuetracker/tests/test_redmine.py
@@ -161,3 +161,13 @@ class TestRedmineIntegration(APITestCase):
         # not admin:admin as defined above
         self.assertEqual(rpc_username, "tester")
         self.assertEqual(rpc_password, "test-me")
+
+    @override_settings(
+        EXTERNAL_ISSUE_RPC_CREDENTIALS="tcms.issuetracker.tests.redmine_post_processing.rpc_no_creds"
+    )
+    def test_overriden_credentials_fallback(self):
+        (rpc_username, rpc_password) = self.integration.rpc_credentials
+
+        # admin:admin as defined above b/c rpc_no_creds() returns None
+        self.assertEqual(rpc_username, "admin")
+        self.assertEqual(rpc_password, "admin")


### PR DESCRIPTION
…NTIALS override returns None