### PR TITLE
Improvement on navigation across all views

### DIFF
--- a/tcms/bugs/templates/bugs/get.html
+++ b/tcms/bugs/templates/bugs/get.html
@@ -17,6 +17,9 @@
 
 {% block contents %}
 <div class="container-cards-pf">
+    {% trans "Bugs" as bugs_breadcrumb_label %}
+    {% include "include/breadcrumbs.html" with search_url="bugs-search" search_label=bugs_breadcrumb_label view_url="bugs-get" object_label="BUG-" current_view="view" %}
+    {% include "include/page_toolbar.html" with current_view="view" view_url="bugs-get" edit_url="bugs-edit" new_url="bugs-new" search_url="bugs-search" admin_url_prefix="bugs/bug" show_actions=True edit_perm=perms.bugs.change_bug add_perm=perms.bugs.add_bug delete_perm=perms.bugs.delete_bug admin_perm=perms.bugs.change_bug %}
     <!-- Important:  if you need to nest additional .row within a .row.row-cards-pf, do *not* use .row-cards-pf on the nested .row  -->
     <h1 class="col-md-12 kiwi-margin-top-0">
         {% if bug.severity %}
@@ -86,7 +89,12 @@
                     {{ object.build }}
                 </h2>
 
-                <div class="card-pf-body"></div>
+                <h2 class="card-pf-title kiwi-text-align-left">
+                    <span class="fa fa-exchange"></span>{% trans 'Related' %}
+                </h2>
+                <div class="card-pf-body">
+                    <a href="{% url 'testruns-search' %}?product={{ object.product_id }}">{% trans 'Test runs for this product' %}</a>
+                </div>
             </div>
         </div>
 

--- a/tcms/bugs/templates/bugs/mutable.html
+++ b/tcms/bugs/templates/bugs/mutable.html
@@ -13,6 +13,9 @@
 
 {% block contents %}
     <div class="container-fluid container-cards-pf">
+        {% trans "Bugs" as bugs_breadcrumb_label %}
+        {% include "include/breadcrumbs.html" with search_url="bugs-search" search_label=bugs_breadcrumb_label view_url="bugs-get" object_label="BUG-" current_view=object|yesno:"edit,new" %}
+        {% include "include/page_toolbar.html" with current_view=object|yesno:"edit,new" view_url="bugs-get" edit_url="bugs-edit" new_url="bugs-new" search_url="bugs-search" edit_perm=perms.bugs.change_bug add_perm=perms.bugs.add_bug %}
         <form class="form-horizontal" action="{{ form_post_url }}" method="post">
             {% csrf_token %}
             <input type="hidden" name="reporter" value="{{ form.reporter.value }}">
@@ -110,8 +113,10 @@
         {% endif %}
 
             <div class="form-group">
-                <div class="col-md-1 col-lg-1">
-                    <button type="submit" class="btn btn-default btn-lg">{% trans "Save" %}</button>
+                <div class="col-md-12 col-lg-12">
+                    <a href="{% if object %}{% url 'bugs-get' object.pk %}{% else %}{% url 'core-views-index' %}{% endif %}"
+                        class="btn btn-danger btn-lg">{% trans "Cancel" %}</a>
+                    <button type="submit" class="btn btn-primary btn-lg">{% trans "Save" %}</button>
                 </div>
             </div>
         </form>

--- a/tcms/bugs/templates/bugs/search.html
+++ b/tcms/bugs/templates/bugs/search.html
@@ -11,6 +11,7 @@
      data-trans-no-records-found="{% trans 'No records found' %}"
      data-trans-x-records-found="{% trans 'Found _TOTAL_ records' %}"
 >
+    {% include "include/page_toolbar.html" with current_view="search" new_url="bugs-new" search_url="bugs-search" add_perm=perms.bugs.add_bug %}
     <form class="form-horizontal" method="get">
         {% csrf_token %}
         <div class="form-group">

--- a/tcms/static/style/patternfly_override.css
+++ b/tcms/static/style/patternfly_override.css
@@ -155,6 +155,17 @@ input[type="submit"].grp-warning {
     cursor: pointer;
 }
 
