### PR TITLE
Add duration filters to test case search

### DIFF
--- a/tcms/rpc/api/testcase.py
+++ b/tcms/rpc/api/testcase.py
@@ -4,7 +4,7 @@ from datetime import timedelta
 from django.contrib.auth import get_user_model
 from django.db.models.functions import Coalesce
 from django.db.utils import NotSupportedError
-from django.forms import EmailField, ValidationError
+from django.forms import DurationField, EmailField, ValidationError
 from django.forms.models import model_to_dict
 from modernrpc.core import REQUEST_KEY, rpc_method
 
@@ -14,6 +14,45 @@ from tcms.rpc import utils
 from tcms.rpc.api.forms.testcase import NewForm, UpdateForm
 from tcms.rpc.decorators import permissions_required
 from tcms.testcases.models import Property, TestCase, TestCasePlan
+
+_DURATION_FIELD = DurationField(required=False)
+_DURATION_FILTER_FIELDS = ("setup_duration", "testing_duration", "expected_duration")
+
+
+def _expected_duration():
+    return Coalesce("setup_duration", timedelta(0)) + Coalesce(
+        "testing_duration", timedelta(0)
+    )
+
+
+def _clean_duration(value):
+    if isinstance(value, (list, tuple)):
+        return [_clean_duration(item) for item in value]
+
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return timedelta(seconds=value)
+
+    if isinstance(value, str):
+        return _DURATION_FIELD.clean(value)
+
+    return value
+
+
+def _clean_duration_filters(query):
+    cleaned_query = {}
+
+    for key, value in query.items():
+        field_name = key.split("__", 1)[0]
+
+        if field_name in _DURATION_FILTER_FIELDS:
+            value = _clean_duration(value)
+
+        if field_name == "expected_duration":
+            key = key.replace("expected_duration", "_expected_duration", 1)
+
+        cleaned_query[key] = value
+
+    return cleaned_query
 
 
 @permissions_required("testcases.add_testcasecomponent")
@@ -268,12 +307,13 @@ def filter(query=None):  # pylint: disable=redefined-builtin
     if query is None:
         query = {}
 
-    test_case_ids = TestCase.objects.filter(**query).values("id")
+    query = _clean_duration_filters(query)
+    test_case_ids = TestCase.objects.annotate(_expected_duration=_expected_duration())
+    test_case_ids = test_case_ids.filter(**query).values("id")
     qs = (
         # note: queries from HistoricalTestCase
         TestCase.history.annotate(  # pylint: disable=no-member
-            expected_duration=Coalesce("setup_duration", timedelta(0))
-            + Coalesce("testing_duration", timedelta(0))
+            expected_duration=_expected_duration()
         )
         .filter(id__in=test_case_ids)
         .values(

--- a/tcms/rpc/tests/test_testcase.py
+++ b/tcms/rpc/tests/test_testcase.py
@@ -247,6 +247,29 @@ class TestCaseFilter(APITestCase):
         self.assertEqual(result[0]["testing_duration"], testing_duration)
         self.assertEqual(result[0]["expected_duration"], expected_duration)
 
+    @parameterized.expand(
+        [
+            ("setup_duration", {"setup_duration": "45"}),
+            ("testing_duration", {"testing_duration": "300"}),
+            ("expected_duration", {"expected_duration": "345"}),
+        ]
+    )
+    def test_filter_by_duration_fields_returns_matching_test_case(self, _name, query):
+        testcase = TestCaseFactory(
+            setup_duration=timedelta(seconds=45),
+            testing_duration=timedelta(minutes=5),
+        )
+        testcase.save()
+        other_testcase = TestCaseFactory(
+            setup_duration=timedelta(minutes=1),
+            testing_duration=timedelta(minutes=2),
+        )
+        other_testcase.save()
+
+        result = self.rpc_client.TestCase.filter(query)
+
+        self.assertEqual([testcase.pk], [case["id"] for case in result])
+
 
 class TestUpdate(APITestCase):
     non_existing_username = "FakeUsername"

--- a/tcms/testcases/forms.py
+++ b/tcms/testcases/forms.py
@@ -87,6 +87,19 @@ class SearchCaseForm(forms.ModelForm):
         model = TestCase
         fields = "__all__"
 
+    setup_duration = forms.DurationField(
+        widget=DurationWidget(),
+        required=False,
+    )
+    testing_duration = forms.DurationField(
+        widget=DurationWidget(),
+        required=False,
+    )
+    expected_duration = forms.DurationField(
+        widget=DurationWidget(),
+        required=False,
+    )
+
     # overriden initial values
     product = forms.ModelChoiceField(queryset=Product.objects.all(), required=False)
     category = forms.ModelChoiceField(queryset=Category.objects.none(), required=False)

--- a/tcms/testcases/static/testcases/js/search.js
+++ b/tcms/testcases/static/testcases/js/search.js
@@ -62,9 +62,37 @@ function preProcessData (data, callbackF) {
     })
 }
 
