### PR TITLE
Remove newline at end of translation string

### DIFF
--- a/tcms/locale/en/LC_MESSAGES/django.po
+++ b/tcms/locale/en/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-09-03 14:17+0000\n"
+"POT-Creation-Date: 2025-09-04 06:51+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1383,10 +1383,10 @@ msgid ""
 "\n"
 "Default tester: %(default_tester)s\n"
 "Text:\n"
-"%(text)s\n"
+"%(text)s"
 msgstr ""
 
-#: tcms/testcases/helpers/email.py:63
+#: tcms/testcases/helpers/email.py:62
 #, python-format
 msgid "DELETED: TestCase #%(pk)d - %(summary)s"
 msgstr ""

--- a/tcms/testcases/helpers/email.py
+++ b/tcms/testcases/helpers/email.py
@@ -29,8 +29,7 @@ Priority: %(priority)s
 
 Default tester: %(default_tester)s
 Text:
-%(text)s
-"""
+%(text)s"""
         )
         % {
             "pk": case.pk,

--- a/tcms/testcases/tests/test_views.py
+++ b/tcms/testcases/tests/test_views.py
@@ -176,8 +176,7 @@ Priority: {test_case.priority}
 
 Default tester: {test_case.default_tester}
 Text:
-{test_case.text}
-"""
+{test_case.text}"""
 
         # Verify notification mail
         send_mail.assert_called_once_with(


### PR DESCRIPTION
b/c it breaks for Esperanto (b/c it is special) and causes errors:

Execution of msgfmt failed: /home/runner/work/Kiwi/Kiwi/tcms/locale/eo/LC_MESSAGES/django.po:1322: 'msgid' and 'msgstr' entries do not both end with '\n'
msgfmt: found 1 fatal error
Execution of msgfmt failed: /home/runner/work/Kiwi/Kiwi/tcms/locale/eo_UY/LC_MESSAGES/django.po:1322: 'msgid' and 'msgstr' entries do not both end with '\n'