+/* Danger pill variant for Delete action in page toolbar */
+.nav-pills > li.kiwi-pill-danger > a {
+    color: #cc0000;
+}
+
+.nav-pills > li.kiwi-pill-danger > a:hover,
+.nav-pills > li.kiwi-pill-danger > a:focus {
+    background-color: #cc0000;
+    color: #fff;
+}
+
 .dataTables_info {
     display: inline;
 }

--- a/tcms/telemetry/templates/telemetry/include/nav.html
+++ b/tcms/telemetry/templates/telemetry/include/nav.html
@@ -1,0 +1,29 @@
+{% load i18n %}
+
+<ul class="nav nav-tabs">
+    <li {% if active_tab == "breakdown" %}class="active"{% endif %}>
+        <a href="{% url 'testing-breakdown' %}">
+            <span class="fa fa-pie-chart"></span> {% trans "Breakdown" %}
+        </a>
+    </li>
+    <li {% if active_tab == "dashboard" %}class="active"{% endif %}>
+        <a href="{% url 'execution-dashboard' %}">
+            <span class="fa fa-table"></span> {% trans "Dashboard" %}
+        </a>
+    </li>
+    <li {% if active_tab == "matrix" %}class="active"{% endif %}>
+        <a href="{% url 'testing-status-matrix' %}">
+            <span class="fa fa-th"></span> {% trans "Matrix" %}
+        </a>
+    </li>
+    <li {% if active_tab == "trends" %}class="active"{% endif %}>
+        <a href="{% url 'testing-execution-trends' %}">
+            <span class="fa fa-line-chart"></span> {% trans "Trends" %}
+        </a>
+    </li>
+    <li {% if active_tab == "health" %}class="active"{% endif %}>
+        <a href="{% url 'test-case-health' %}">
+            <span class="fa fa-heartbeat"></span> {% trans "TestCase health" %}
+        </a>
+    </li>
+</ul>

--- a/tcms/telemetry/templates/telemetry/testing/breakdown.html
+++ b/tcms/telemetry/templates/telemetry/testing/breakdown.html
@@ -7,6 +7,7 @@
 
 {% block contents %}
     <div class="container-fluid container-cards-pf">
+        {% include "telemetry/include/nav.html" with active_tab="breakdown" %}
         {% include "telemetry/include/filters.html" %}
 
         <div class="col-md-3 kiwi-text-align-center">

--- a/tcms/telemetry/templates/telemetry/testing/execution-dashboard.html
+++ b/tcms/telemetry/templates/telemetry/testing/execution-dashboard.html
@@ -11,6 +11,7 @@
          data-trans-no-records-found="{% trans 'No records found' %}"
          data-trans-x-records-found="{% trans 'Found _TOTAL_ records' %}"
     >
+        {% include "telemetry/include/nav.html" with active_tab="dashboard" %}
         {% include "telemetry/include/filters.html" %}
 
         <form class="form-horizontal">

--- a/tcms/telemetry/templates/telemetry/testing/execution-trends.html
+++ b/tcms/telemetry/templates/telemetry/testing/execution-trends.html
@@ -7,6 +7,7 @@
 
 {% block contents %}
     <div class="container-fluid container-cards-pf main" data-total-key="{% trans 'TOTAL' %}">
+        {% include "telemetry/include/nav.html" with active_tab="trends" %}
         {% include "telemetry/include/filters.html" %}
 
         <div class="passing-rate-summary">

--- a/tcms/telemetry/templates/telemetry/testing/status-matrix.html
+++ b/tcms/telemetry/templates/telemetry/testing/status-matrix.html
@@ -7,6 +7,7 @@
 
 {% block contents %}
     <div class="container-fluid container-cards-pf">
+        {% include "telemetry/include/nav.html" with active_tab="matrix" %}
         {% include "telemetry/include/filters.html" %}
 
         <form class="form-horizontal">

