### PR TITLE
Truncate TestCase.text length for Jira 1-click bug reports

### DIFF
--- a/tcms/issuetracker/base.py
+++ b/tcms/issuetracker/base.py
@@ -37,6 +37,16 @@ class IssueTrackerType:
         self.bug_system = bug_system
         self.request = request
 
+    @staticmethod
+    def truncate(in_str, max_length):
+        result = in_str
+
+        if max_length < len(in_str):
+            result = in_str[:max_length]
+            result += "\n... truncated ..."
+
+        return result
+
     @classmethod
     def bug_id_from_url(cls, url):
         """
@@ -74,11 +84,15 @@ class IssueTrackerType:
 
         return result
 
-    def _report_comment(self, execution, user=None):  # pylint: disable=no-self-use
+    def _report_comment(
+        self, execution, user=None, max_text_length=None
+    ):  # pylint: disable=no-self-use
         """
         Returns the comment which is used in the original defect report.
         """
         txt = execution.case.get_text_with_version(execution.case_text_version)
+        if max_text_length:
+            txt = self.truncate(txt, max_text_length)
 
         reporter = "Unknown"
         if user:

--- a/tcms/issuetracker/types.py
+++ b/tcms/issuetracker/types.py
@@ -40,6 +40,12 @@ class JIRA(IssueTrackerType):
     Additional control can be applied via the ``JIRA_OPTIONS`` configuration
     setting (in ``product.py``). By default this setting is not provided and
     the code uses ``jira.JIRA.DEFAULT_OPTIONS`` from the ``jira`` Python module!
+
+    .. warning::
+
+        ``TestCase.text`` will be truncated to 30k chars for automated POST
+        requests and 6k chars for fallback GET requests to fit inside Jira limitations.
+        Otherwise you may see 400, 414 and/or 500 errors!
     """
 
     def _rpc_connection(self):
@@ -137,7 +143,7 @@ class JIRA(IssueTrackerType):
                 project=project.id,
                 issuetype={"name": issue_type.name},
                 summary=f"Failed test: {execution.case.summary}",
-                description=self._report_comment(execution, user),
+                description=self._report_comment(execution, user, 30000),
             )
             new_url = self.bug_system.base_url + "/browse/" + new_issue.key
 
@@ -156,7 +162,7 @@ class JIRA(IssueTrackerType):
             "pid": project.id,
             "issuetype": issue_type.id,
             "summary": f"Failed test: {execution.case.summary}",
-            "description": self._report_comment(execution, user),
+            "description": self._report_comment(execution, user, 6000),
         }
 
         url = self.bug_system.base_url


### PR DESCRIPTION
text will be truncated to 30k chars for automated POST requests and 6k chars for fallback GET requests to fit inside Jira limitations.

Otherwise you may see 400, 414 and/or 500 errors!