### PR TITLE
Add user autocomplete for test run assignee updates

### DIFF
--- a/tcms/static/js/jsonrpc.js
+++ b/tcms/static/js/jsonrpc.js
@@ -86,3 +86,45 @@ export function testPlanAutoComplete (selector, planCache) {
         }
     })
 }
+
+export function userAutoComplete (selector, cache) {
+    $(`${selector}.typeahead`).typeahead({
+        minLength: 1,
+        highlight: true
+    }, {
+        name: 'users-autocomplete',
+        limit: 100,
+        async: true,
+        display: function (user) {
+            let displayName = user.username
+            if (user.email) {
+                displayName += ` <${user.email}>`
+            }
+            cache[displayName] = user
+            return displayName
+        },
+        source: function (query, processSync, processAsync) {
+            query = query.trim()
+            if (query === '') {
+                return
+            }
+
+            let rpcQuery = { pk: query }
+
+            if (isNaN(query)) {
+                if (query.length < 3) {
+                    return
+                }
+
+                rpcQuery = { username__icontains: query }
+                if (query.indexOf('@') > -1) {
+                    rpcQuery = { email__icontains: query }
+                }
+            }
+
+            jsonRPC('User.filter', rpcQuery, function (data) {
+                return processAsync(data)
+            })
+        }
+    })
+}

--- a/tcms/testruns/static/testruns/js/get.js
+++ b/tcms/testruns/static/testruns/js/get.js
@@ -1,5 +1,5 @@
 import { fetchBugDetails } from '../../../../static/js/bugs'