--- a/tcms/telemetry/templates/telemetry/testing/test-case-health.html
+++ b/tcms/telemetry/templates/telemetry/testing/test-case-health.html
@@ -7,6 +7,7 @@
 
 {% block contents %}
     <div class="container-fluid container-cards-pf">
+        {% include "telemetry/include/nav.html" with active_tab="health" %}
         {% include "telemetry/include/filters.html" %}
 
         <h2>{% trans "Most frequently failing test cases" %}</h2>

--- a/tcms/templates/include/breadcrumbs.html
+++ b/tcms/templates/include/breadcrumbs.html
@@ -1,0 +1,14 @@
+{% load i18n %}
+
+<ol class="breadcrumb">
+    <li><a href="{% url 'core-views-index' %}">{% trans "Dashboard" %}</a></li>
+    <li><a href="{% url search_url %}">{{ search_label }}</a></li>
+    {% if current_view == "view" %}
+        <li class="active">{{ object_label }}{{ object.pk }}: {{ object }}</li>
+    {% elif current_view == "edit" %}
+        <li><a href="{% url view_url object.pk %}">{{ object_label }}{{ object.pk }}: {{ object }}</a></li>
+        <li class="active">{% trans "Edit" %}</li>
+    {% elif current_view == "new" %}
+        <li class="active">{% trans "New" %}</li>
+    {% endif %}
+</ol>

--- a/tcms/templates/include/page_toolbar.html
+++ b/tcms/templates/include/page_toolbar.html
@@ -1,0 +1,87 @@
+{% load i18n %}
+
+<div class="well well-sm clearfix">
+    <ul class="nav nav-pills pull-left">
+        {% if view_url and object %}
+        <li {% if current_view == "view" %}class="active"{% endif %}>
+            <a href="{% url view_url object.pk %}">
+                <span class="fa fa-eye"></span> {% trans "View" %}
+            </a>
+        </li>
+        {% endif %}
+
+        {% if edit_url and object %}
+            {% if edit_perm %}
+            <li {% if current_view == "edit" %}class="active"{% endif %}>
+                <a href="{% url edit_url object.pk %}">
+                    <span class="fa fa-pencil"></span> {% trans "Edit" %}
+                </a>
+            </li>
+            {% endif %}
+        {% endif %}
+
+        {% if new_url %}
+            {% if add_perm %}
+            <li {% if current_view == "new" %}class="active"{% endif %}>
+                <a href="{% url new_url %}">
+                    <span class="fa fa-plus"></span> {% trans "New" %}
+                </a>
+            </li>
+            {% endif %}
+        {% endif %}
+
+        {% if search_url %}
+        <li {% if current_view == "search" %}class="active"{% endif %}>
+            <a href="{% url search_url %}">
+                <span class="fa fa-search"></span> {% trans "Search" %}
+            </a>
+        </li>
+        {% endif %}
+    </ul>
+
+    {% if show_actions and object %}
+    <ul class="nav nav-pills pull-right">
+        {% if tc_clone %}
+            {% if add_perm %}
+            <li>
+                <a href="{% url 'testcases-clone' %}?c={{ object.pk }}" title="{% trans 'Clone' %}">
+                    <span class="fa fa-clone"></span> {% trans "Clone" %}
+                </a>
+            </li>
+            {% endif %}
+        {% elif clone_url %}
+            {% if add_perm %}
+            <li>
+                <a href="{% url clone_url object.pk %}" title="{% trans 'Clone' %}">
+                    <span class="fa fa-clone"></span> {% trans "Clone" %}
+                </a>
+            </li>
+            {% endif %}
+        {% endif %}
+
+        {% if admin_url_prefix and show_history %}
+        <li>
+            <a href="/admin/{{ admin_url_prefix }}/{{ object.pk }}/history/" title="{% trans 'History' %}">
+                <span class="fa fa-history"></span> {% trans "History" %}
+            </a>
+        </li>
+        {% endif %}
+
+        {% if admin_perm %}
+        <li>
+            <a href="/admin/{{ admin_url_prefix }}/{{ object.pk }}/change/" title="{% trans 'Permissions' %}">
+                <span class="fa fa-lock"></span> {% trans "Admin" %}
+            </a>
+        </li>
+        {% endif %}
+
+        {% if delete_perm %}
+        <li class="kiwi-pill-danger">
+            <a href="/admin/{{ admin_url_prefix }}/{{ object.pk }}/delete/" title="{% trans 'Delete' %}">
+                <span class="fa fa-trash-o"></span> {% trans "Delete" %}
+            </a>
+        </li>
+        {% endif %}
+    </ul>
+    {% endif %}
+</div>

