### PR TITLE
Revert "Bump psycopg[binary] from 3.2.10 to 3.2.11"

### DIFF
--- a/requirements/postgres.txt
+++ b/requirements/postgres.txt
@@ -1,2 +1,2 @@
 -r base.txt
-psycopg[binary]==3.2.11
+psycopg[binary]==3.2.10


### PR DESCRIPTION
Reverts kiwitcms/Kiwi#4147.

Initial PR looked good but suddenly every test with postgres started failing. 