-import { jsonRPC } from '../../../../static/js/jsonrpc'
+import { jsonRPC, userAutoComplete } from '../../../../static/js/jsonrpc'
 import { propertiesCard } from '../../../../static/js/properties'
 import { tagsCard } from '../../../../static/js/tags'
 import {
@@ -16,11 +16,13 @@ import { initSimpleMDE } from '../../../../static/js/simplemde_security_override
 const allExecutionStatuses = {}
 const allExecutions = {}
 const expandedExecutionIds = []
+const userAutocompleteCache = {}
 const permissions = {
     removeTag: false,
     addComment: false,
     removeComment: false,
-    viewHistoricalTestExecution: false
+    viewHistoricalTestExecution: false,
+    viewUser: false
 }
 const autocompleteCache = {}
 
@@ -42,6 +44,7 @@ export function pageTestrunsGetReadyHandler () {
     permissions.addComment = $('#test_run_pk').data('perm-add-comment') === 'True'
     permissions.removeComment = $('#test_run_pk').data('perm-remove-comment') === 'True'
     permissions.viewHistoricalTestExecution = $('#test_run_pk').data('perm-view-historical-testexecution') === 'True'
+    permissions.viewUser = $('#test_run_pk').data('perm-view-user') === 'True'
 
     const testRunId = $('#test_run_pk').data('pk')
 
@@ -135,7 +138,7 @@ export function pageTestrunsGetReadyHandler () {
 
     $('.change-assignee-bulk').click(function () {
         $(this).parents('.dropdown').toggleClass('open')
-        changeAssigneeBulk()
+        openChangeAssigneeModal()
 
         return false
     })
@@ -189,6 +192,10 @@ export function pageTestrunsGetReadyHandler () {
     })
 
     quickSearchAndAddTestCase(testRunId, addTestCaseToRun, autocompleteCache, { case_status__is_confirmed: true })
+    if (permissions.viewUser) {
+        userAutoComplete('#id-change-assignee', userAutocompleteCache)
+    }
+
     $('#btn-search-cases').click(function () {
         return advancedSearchAndAddTestCases(
             testRunId, 'TestRun.add_case', $(this).attr('href'),
@@ -811,19 +818,35 @@ function reloadRowFor (execution, updateTestRun = false) {
     })
 }
 
-function changeAssigneeBulk () {
+function openChangeAssigneeModal () {
     const selected = selectedCheckboxes()
     if ($.isEmptyObject(selected)) {
         return false
     }
 
-    const enterAssigneeText = $('#test_run_pk').data('trans-enter-assignee-name-or-email')
-    const assignee = prompt(enterAssigneeText)
+    const input = $('#id-change-assignee')
+    input.val('')
+    $('.change-assignee-form').off('submit')
+    $('.change-assignee-form').submit(() => {
+        const assigneeValue = input.val().trim()
+        const selectedUser = userAutocompleteCache[assigneeValue]
+        const assignee = selectedUser ? selectedUser.username : assigneeValue
 
-    if (!assignee) {
+        if (!assignee) {
+            return false
+        }
+
+        changeAssigneeBulk(selected.executionIds, assignee)
+        $('#change-assignee-modal').modal('hide')
         return false
-    }
-    selected.executionIds.forEach(executionId => {
+    })
+
+    $('#change-assignee-modal').modal('show')
+    return true
+}
+
+function changeAssigneeBulk (executionIds, assignee) {
+    executionIds.forEach(executionId => {
         jsonRPC('TestExecution.update', [executionId, { assignee }], execution => {
             reloadRowFor(execution)
         })

--- a/tcms/testruns/templates/testruns/get.html
+++ b/tcms/testruns/templates/testruns/get.html
@@ -19,6 +19,7 @@
             data-perm-add-comment="{{ perms.django_comments.add_comment }}"
             data-perm-remove-comment="{{ perms.django_comments.delete_comment }}"
             data-perm-view-historical-testexecution="{{ perms.testruns.view_historicaltestexecution }}"
+            data-perm-view-user="{{ perms.auth.view_user }}"
             data-trans-no-executions-selected="{% trans 'No rows selected! Please select at least one!'%}"
             data-trans-enter-assignee-name-or-email="{% trans 'Enter username, email or user ID:'%}"
             data-trans-are-you-sure="{% trans 'Are you sure?' %}"
@@ -604,6 +605,40 @@
     </div>
   </div>
 </div>
+
+{% if perms.testruns.change_testexecution %}
+<div class="modal fade" id="change-assignee-modal" tabindex="-1" role="dialog" aria-labelledby="change-assignee-modal-title" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-hidden="true" aria-label="Close">
+          <span class="pficon pficon-close"></span>
+        </button>
+        <h4 class="modal-title" id="change-assignee-modal-title">{% trans "Assignee" %}</h4>
+      </div>
+      <form class="form-horizontal change-assignee-form">
+        <div class="modal-body">
+          <div class="form-group">
+            <label class="col-sm-3 control-label" for="id-change-assignee">{% trans "Assignee" %}</label>
+            <div class="col-sm-9">
+              <input type="text" id="id-change-assignee" class="form-control typeahead" placeholder="{% trans 'Username or email' %}">
+              {% if perms.auth.view_user %}
+                <span class="help-block">{% trans "Start typing to search for a user" %}</span>
+              {% else %}
+                <span class="help-block">{% trans "Enter an exact username, email or user ID" %}</span>
+              {% endif %}
+            </div>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-danger" data-dismiss="modal">{% trans "Cancel" %}</button>
+          <button type="submit" class="btn btn-primary change-assignee-button">{% trans "Save" %}</button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+{% endif %}
 
 <div class="modal fade" id="one-click-bug-report-modal" tabindex="-1" role="dialog" aria-labelledby="one-click-bug-report-title" aria-hidden="true">
   <div class="modal-dialog">

--- a/tcms/testruns/tests/test_views.py
+++ b/tcms/testruns/tests/test_views.py
@@ -248,11 +248,22 @@ class TestRunCasesMenu(BaseCaseRun):
         user_should_have_perm(self.tester, "testruns.change_testexecution")
         response = self.client.get(self.url)
         self.assertContains(response, self.change_assignee_html, html=True)
+        self.assertContains(response, 'id="change-assignee-modal"')
+        self.assertContains(response, 'data-perm-view-user="False"')
+        self.assertContains(response, _("Enter an exact username, email or user ID"))
 
     def test_change_assignee_without_permission(self):
         remove_perm_from_user(self.tester, "testruns.change_testexecution")
         response = self.client.get(self.url)
         self.assertNotContains(response, self.change_assignee_html, html=True)
+        self.assertNotContains(response, 'id="change-assignee-modal"')
+
+    def test_change_assignee_with_user_view_permission(self):
+        user_should_have_perm(self.tester, "testruns.change_testexecution")
+        user_should_have_perm(self.tester, "auth.view_user")
+        response = self.client.get(self.url)
+        self.assertContains(response, 'data-perm-view-user="True"')
+        self.assertContains(response, _("Start typing to search for a user"))
 
     def test_update_text_version_with_permission(self):
         user_should_have_perm(self.tester, "testruns.change_testexecution")


### PR DESCRIPTION
## Summary

- replace the Test Run bulk assignee `prompt()` with a Bootstrap modal
- add a reusable `typeahead.js` user autocomplete backed by the existing `User.filter` JSON-RPC method
- keep manual assignee entry available when the user lacks `auth.view_user`
- keep the existing `TestExecution.update` flow and add view coverage for modal visibility/permission text

Fixes #2510

## Verification

- `cd tcms && .\node_modules\.bin\eslint.cmd static\js\jsonrpc.js testruns\static\testruns\js\get.js`
- `git diff --check`

## Test Coverage

- Added view assertions for the assignee modal and `auth.view_user`-dependent help text.