--- a/tcms/templates/navbar.html
+++ b/tcms/templates/navbar.html
@@ -88,6 +88,17 @@
                             <a href="{% url "plans-search" %}?author={{ user.username }}" target="_parent">{% trans "My Test Plans" %}</a>
                         </li>
 
+                        <li>
+                            <a href="{% url "testcases-search" %}?author={{ user.username }}" target="_parent">{% trans "My Test Cases" %}</a>
+                        </li>
+
+                        {% url "bugs-search" as bugs_search_url %}
+                        {% if bugs_search_url %}
+                        <li>
+                            <a href="{{ bugs_search_url }}?reporter={{ user.username }}" target="_parent">{% trans "My Bugs" %}</a>
+                        </li>
+                        {% endif %}
+
                         <li class="divider"></li>
 
                         <li>

--- a/tcms/templates/registration/registration_form.html
+++ b/tcms/templates/registration/registration_form.html
@@ -53,6 +53,15 @@
             <button type="submit" class="btn btn-primary btn-lg" tabindex="5">{% trans "Register" %}</button>
           </div>
         </div>
+
+        <div class="form-group">
+          <div class="col-xs-12 col-sm-offset-2 col-sm-10 col-md-offset-2 col-md-10">
+            <span class="help-block">
+                {% trans "Already have an account?" %}
+                <a href="{% url 'tcms-login' %}">{% trans "Log in" %}</a>
+            </span>
+          </div>
+        </div>
       </form>
 </div>
 {% endblock %}

--- a/tcms/testcases/templates/testcases/get.html
+++ b/tcms/testcases/templates/testcases/get.html
@@ -10,6 +10,9 @@
 
 {% block contents %}
 <div class="container-cards-pf">
+    {% trans "Test Cases" as tc_breadcrumb_label %}
+    {% include "include/breadcrumbs.html" with search_url="testcases-search" search_label=tc_breadcrumb_label view_url="testcases-get" object_label="TC-" current_view="view" %}
+    {% include "include/page_toolbar.html" with current_view="view" view_url="testcases-get" edit_url="testcases-edit" new_url="testcases-new" search_url="testcases-search" tc_clone=True admin_url_prefix="testcases/testcase" show_actions=True show_history=True edit_perm=perms.testcases.change_testcase add_perm=perms.testcases.add_testcase delete_perm=perms.testcases.delete_testcase admin_perm=perms.testcases.change_testcase %}
     <!-- Important:  if you need to nest additional .row within a .row.row-cards-pf, do *not* use .row-cards-pf on the nested .row  -->
     <h1 class="col-md-12 kiwi-margin-top-0">
         <span id="test_case_pk"
@@ -118,7 +121,12 @@
                     {% endif %}
                 </h2>
 
-                <div class="card-pf-body"></div>
+                <h2 class="card-pf-title kiwi-text-align-left">
+                    <span class="fa fa-exchange"></span>{% trans 'Related' %}
+                </h2>
+                <div class="card-pf-body">
+                    <a href="{% url 'testruns-search' %}?case={{ object.pk }}">{% trans 'Test runs with this case' %}</a>
+                </div>
             </div>
         </div>
 

--- a/tcms/testcases/templates/testcases/mutable.html
+++ b/tcms/testcases/templates/testcases/mutable.html
@@ -17,6 +17,9 @@
 
 {% block contents %}
     <div class="container-fluid container-cards-pf">
