### PR TITLE
Add last modified date to TestCase and TestPlan

### DIFF
--- a/tcms/testcases/static/testcases/js/search.js
+++ b/tcms/testcases/static/testcases/js/search.js
@@ -157,6 +157,7 @@ export function pageTestcasesSearchReadyHandler () {
                 }
             },
             { data: 'create_date' },
+            { data: 'last_modified' },
             { data: 'category__name' },
             { data: 'component_names' },
             { data: 'priority__value' },

--- a/tcms/testcases/templates/testcases/get.html
+++ b/tcms/testcases/templates/testcases/get.html
@@ -70,6 +70,11 @@
                 </h2>
 
                 <h2 class="card-pf-title kiwi-text-align-left">
+                    <span class="fa fa-pencil"></span>{% trans 'Last modified' %}:
+                    {{ last_modified }}
+                </h2>
+
+                <h2 class="card-pf-title kiwi-text-align-left">
                     <span class="fa fa-clock-o"></span>{% trans 'Setup duration' %}:
                     {{ object.setup_duration|default:"-" }}
                 </h2>

--- a/tcms/testcases/templates/testcases/search.html
+++ b/tcms/testcases/templates/testcases/search.html
@@ -165,6 +165,7 @@
                     <th>{% trans "ID" %}</th>
                     <th>{% trans "Summary" %}</th>
                     <th>{% trans "Created on" %}</th>
+                    <th>{% trans "Last modified" %}</th>
                     <th>{% trans "Category" %}</th>
                     <th>{% trans "Component" %}</th>
                     <th>{% trans "Priority" %}</th>

--- a/tcms/testcases/views.py
+++ b/tcms/testcases/views.py
@@ -125,6 +125,11 @@ class TestCaseGetView(DetailView):
         context["executions"] = self.object.executions.select_related(
             "run", "tested_by", "assignee", "case", "status"
         ).order_by("run__plan", "run")
+        context["last_modified"] = (
+            self.object.history.latest().history_date
+            if self.object.history.exists()
+            else self.object.create_date
+        )
         context["OBJECT_MENU_ITEMS"] = [
             (
                 "...",

--- a/tcms/testplans/static/testplans/js/search.js
+++ b/tcms/testplans/static/testplans/js/search.js
@@ -117,6 +117,7 @@ export function pageTestplansSearchReadyHandler () {
                 }
             },
             { data: 'create_date' },
+            { data: 'last_modified' },
             { data: 'product__name' },
             { data: 'product_version__value' },
             { data: 'type__name' },

--- a/tcms/testplans/templates/testplans/get.html
+++ b/tcms/testplans/templates/testplans/get.html
@@ -60,6 +60,11 @@
                 </h2>
 
                 <h2 class="card-pf-title kiwi-text-align-left">
+                    <span class="fa fa-pencil"></span>{% trans 'Last modified' %}:
+                    {{ last_modified }}
+                </h2>
+
+                <h2 class="card-pf-title kiwi-text-align-left">
                 <span id="product_pk"
                       class="fa fa-shopping-cart"></span>{% trans 'Product' %}:
                     <a href="{% url "plans-search" %}?product={{ object.product_id }}"

--- a/tcms/testplans/templates/testplans/search.html
+++ b/tcms/testplans/templates/testplans/search.html
@@ -116,6 +116,7 @@
                     <th>{% trans "ID" %}</th>
                     <th>{% trans "Test plan" %}</th>
                     <th>{% trans "Created on" %}</th>
+                    <th>{% trans "Last modified" %}</th>
                     <th>{% trans "Product" %}</th>
                     <th>{% trans "Version" %}</th>
                     <th>{% trans "Type" %}</th>

--- a/tcms/testplans/views.py
+++ b/tcms/testplans/views.py
@@ -136,6 +136,11 @@ class TestPlanGetView(DetailView):
         context["test_runs"] = TestRun.objects.filter(
             plan_id=self.object.pk, stop_date__isnull=True
         ).order_by("-id")[:5]
+        context["last_modified"] = (
+            self.object.history.latest().history_date
+            if self.object.history.exists()
+            else self.object.create_date
+        )
         context["OBJECT_MENU_ITEMS"] = [
             (
                 "...",


### PR DESCRIPTION
- Add updated_at field to both models with migrations. 
- Show last modified date in detail view sidebars and search result tables. 
- Expose updated_at via RPC API filter and update responses.
- If the entry never been modified yet, use created date on the modified date


implements #4140 

---

### Screenshots

<img width="1835" height="741" alt="image" src="https://github.com/user-attachments/assets/3eb5b7c3-cbbc-499a-a41e-9076a67ee59f" />

<img width="1855" height="852" alt="opera_n4Krs0xbOt" src="https://github.com/user-attachments/assets/bbfea9ba-1c61-488d-8678-a62926eb3f53" />

<img width="1834" height="397" alt="opera_NJvRzpuVii" src="https://github.com/user-attachments/assets/24485ed0-f107-4527-97fb-959abc1ba1ec" />

<img width="1854" height="580" alt="opera_bTBkccZ3eD" src="https://github.com/user-attachments/assets/917460e2-5f6a-457c-9770-56e9c4519aae" />
