### PR TITLE
Update node_modules/brace-expansion from 1.1.11 to 1.1.12

### DIFF
--- a/tcms/package-lock.json
+++ b/tcms/package-lock.json
@@ -1,9 +1,10 @@
 {
-  "name": "relock-npm-lock-v2-jzG3Ch",
+  "name": "tcms",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
+      "name": "tcms",
       "dependencies": {
         "bootstrap-duration-picker": "2.1.3",
         "bootstrap-switch": "3.3.4",
@@ -1194,10 +1195,11 @@
       "optional": true
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -6460,9 +6462,9 @@
       "optional": true
     },
     "brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",


### PR DESCRIPTION
in order to fix Regular Expression Denial of Service vulnerability, see https://github.com/advisories/GHSA-v6h2-p8h4-qcjw

This is part of Kiwi TCMS' development dependencies and not used in production. This dependency inclusion graph is:

tcms
├─┬ eslint-plugin-import@2.32.0
│ ├─┬ minimatch@3.1.2
│ │ └─┬ brace-expansion@1.1.12

which is part of our development dependencies and not used in production