+        {% trans "Test Cases" as tc_breadcrumb_label %}
+        {% include "include/breadcrumbs.html" with search_url="testcases-search" search_label=tc_breadcrumb_label view_url="testcases-get" object_label="TC-" current_view=object|yesno:"edit,new" %}
+        {% include "include/page_toolbar.html" with current_view=object|yesno:"edit,new" view_url="testcases-get" edit_url="testcases-edit" new_url="testcases-new" search_url="testcases-search" edit_perm=perms.testcases.change_testcase add_perm=perms.testcases.add_testcase %}
         <form class="form-horizontal" action="{% if object %}{% url 'testcases-edit' object.pk %}{% else %}{% url 'testcases-new' %}{% endif %}" method="post">
             {% csrf_token %}
             <input type="hidden" name="author" value="{{ form.author.value }}">

--- a/tcms/testcases/templates/testcases/search.html
+++ b/tcms/testcases/templates/testcases/search.html
@@ -11,6 +11,7 @@
      data-trans-no-records-found="{% trans 'No records found' %}"
      data-trans-x-records-found="{% trans 'Found _TOTAL_ records' %}"
 >
+    {% include "include/page_toolbar.html" with current_view="search" new_url="testcases-new" search_url="testcases-search" add_perm=perms.testcases.add_testcase %}
     <form class="form-horizontal" method="get">
         {% csrf_token %}
         <div class="form-group">

--- a/tcms/testplans/templates/testplans/get.html
+++ b/tcms/testplans/templates/testplans/get.html
@@ -10,6 +10,9 @@
 
 {% block contents %}
 <div class="container-cards-pf">
+    {% trans "Test Plans" as tp_breadcrumb_label %}
+    {% include "include/breadcrumbs.html" with search_url="plans-search" search_label=tp_breadcrumb_label view_url="test_plan_url" object_label="TP-" current_view="view" %}
+    {% include "include/page_toolbar.html" with current_view="view" view_url="test_plan_url" edit_url="plan-edit" new_url="plans-new" search_url="plans-search" clone_url="plans-clone" admin_url_prefix="testplans/testplan" show_actions=True show_history=True edit_perm=perms.testplans.change_testplan add_perm=perms.testplans.add_testplan delete_perm=perms.testplans.delete_testplan admin_perm=perms.testplans.change_testplan %}
     <!-- Important:  if you need to nest additional .row within a .row.row-cards-pf, do *not* use .row-cards-pf on the nested .row  -->
     <h1 class="col-md-12 kiwi-margin-top-0">
         {% if not object.is_active %}<s>{% endif %}
@@ -87,6 +90,14 @@
 
                 <div class="card-pf-body">
                     {{ object.tree_view_html|safe }}
+                </div>
+
+                <h2 class="card-pf-title kiwi-text-align-left">
+                    <span class="fa fa-exchange"></span>{% trans 'Related' %}
+                </h2>
+                <div class="card-pf-body">
+                    <a href="{% url 'testcases-search' %}?plan={{ object.pk }}">{% trans 'Test cases in this plan' %}</a><br>
+                    <a href="{% url 'testruns-search' %}?plan={{ object.pk }}">{% trans 'Test runs for this plan' %}</a>
                 </div>
             </div>
         </div>

--- a/tcms/testplans/templates/testplans/mutable.html
+++ b/tcms/testplans/templates/testplans/mutable.html
@@ -17,6 +17,9 @@
 
 {% block contents %}
     <div class="container-fluid container-cards-pf">
+        {% trans "Test Plans" as tp_breadcrumb_label %}
+        {% include "include/breadcrumbs.html" with search_url="plans-search" search_label=tp_breadcrumb_label view_url="test_plan_url" object_label="TP-" current_view=object|yesno:"edit,new" %}
+        {% include "include/page_toolbar.html" with current_view=object|yesno:"edit,new" view_url="test_plan_url" edit_url="plan-edit" new_url="plans-new" search_url="plans-search" edit_perm=perms.testplans.change_testplan add_perm=perms.testplans.add_testplan %}
         <form class="form-horizontal" action="{% if object %}{% url 'plan-edit' object.pk %}{% else %}{% url 'plans-new' %}{% endif %}" method="post">
             {% csrf_token %}
             <input type="hidden" name="author" value="{{ form.author.value }}">
