### PR TITLE
Revert "Bump django-colorfield from 0.12.0 to 0.13.0"

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,7 +6,7 @@ bleach-allowlist==1.0.3
 defusedxml==0.7.1
 Django==5.1.7
 django-attachments==1.11
-django-colorfield==0.13.0
+django-colorfield==0.12.0
 django-contrib-comments==2.2.0
 django-extensions==4.0
 django-grappelli==4.0.1


### PR DESCRIPTION
Reverts kiwitcms/Kiwi#3951 - breaks docker build