### PR TITLE
Pin setuptools<=81 to workaround pkg_resources API deprecation

### DIFF
--- a/Dockerfile.buildroot
+++ b/Dockerfile.buildroot
@@ -19,7 +19,7 @@ ENV PATH=/venv/bin:${PATH} \
 RUN python3.11 -m venv /venv
 
 # because we get some errors from other packages which need newer versions
-RUN pip3 install --no-cache-dir --upgrade pip setuptools twine wheel
+RUN pip3 install --no-cache-dir --upgrade pip "setuptools<82" twine wheel
 
 # build and install the application
 COPY . /Kiwi/

--- a/requirements/readthedocs.txt
+++ b/requirements/readthedocs.txt
@@ -1,5 +1,6 @@
 -r base.txt
 
+setuptools<82
 Sphinx==9.0.4
 sphinx-removed-in
 docutils

--- a/tests/check-build
+++ b/tests/check-build
@@ -92,7 +92,7 @@ tar -tvf dist/kiwitcms-*.tar.gz | grep "tcms/testruns/templates"
 echo "..... Trying to install the new tarballs inside a virtualenv"
 $(which python) -m venv .venv/test-tarball
 source .venv/test-tarball/bin/activate
-pip install --upgrade setuptools pip
+pip install --upgrade "setuptools<82" pip
 # workaround for https://github.com/pypa/setuptools/issues/3424
 pip install setuptools-scm-git-archive
 pip install --no-binary :all: dist/kiwitcms*.tar.gz
@@ -103,7 +103,7 @@ rm -rf .venv/
 echo "..... Trying to install the new wheels inside a virtualenv"
 $(which python) -m venv .venv/test-wheel
 source .venv/test-wheel/bin/activate
-pip install --upgrade setuptools pip
+pip install --upgrade "setuptools<82" pip
 pip install -r requirements/tarballs.txt
 pip install --only-binary :all: dist/kiwitcms*.whl
 pip freeze | grep kiwitcms


### PR DESCRIPTION
See notice at:
https://setuptools.pypa.io/en/latest/history.html#v82-0-0

Most common uses of pkg_resources have been superseded by the importlib.resources and importlib.metadata projects.

What we were seeing on our side before this depractation was:
```
UserWarning: pkg_resources is deprecated as an API. See
https://setuptools.pypa.io/en/latest/pkg_resources.html.

The pkg_resources package is slated for removal as early as 2025-11-30.
Refrain from using this package or pin to Setuptools<81.
```

We would fix this properly but for now pin the version b/c 82.0.0 is already causing existing CI jobs to fail for us.