+function updateDurationParam (inputSelector, paramName, params) {
+    const value = $(inputSelector).val()
+
+    if (value && value !== '0') {
+        params[paramName] = value
+    }
+}
+
 export function pageTestcasesSearchReadyHandler () {
     initializeDateTimePicker('#id_before')
     initializeDateTimePicker('#id_after')
+    $('.duration-picker').durationPicker({
+        translations: {
+            day: $('html').data('trans-day'),
+            days: $('html').data('trans-days'),
+
+            hour: $('html').data('trans-hour'),
+            hours: $('html').data('trans-hours'),
+
+            minute: $('html').data('trans-minute'),
+            minutes: $('html').data('trans-minutes'),
+
+            second: $('html').data('trans-second'),
+            seconds: $('html').data('trans-seconds')
+        },
+
+        showDays: true,
+        showHours: true,
+        showMinutes: true,
+        showSeconds: true
+    })
 
     const table = $('#resultsTable').DataTable({
         pageLength: $('#navbar').data('defaultpagesize'),
@@ -110,6 +138,10 @@ export function pageTestcasesSearchReadyHandler () {
             if ($('#id_run').val()) {
                 params.executions__run__in = [$('#id_run').val()]
             };
+
+            updateDurationParam('#id_setup_duration', 'setup_duration', params)
+            updateDurationParam('#id_testing_duration', 'testing_duration', params)
+            updateDurationParam('#id_expected_duration', 'expected_duration', params)
 
             const testPlanIds = selectedPlanIds()
             if (testPlanIds.length) {

--- a/tcms/testcases/templates/testcases/search.html
+++ b/tcms/testcases/templates/testcases/search.html
@@ -2,6 +2,9 @@
 {% load i18n %}
 {% load static %}
 
+{% block head %}
+    {{ form.media }}
+{% endblock %}
 {% block title %}{% trans "Search Test Cases" %}{% endblock %}
 {% block page_id %}page-testcases-search{% endblock %}
 
@@ -146,6 +149,26 @@
             <label class="col-md-1 col-lg-1" for="id_run">{% trans "Test run" %}</label>
             <div class="col-md-3 col-lg-3">
                 <input id="id_run" type="text" class="form-control" placeholder="{% trans 'ID' %}" value="">
+            </div>
+        </div>
+
+        <div class="form-group">
+            <label class="col-md-1 col-lg-1" for="id_setup_duration">{% trans "Setup duration" %}</label>
+            <div class="col-md-3 col-lg-3">
+                <input class="duration-picker" id="id_setup_duration" type="hidden"
+                    value="{{ form.setup_duration.value|default:'0' }}">
+            </div>
+
+            <label class="col-md-1 col-lg-1" for="id_testing_duration">{% trans "Testing duration" %}</label>
+            <div class="col-md-3 col-lg-3">
+                <input class="duration-picker" id="id_testing_duration" type="hidden"
+                    value="{{ form.testing_duration.value|default:'0' }}">
+            </div>
+
+            <label class="col-md-1 col-lg-1" for="id_expected_duration">{% trans "Expected duration" %}</label>
+            <div class="col-md-3 col-lg-3">
+                <input class="duration-picker" id="id_expected_duration" type="hidden"
+                    value="{{ form.expected_duration.value|default:'0' }}">
             </div>
         </div>
 

--- a/tcms/testcases/tests/test_views.py
+++ b/tcms/testcases/tests/test_views.py
@@ -539,3 +539,10 @@ class TestSearchCases(BasePlanCase):
             f'<option value="{self.product.pk}" selected>{self.product.name}</option>',
             html=True,
         )
+
+    def test_search_page_includes_duration_filters(self):
+        response = self.client.get(self.search_url, {})
+
+        self.assertContains(response, 'for="id_setup_duration"')
+        self.assertContains(response, 'for="id_testing_duration"')
+        self.assertContains(response, 'for="id_expected_duration"')


### PR DESCRIPTION
Closes #1923

## Summary
- add setup, testing, and expected duration filters to the /cases/search/ page
- initialize the existing duration picker widget on the search page and pass non-zero duration values into TestCase.filter
- make TestCase.filter normalize duration filter values and support filtering by annotated expected_duration

## Testing
- LANG=en_US.UTF-8 .venv/bin/python manage.py test tcms.rpc.tests.test_testcase.TestCaseFilter tcms.testcases.tests.test_views.TestSearchCases --settings=tcms.settings.test -v2
- .venv/bin/flake8 tcms/rpc/api/testcase.py tcms/rpc/tests/test_testcase.py tcms/testcases/forms.py tcms/testcases/tests/test_views.py
- .venv/bin/black --check tcms/rpc/api/testcase.py tcms/rpc/tests/test_testcase.py tcms/testcases/forms.py tcms/testcases/tests/test_views.py
- .venv/bin/isort --check --diff tcms/rpc/api/testcase.py tcms/rpc/tests/test_testcase.py tcms/testcases/forms.py tcms/testcases/tests/test_views.py
- ./node_modules/.bin/eslint testcases/static/testcases/js/search.js
- git diff --check