### PR TITLE
Use the OS version for python3-cryptography

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM registry.access.redhat.com/ubi9-minimal
 
 RUN microdnf -y module enable nginx:1.22 && \
-    microdnf -y --nodocs install python3.11 mariadb-connector-c libpq \
+    microdnf -y --nodocs install python3.11 python3.11-cryptography mariadb-connector-c libpq \
     nginx-core sscg tar glibc-langpack-en && \
     microdnf -y --nodocs update && \
     microdnf clean all

--- a/Dockerfile.buildroot
+++ b/Dockerfile.buildroot
@@ -4,7 +4,7 @@
 FROM registry.access.redhat.com/ubi9-minimal
 
 RUN microdnf -y module enable nodejs:22 && \
-    microdnf -y --nodocs install python3.11-devel mariadb-connector-c-devel tar gzip make \
+    microdnf -y --nodocs install python3.11-cryptography python3.11-devel mariadb-connector-c-devel tar gzip make \
     postgresql-devel libffi-devel gcc gettext npm unzip which rust cargo findutils \
     libjpeg-turbo-devel && \
     microdnf -y --nodocs update && \


### PR DESCRIPTION
trying to avoid this package being pulled via `pip install`: cryptography>=3.4.0 (from pyjwt[crypto]>=2.4.0->PyGithub==2.9.0->kiwitcms==15.4)

b/c it pulls in maturin==1.13.3 as build dependency which requires rustc 1.89.0!