### PR TITLE
Refactor remove_link function to handle empty query in testexecution.py

### DIFF
--- a/tcms/rpc/api/testexecution.py
+++ b/tcms/rpc/api/testexecution.py
@@ -283,7 +283,8 @@ def remove_link(query):
                       :class:`tcms.core.contrib.linkreference.models.LinkReference`
         :type query: dict
     """
-    LinkReference.objects.filter(**query).delete()
+    if query:  # Ensure query is not empty
+        LinkReference.objects.filter(**query).delete()
 
 
 @permissions_required("linkreference.view_linkreference")

--- a/tcms/testruns/static/testruns/js/get.js
+++ b/tcms/testruns/static/testruns/js/get.js
@@ -920,9 +920,11 @@ export function bindDeleteLinkButton () {
         const row = $(event.target).parents('li')
         const linkId = $(event.target).parent('.js-remove-linkreference').data('link-id')
 
-        jsonRPC('TestExecution.remove_link', { pk: linkId }, () => {
-            $(row).fadeOut(500)
-        })
+        if (linkId) {
+            jsonRPC('TestExecution.remove_link', { pk: linkId }, () => {
+                $(row).fadeOut(500);
+            });
+        }
         return false
     })
 }


### PR DESCRIPTION
The remove_link function in testexecution.py has been refactored to handle the case where the query parameter is empty. This change ensures that the LinkReference objects are only deleted when the query is not empty, preventing any unintended deletions.