### PR TITLE
Track tag add/remove operations in change history

### DIFF
--- a/tcms/rpc/tests/test_testcase.py
+++ b/tcms/rpc/tests/test_testcase.py
@@ -716,6 +716,12 @@ class TestAddTag(APITestCase):
         ).exists()
         self.assertTrue(tag_exists)
 
+        history_entry = self.testcase.history.latest("history_id")
+        self.assertIn(self.tag1.name, history_entry.history_change_reason)
+        self.assertIn(
+            f"Tag added: {self.tag1.name}", history_entry.history_change_reason
+        )
+
     def test_add_tag_without_permissions(self):
         unauthorized_user = UserFactory()
         unauthorized_user.set_password("api-testing")
@@ -759,6 +765,12 @@ class TestRemoveTag(APITestCase):
             pk=self.testcase.pk, tag__pk=self.tag0.pk
         ).exists()
         self.assertFalse(tag_exists)
+
+        history_entry = self.testcase.history.latest("history_id")
+        self.assertIn(self.tag0.name, history_entry.history_change_reason)
+        self.assertIn(
+            f"Tag removed: {self.tag0.name}", history_entry.history_change_reason
+        )
 
     def test_remove_tag_without_permissions(self):
         unauthorized_user = UserFactory()

--- a/tcms/rpc/tests/test_testplan.py
+++ b/tcms/rpc/tests/test_testplan.py
@@ -92,6 +92,12 @@ class TestAddTag(APITestCase):
         ).exists()
         self.assertTrue(tag_exists)
 
+        history_entry = self.plans[0].history.latest("history_id")
+        self.assertIn(self.tag1.name, history_entry.history_change_reason)
+        self.assertIn(
+            f"Tag added: {self.tag1.name}", history_entry.history_change_reason
+        )
+
     def test_add_tag_without_permissions(self):
         unauthorized_user = UserFactory()
         unauthorized_user.set_password("api-testing")
@@ -141,6 +147,12 @@ class TestRemoveTag(APITestCase):
             pk=self.plans[0].pk, tag__pk=self.tag0.pk
         ).exists()
         self.assertFalse(tag_exists)
+
+        history_entry = self.plans[0].history.latest("history_id")
+        self.assertIn(self.tag0.name, history_entry.history_change_reason)
+        self.assertIn(
+            f"Tag removed: {self.tag0.name}", history_entry.history_change_reason
+        )
 
     def test_remove_tag_without_permissions(self):
         unauthorized_user = UserFactory()

--- a/tcms/testplans/models.py
+++ b/tcms/testplans/models.py
@@ -63,10 +63,21 @@ class TestPlan(TreeNode, UrlMixin):
         )[0]
 
     def add_tag(self, tag):
-        return TestPlanTag.objects.get_or_create(plan=self, tag=tag)
+        result = TestPlanTag.objects.get_or_create(plan=self, tag=tag)
+        self._change_reason = (  # pylint: disable=protected-access
+            f"Tag added: {tag.name}\n\n"
+            f"--- tag\n+++ tag\n@@ -1,1 +1,1 @@\n-\n+{tag.name}"
+        )
+        self.save()
+        return result
 
     def remove_tag(self, tag):
         TestPlanTag.objects.filter(plan=self, tag=tag).delete()
+        self._change_reason = (  # pylint: disable=protected-access
+            f"Tag removed: {tag.name}\n\n"
+            f"--- tag\n+++ tag\n@@ -1,1 +1,1 @@\n-{tag.name}\n+"
+        )
+        self.save()
 
     def delete_case(self, case):
         TestCasePlan.objects.filter(case=case.pk, plan=self.pk).delete()


### PR DESCRIPTION
implements #4085 

Tag operations on TestCase and TestPlan are M2M changes that bypass simple_history's field-level tracking. 

---

### Screenshots

<img width="1905" height="895" alt="chrome_jUt4ulOIUB" src="https://github.com/user-attachments/assets/c9c27f3e-d294-4dbb-8921-3dfcbc1acb3e" />
