### PR TITLE
Refactor request_contents_processor() to expose only data we use

### DIFF
--- a/tcms/core/context_processors.py
+++ b/tcms/core/context_processors.py
@@ -5,9 +5,14 @@ from django.utils import timezone
 
 def request_contents_processor(request):
     """
-    Django request contents RequestContext Handler
+    Exposes only values that we need, not everything!
     """
-    return {"REQUEST_CONTENTS": request.GET or request.POST}
+    data = request.GET or request.POST
+    return {
+        "REQUEST__ALLOW_SELECT": data.get("allow_select"),
+        "REQUEST__NEXT": data.get("next", ""),
+        "REQUEST__NONAV": data.get("nonav"),
+    }
 
 
 def settings_processor(_request):

--- a/tcms/templates/base.html
+++ b/tcms/templates/base.html
@@ -32,7 +32,7 @@
     {% block head %}{% endblock %}
 </head>
 <body id="{% block page_id %}{% endblock %}" class="{% block body_class %}{% endblock %}">
-    {% if not REQUEST_CONTENTS.nonav %}
+    {% if not REQUEST__NONAV %}
         {% include 'navbar.html' %}
     {% endif %}
 

--- a/tcms/templates/include/ads.html
+++ b/tcms/templates/include/ads.html
@@ -1,4 +1,4 @@
-{% if not REQUEST_CONTENTS.nonav %}
+{% if not REQUEST__NONAV %}
     <script async src="https://media.ethicalads.io/media/client/ethicalads.min.js"></script>
     <div data-ea-publisher="kiwitcms-container" data-ea-type="text" data-ea-style="fixedfooter"></div>
 {% endif %}

--- a/tcms/templates/registration/password_reset_form.html
+++ b/tcms/templates/registration/password_reset_form.html
@@ -9,7 +9,7 @@
     <div class="col-sm-7 col-md-6 col-lg-5 login">
       <form class="form-horizontal" role="form" action="{% url "tcms-password_reset" %}" method="POST">
         {% csrf_token %}
-        <input type="hidden" name="next" value="{{ REQUEST_CONTENTS.next }}" />
+        <input type="hidden" name="next" value="{{ REQUEST__NEXT }}" />
 
         <div class="form-group">
           {{ form.email.errors }}

--- a/tcms/testcases/templates/testcases/search.html
+++ b/tcms/testcases/templates/testcases/search.html
@@ -165,7 +165,7 @@
             </thead>
         </table>
 
-        {% if REQUEST_CONTENTS.allow_select %}
+        {% if REQUEST__ALLOW_SELECT %}
         <div class="form-group">
             <button id="select-btn" type="submit" class="btn btn-primary">{% trans "Select" %}</button>
         </div>


### PR DESCRIPTION
instead of the entire request contents. Otherwise this leads to traceback recursion in edge cases, for example when Kiwi TCMS is handling an error!