### PR TITLE
Strip \n and \r characters from email subjects to avoid crashes

### DIFF
--- a/tcms/core/utils/mailto.py
+++ b/tcms/core/utils/mailto.py
@@ -30,6 +30,9 @@ def mailto(  # pylint: disable=invalid-name
     context=None,
     cc=None,
 ):
+    # no multi-line email headers
+    subject = subject.replace("\n", " ").replace("\r", " ")
+
     # make a list with recipients and filter out duplicates
     if isinstance(recipients, list):
         recipients = list(set(recipients))


### PR DESCRIPTION
Fixes Sentry KIWI-TCMS-P7, https://kiwitcms.sentry.io/issues/5547586648/