@@ -168,8 +171,10 @@
             </div>
 
             <div class="form-group">
-                <div class="col-md-1 col-lg-1">
-                    <button type="submit" class="btn btn-default btn-lg">{% trans "Save" %}</button>
+                <div class="col-md-12 col-lg-12">
+                    <a href="{% if object %}{% url 'test_plan_url' object.pk %}{% else %}{% url 'core-views-index' %}{% endif %}"
+                        class="btn btn-danger btn-lg">{% trans "Cancel" %}</a>
+                    <button type="submit" class="btn btn-primary btn-lg">{% trans "Save" %}</button>
                 </div>
             </div>
         </form>

--- a/tcms/testplans/templates/testplans/search.html
+++ b/tcms/testplans/templates/testplans/search.html
@@ -13,6 +13,7 @@
     data-trans-no-records-found="{% trans 'No records found' %}"
     data-trans-x-records-found="{% trans 'Found _TOTAL_ records' %}"
 >
+    {% include "include/page_toolbar.html" with current_view="search" new_url="plans-new" search_url="plans-search" add_perm=perms.testplans.add_testplan %}
     <form class="form-horizontal" method="get">
         {% csrf_token %}
 

--- a/tcms/testruns/templates/testruns/get.html
+++ b/tcms/testruns/templates/testruns/get.html
@@ -10,6 +10,9 @@
 
 {% block contents %}
 <div class="container-cards-pf">
+    {% trans "Test Runs" as tr_breadcrumb_label %}
+    {% include "include/breadcrumbs.html" with search_url="testruns-search" search_label=tr_breadcrumb_label view_url="testruns-get" object_label="TR-" current_view="view" %}
+    {% include "include/page_toolbar.html" with current_view="view" view_url="testruns-get" edit_url="testruns-edit" new_url="testruns-new" search_url="testruns-search" clone_url="testruns-clone" admin_url_prefix="testruns/testrun" show_actions=True show_history=True edit_perm=perms.testruns.change_testrun add_perm=perms.testruns.add_testrun delete_perm=perms.testruns.delete_testrun admin_perm=perms.testruns.change_testrun %}
     <!-- Important:  if you need to nest additional .row within a .row.row-cards-pf, do *not* use .row-cards-pf on the nested .row  -->
     <h1 class="col-md-12 kiwi-margin-top-0" {% if object.stop_date %}style="text-decoration: line-through"{% endif %}>
         <span id="test_run_pk"
@@ -105,7 +108,12 @@
                     {% endif %}
                 </h2>
 
-                <div class="card-pf-body"></div>
+                <h2 class="card-pf-title kiwi-text-align-left">
+                    <span class="fa fa-exchange"></span>{% trans 'Related' %}
+                </h2>
+                <div class="card-pf-body">
+                    <a href="{% url 'testcases-search' %}?plan={{ object.plan_id }}">{% trans 'Test cases in test plan' %}</a>
+                </div>
             </div>
         </div>
 

--- a/tcms/testruns/templates/testruns/mutable.html
+++ b/tcms/testruns/templates/testruns/mutable.html
@@ -16,6 +16,9 @@
 
 {% block contents %}
 <div class="container-fluid container-cards-pf">
+    {% trans "Test Runs" as tr_breadcrumb_label %}
+    {% include "include/breadcrumbs.html" with search_url="testruns-search" search_label=tr_breadcrumb_label view_url="testruns-get" object_label="TR-" current_view=object|yesno:"edit,new" %}
+    {% include "include/page_toolbar.html" with current_view=object|yesno:"edit,new" view_url="testruns-get" edit_url="testruns-edit" new_url="testruns-new" search_url="testruns-search" edit_perm=perms.testruns.change_testrun add_perm=perms.testruns.add_testrun %}
     <form class="form-horizontal" action="{% if object %}{% url 'testruns-edit' object.pk %}{% else %}{% url 'testruns-new' %}{% endif %}" method="post">
         {% csrf_token %}
 
