### PR TITLE
Add robots.txt to tell various robots to stop indexing Kiwi TCMS

### DIFF
--- a/tcms/core/templates/robots.txt
+++ b/tcms/core/templates/robots.txt
@@ -1,0 +1,26 @@
+User-Agent: *
+Disallow: /
+
+User-agent: CCBot
+Disallow: /
+
+User-agent: ChatGPT-User
+Disallow: /
+
+User-agent: GPTBot
+Disallow: /
+
+User-agent: Google-Extended
+Disallow: /
+
+User-agent: anthropic-ai
+Disallow: /
+
+User-agent: Omgilibot
+Disallow: /
+
+User-agent: Omgili
+Disallow: /
+
+User-agent: FacebookBot
+Disallow: /

--- a/tcms/urls.py
+++ b/tcms/urls.py
@@ -23,6 +23,10 @@ from tcms.testplans import urls as testplans_urls
 from tcms.testruns import urls as testruns_urls
 
 urlpatterns = [
+    re_path(
+        r"^robots.txt$",
+        TemplateView.as_view(template_name="robots.txt", content_type="text/plain"),
+    ),
     re_path(r"^$", core_views.DashboardView.as_view(), name="core-views-index"),
     re_path(r"^captcha/", include(captcha_urls)),
     re_path(r"^xml-rpc/", RPCEntryPoint.as_view(protocol=Protocol.XML_RPC)),


### PR DESCRIPTION
b/c everything is login-protected anyway!

Inspired by https://adamj.eu/tech/2020/02/10/robots-txt/ and https://neil-clarke.com/block-the-bots-that-feed-ai-models-by-scraping-your-website/