### PR TITLE
Update Django from 5.1.8 to 5.1.9

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,7 +4,7 @@ allpairspy==2.5.1
 bleach==6.2.0
 bleach-allowlist==1.0.3
 defusedxml==0.7.1
-Django==5.1.8
+Django==5.1.9
 django-attachments==1.12
 django-colorfield==0.14.0
 django-contrib-comments==2.2.0


### PR DESCRIPTION
https://docs.djangoproject.com/en/5.1/releases/5.1.9/

CVE-2025-32873: Denial-of-service possibility in strip_tags()

not used in Kiwi TCMS