@@ -206,8 +209,10 @@
         </div>
 
         <div class="form-group">
-            <div class="col-md-1 col-lg-1">
-                <button type="submit" class="btn btn-default btn-lg">{% trans "Save" %}</button>
+            <div class="col-md-12 col-lg-12">
+                <a href="{% if object %}{% url 'testruns-get' object.pk %}{% else %}{% url 'core-views-index' %}{% endif %}"
+                    class="btn btn-danger btn-lg">{% trans "Cancel" %}</a>
+                <button type="submit" class="btn btn-primary btn-lg">{% trans "Save" %}</button>
             </div>
         </div>
 

--- a/tcms/testruns/templates/testruns/search.html
+++ b/tcms/testruns/templates/testruns/search.html
@@ -11,6 +11,7 @@
      data-trans-no-records-found="{% trans 'No records found' %}"
      data-trans-x-records-found="{% trans 'Found _TOTAL_ records' %}"
 >
+    {% include "include/page_toolbar.html" with current_view="search" new_url="testruns-new" search_url="testruns-search" add_perm=perms.testruns.add_testrun %}
     <form class="form-horizontal" method="get">
         {% csrf_token %}
 


### PR DESCRIPTION
Hello,

this is my PR related to navigations throughout the tcms.
The background of having this update is the difficulties I found during my first use on the tcms and i found a little confused on how I go around the menus. 

I hope this PR can be useful.


Below are the updates that I propose: 

### Add page toolbar with New/Search pills to all search pages. 
<img width="1855" height="432" alt="opera_Fl435mpoYX" src="https://github.com/user-attachments/assets/6b29e04e-b583-4dce-987b-6999e4a6c423" />


### Add breadcrumbs (Dashboard > Search > Entity) to all detail, edit and create pages. 
<img width="1854" height="512" alt="opera_weiMjp6C0H" src="https://github.com/user-attachments/assets/5e662992-24e8-4270-b560-01570ba8eeb9" />

### Add telemetry sub-nav tabs. 
<img width="1850" height="637" alt="opera_p62fnKvVoC" src="https://github.com/user-attachments/assets/7e60a6c3-e714-49c0-b0d0-6404dbb4a767" />

### Add related links in detail page sidebars. 
<img width="451" height="379" alt="image" src="https://github.com/user-attachments/assets/65a6e11a-a0b8-4a06-ab90-ecf14af22f39" />


### Add cancel buttons and consistent Save styling on edit/create forms.
<img width="1154" height="261" alt="image" src="https://github.com/user-attachments/assets/14bffd23-9a1d-4832-ac9a-1faa94eed361" />


### Add "My Test Cases" and "My Bugs" shortcuts to user dropdown menu. 

<img width="212" height="311" alt="opera_3pCKjcSwrW" src="https://github.com/user-attachments/assets/75baba23-e83d-4456-9fac-0a7d76447278" />



### Add "Already have an account? Log in" link to registration page. 

<img width="1213" height="634" alt="image" src="https://github.com/user-attachments/assets/f7aea22f-b6d7-4976-921b-1923517750c3" />


### Unify toolbar action buttons (Clone, History, Admin, Delete) to use nav-pills style matching View/Edit/New/Search pills, with a kiwi-pill-danger variant for the Delete action.

<img width="1840" height="654" alt="opera_Qcqp9WBSFy" src="https://github.com/user-attachments/assets/1df04c10-b9f3-457d-89ea-03f60d6d7ecb" />

<img width="1835" height="590" alt="opera_oEfb9IqVWw" src="https://github.com/user-attachments/assets/d7f81617-a946-43b2-adfe-45fcda309c9c" />

<img width="1838" height="451" alt="opera_iWx3JODaTS" src="https://github.com/user-attachments/assets/422e9273-ddf9-43f4-ae8b-df1eec5b4048" />
