### PR TITLE
Enable EthicalAds

### DIFF
--- a/etc/nginx.conf
+++ b/etc/nginx.conf
@@ -63,7 +63,7 @@ http {
     }
 
     # WARNING: make sure these match tcms.core.middleware.ExtraHeadersMiddleware
-    add_header Content-Security-Policy "script-src 'self' cdn.crowdin.com plausible.io;";
+    add_header Content-Security-Policy "script-src 'self' cdn.crowdin.com *.ethicalads.io plausible.io;";
 
     server {
         listen       8080;

--- a/tcms/core/middleware.py
+++ b/tcms/core/middleware.py
@@ -29,7 +29,7 @@ class ExtraHeadersMiddleware(MiddlewareMixin):
     def process_response(self, request, response):
         if settings.DEBUG:
             response.headers["Content-Security-Policy"] = (
-                "script-src 'self' cdn.crowdin.com plausible.io;"
+                "script-src 'self' cdn.crowdin.com *.ethicalads.io plausible.io;"
             )
 
             if request.path.find("/uploads/") > -1:

--- a/tcms/templates/base.html
+++ b/tcms/templates/base.html
@@ -65,5 +65,6 @@
     <script src="{% static 'js/bundle.js' %}"></script>
 
     {% block contents %}{% endblock %}
+    {% include 'include/ads.html' %}
 </body>
 </html>

--- a/tcms/templates/include/ads.html
+++ b/tcms/templates/include/ads.html
@@ -1,0 +1,4 @@
+{% if not REQUEST_CONTENTS.nonav %}
+    <script async src="https://media.ethicalads.io/media/client/ethicalads.min.js"></script>
+    <div data-ea-publisher="kiwitcms-container" data-ea-type="text" data-ea-style="fixedfooter"></div>
+{% endif %}

--- a/tests/test_http.sh
+++ b/tests/test_http.sh
@@ -93,8 +93,8 @@ _EOF_
     rlPhaseEnd
 
     rlPhaseStartTest "Should send Content-Security-Policy header"
-        rlRun -t -c "curl -k -D- $HTTPS 2>/dev/null | grep $'Content-Security-Policy: script-src \'self\' cdn.crowdin.com plausible.io;'"
-        rlRun -t -c "curl -k -D- $PROXY 2>/dev/null | grep $'Content-Security-Policy: script-src \'self\' cdn.crowdin.com plausible.io;'"
+        rlRun -t -c "curl -k -D- $HTTPS 2>/dev/null | grep $'Content-Security-Policy: script-src \'self\' cdn.crowdin.com \*.ethicalads.io plausible.io;'"
+        rlRun -t -c "curl -k -D- $PROXY 2>/dev/null | grep $'Content-Security-Policy: script-src \'self\' cdn.crowdin.com \*.ethicalads.io plausible.io;'"
     rlPhaseEnd
 
     rlPhaseStartTest "Should not execute inline JavaScript"

--- a/tests/ui/test_upload_file.robot
+++ b/tests/ui/test_upload_file.robot
@@ -14,7 +14,7 @@ ${TEST_PLAN_URL}        ${SERVER}/plan/1/
 *** Test Cases ***
 Uploading file works via file upload
     Open Browser    ${LOGIN_URL}    ${BROWSER}
-    Maximize Browser Window
+    Set Window Size     3024    1890
     Set Selenium Speed    ${DELAY}
     Title Should Be    Kiwi TCMS - Login
 


### PR DESCRIPTION
- EthicalAds is a GDPR-compliant ad network for devs
- No cookie banners, and only dev-focused ads.