### PR TITLE
Fix failing docker build by pinning pillow to 11.3.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -16,6 +16,8 @@ django-simple-history==3.10.1
 django-tree-queries==0.21.2
 jira==3.10.5
 Markdown==3.9
+# transient dependency of django-color-field/django-simple-captcha
+pillow==11.3.0
 PyGithub==2.8.1
 Pygments==2.19.2
 python-gitlab==6.4.0


### PR DESCRIPTION
version 12.0.0 was released on Oct 15th 2025 and is failing to install, seemingly b/c we can't build a wheel for one of its dependencies:

Collecting Pillow>=9.0.0 (from django-colorfield==0.14.0->kiwitcms==15.0)
  Downloading pillow-12.0.0.tar.gz (47.0 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 47.0/47.0 MB 85.1 MB/s  0:00:00
  Installing build dependencies: started
  Installing build dependencies: finished with status 'error'
  error: subprocess-exited-with-error

  .....

  ERROR: Failed building wheel for cmake