### PR TITLE
Revert "Update django from 4.2.11 to 5.0.4"

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,7 +4,7 @@ allpairspy==2.5.1
 bleach==6.1.0
 bleach-allowlist==1.0.3
 defusedxml==0.7.1
-Django==5.0.4
+Django==4.2.11
 django-attachments==1.11
 django-colorfield==0.11.0
 django-contrib-comments==2.2.0


### PR DESCRIPTION
Django 5 seems to include some sort of inline JavaScript which is blocked by our Content-Security-Policy and causes the SimpleMDE editor not to render

This reverts commit 752aa84ecc7c10c3e748e4f9c8f54f1f020dce04.