### PR TITLE
Update filter logic for Automated=False. Fixes #3841

### DIFF
--- a/tcms/testplans/static/testplans/js/get.js
+++ b/tcms/testplans/static/testplans/js/get.js
@@ -707,7 +707,7 @@ function filterTestCasesByProperty (planId, testCases, filterBy, filterValue) {
         })
     } else {
         testCases.filter(function (tc) {
-            return (tc[filterBy] && tc[filterBy].toString().toLowerCase().indexOf(filterValue) > -1)
+            return (tc[filterBy] !== undefined && tc[filterBy].toString().toLowerCase().indexOf(filterValue) > -1)
         }).forEach(tc => $(`[data-testcase-pk=${tc.id}]`).show())
     }
 }


### PR DESCRIPTION
the boolean expression tc[filterBy] was intended to check whether the requested field exists, as a way to avoid crashes in the case where we may have forgotten to update the code. However in the case when trying to search for manual test cases the raw value of this field is `false` which caused the entire expression to be evaulated as False and did not apply the filter.