### PR TITLE
Do not execute Docker image tests as root

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -260,7 +260,15 @@ jobs:
       - name: Setup
         run: |
           sudo apt-get update
-          sudo apt-get install firefox wrk
+          sudo apt-get install firefox git make wrk
+
+          # install beakerlib from source it doesn't ship DEB packages
+          if [ ! -f "/usr/share/beakerlib/beakerlib.sh" ]; then
+              git clone https://github.com/beakerlib/beakerlib.git
+              sudo make -C beakerlib/ install
+          fi
+
+          pip install -r requirements/devel.txt
 
       - name: Docker version info
         run: |
@@ -272,7 +280,6 @@ jobs:
 
       - name: Execute tests
         run: |
-          pip install -r requirements/devel.txt
           make test-docker-image
           docker images
 

--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ docker-manifest:
 
 .PHONY: test-docker-image
 test-docker-image: docker-image
-	sudo --preserve-env env PATH=$$PATH ./tests/runner.sh
+	./tests/runner.sh
 
 .PHONY: docs
 docs:

--- a/tests/runner.sh
+++ b/tests/runner.sh
@@ -6,14 +6,6 @@
 rm -rf /var/tmp/beakerlib-*/
 export BEAKERLIB_JOURNAL=0
 
-# install beakerlib from source b/c beakerlib doesn't ship
-# .deb packages
-if [ ! -f "/usr/share/beakerlib/beakerlib.sh" ]; then
-    sudo apt-get update
-    sudo apt-get install git make
-    git clone https://github.com/beakerlib/beakerlib.git
-    make -C beakerlib/ install
-fi
 
 # execute test scripts
 ./tests/test_docker.sh


### PR DESCRIPTION
- because newer versions of Firefox and Chrome can't deal with that
- and because we shouldn't have to anyway

- move beakerlib setup inside GHA because this is where it belongs