### PR TITLE
Refactor: use the public interface tcms_api.TCMS().exec in tests

### DIFF
--- a/tcms/rpc/tests/test_testcase.py
+++ b/tcms/rpc/tests/test_testcase.py
@@ -4,11 +4,11 @@
 import unittest
 from datetime import timedelta
 
+import tcms_api
 from attachments.models import Attachment
 from django.contrib.auth.models import Permission
 from django.core.exceptions import ValidationError
 from parameterized import parameterized
-from tcms_api import xmlrpc
 
 from tcms.core.helpers import comments
 from tcms.management.models import Priority
@@ -699,11 +699,11 @@ class TestAddTag(APITestCase):
         unauthorized_user.user_permissions.add(*Permission.objects.all())
         remove_perm_from_user(unauthorized_user, "testcases.add_testcasetag")
 
-        rpc_client = xmlrpc.TCMSXmlrpc(
+        rpc_client = tcms_api.TCMS(
+            f"{self.live_server_url}/xml-rpc/",
             unauthorized_user.username,
             "api-testing",
-            f"{self.live_server_url}/xml-rpc/",
-        ).server
+        ).exec
 
         with self.assertRaisesRegex(
             XmlRPCFault, 'Authentication failed when calling "TestCase.add_tag"'
@@ -742,11 +742,11 @@ class TestRemoveTag(APITestCase):
         unauthorized_user.user_permissions.add(*Permission.objects.all())
         remove_perm_from_user(unauthorized_user, "testcases.delete_testcasetag")
 
-        rpc_client = xmlrpc.TCMSXmlrpc(
+        rpc_client = tcms_api.TCMS(
+            f"{self.live_server_url}/xml-rpc/",
             unauthorized_user.username,
             "api-testing",
-            f"{self.live_server_url}/xml-rpc/",
-        ).server
+        ).exec
 
         with self.assertRaisesRegex(
             XmlRPCFault, 'Authentication failed when calling "TestCase.remove_tag"'

--- a/tcms/rpc/tests/test_testplan.py
+++ b/tcms/rpc/tests/test_testplan.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=attribute-defined-outside-init, invalid-name, objects-update-used
 
+import tcms_api
 from attachments.models import Attachment
 from django.contrib.auth.models import Permission
 from django.test import override_settings
-from tcms_api import xmlrpc
 
 from tcms.rpc.tests.utils import APIPermissionsTestCase, APITestCase
 from tcms.testcases.models import TestCasePlan
@@ -95,11 +95,11 @@ class TestAddTag(APITestCase):
         unauthorized_user.user_permissions.add(*Permission.objects.all())
         remove_perm_from_user(unauthorized_user, "testplans.add_testplantag")
 
-        rpc_client = xmlrpc.TCMSXmlrpc(
+        rpc_client = tcms_api.TCMS(
+            f"{self.live_server_url}/xml-rpc/",
             unauthorized_user.username,
             "api-testing",
-            f"{self.live_server_url}/xml-rpc/",
-        ).server
+        ).exec
 
         with self.assertRaisesRegex(
             XmlRPCFault, 'Authentication failed when calling "TestPlan.add_tag"'
@@ -144,11 +144,11 @@ class TestRemoveTag(APITestCase):
         unauthorized_user.user_permissions.add(*Permission.objects.all())
         remove_perm_from_user(unauthorized_user, "testplans.delete_testplantag")
 
-        rpc_client = xmlrpc.TCMSXmlrpc(
+        rpc_client = tcms_api.TCMS(
+            f"{self.live_server_url}/xml-rpc/",
             unauthorized_user.username,
             "api-testing",
-            f"{self.live_server_url}/xml-rpc/",
-        ).server
+        ).exec
 
         with self.assertRaisesRegex(
             XmlRPCFault, 'Authentication failed when calling "TestPlan.remove_tag"'

--- a/tcms/rpc/tests/test_testrun.py
+++ b/tcms/rpc/tests/test_testrun.py
@@ -3,10 +3,10 @@
 
 from datetime import datetime
 
+import tcms_api
 from attachments.models import Attachment
 from django.contrib.auth.models import Permission
 from django.utils.translation import gettext_lazy as _
-from tcms_api import xmlrpc
 
 from tcms.rpc.tests.utils import APIPermissionsTestCase, APITestCase
 from tcms.testcases.models import TestCaseStatus
@@ -70,11 +70,11 @@ class TestAddCase(APITestCase):
         unauthorized_user.user_permissions.add(*Permission.objects.all())
         remove_perm_from_user(unauthorized_user, "testruns.add_testexecution")
 
-        rpc_client = xmlrpc.TCMSXmlrpc(
+        rpc_client = tcms_api.TCMS(
+            f"{self.live_server_url}/xml-rpc/",
             unauthorized_user.username,
             "api-testing",
-            f"{self.live_server_url}/xml-rpc/",
-        ).server
+        ).exec
 
         with self.assertRaisesRegex(
             XmlRPCFault, 'Authentication failed when calling "TestRun.add_case"'
@@ -127,11 +127,11 @@ class TestRemovesCase(APITestCase):
         unauthorized_user.user_permissions.add(*Permission.objects.all())
         remove_perm_from_user(unauthorized_user, "testruns.delete_testexecution")
 
-        rpc_client = xmlrpc.TCMSXmlrpc(
+        rpc_client = tcms_api.TCMS(
+            f"{self.live_server_url}/xml-rpc/",
             unauthorized_user.username,
             "api-testing",
-            f"{self.live_server_url}/xml-rpc/",
-        ).server
+        ).exec
 
         with self.assertRaisesRegex(
             XmlRPCFault, 'Authentication failed when calling "TestRun.remove_case"'
@@ -254,11 +254,11 @@ class TestAddTag(APITestCase):
         unauthorized_user.user_permissions.add(*Permission.objects.all())
         remove_perm_from_user(unauthorized_user, "testruns.add_testruntag")
 
-        rpc_client = xmlrpc.TCMSXmlrpc(
+        rpc_client = tcms_api.TCMS(
+            f"{self.live_server_url}/xml-rpc/",
             unauthorized_user.username,
             "api-testing",
-            f"{self.live_server_url}/xml-rpc/",
-        ).server
+        ).exec
 
         with self.assertRaisesRegex(
             XmlRPCFault, 'Authentication failed when calling "TestRun.add_tag"'
@@ -327,11 +327,11 @@ class TestRemoveTag(APITestCase):
         unauthorized_user.user_permissions.add(*Permission.objects.all())
         remove_perm_from_user(unauthorized_user, "testruns.delete_testruntag")
 
-        rpc_client = xmlrpc.TCMSXmlrpc(
+        rpc_client = tcms_api.TCMS(
+            f"{self.live_server_url}/xml-rpc/",
             unauthorized_user.username,
             "api-testing",
-            f"{self.live_server_url}/xml-rpc/",
-        ).server
+        ).exec
 
         with self.assertRaisesRegex(
             XmlRPCFault, 'Authentication failed when calling "TestRun.remove_tag"'

--- a/tcms/rpc/tests/utils.py
+++ b/tcms/rpc/tests/utils.py
@@ -25,11 +25,11 @@ class APITestCase(test.LiveServerTestCase):
         initiate_user_with_default_setups(self.api_user)
 
         # this is the XML-RPC ServerProxy with cookies support
-        self.rpc_client = tcms_api.xmlrpc.TCMSXmlrpc(
+        self.rpc_client = tcms_api.TCMS(
+            f"{self.live_server_url}/xml-rpc/",
             self.api_user.username,
             "api-testing",
-            f"{self.live_server_url}/xml-rpc/",
-        ).server
+        ).exec
 
 
 class APIPermissionsTestCase(PermissionsTestMixin, test.LiveServerTestCase):
@@ -50,11 +50,11 @@ class APIPermissionsTestCase(PermissionsTestMixin, test.LiveServerTestCase):
         self.tester.save()
 
         # this is the XML-RPC ServerProxy with cookies support
-        self.rpc_client = tcms_api.xmlrpc.TCMSXmlrpc(
+        self.rpc_client = tcms_api.TCMS(
+            f"{self.live_server_url}/xml-rpc/",
             self.tester.username,
             "password",
-            f"{self.live_server_url}/xml-rpc/",
-        ).server
+        ).exec
 
     def verify_api_with_permission(self):
         """


### PR DESCRIPTION
as documented for the tcms-api package instead of internal classes whose implementation may change. The public interface also provides a workaround for SSL issues which sometimes present themselves when we have long running workflows (not present in the API test suite ATM).