### PR TITLE
Adjust angle bracket icon direction when viewing nested testplans

### DIFF
--- a/tcms/testplans/static/testplans/js/get.js
+++ b/tcms/testplans/static/testplans/js/get.js
@@ -127,6 +127,7 @@ function adjustTestPlanFamilyTree () {
     $('#test-plan-family-tree').find('.list-group-item.active').each(function (index, element) {
         $(element).parents('.list-group-item-container').each(function (idx, container) {
             $(container).toggleClass('hidden')
+            $(container).siblings('.list-group-item-header').find('.fa-angle-right').toggleClass('fa-angle-down')
         })
     })
 }


### PR DESCRIPTION
Fixes #3163

when viewing a test plan which is part of a tree structure all of its parents appear expended by default and the current TP is highlighted on the page. This commit adjusts the direction of the existing angle brackets icons to relfect this state and makes icons for parent test plans to point down, instead of right!