### PR TITLE
Add TestCase duration filters to case search

### DIFF
--- a/tcms/rpc/api/testcase.py
+++ b/tcms/rpc/api/testcase.py
@@ -6,6 +6,7 @@ from django.db.models.functions import Coalesce
 from django.db.utils import NotSupportedError
 from django.forms import EmailField, ValidationError
 from django.forms.models import model_to_dict
+from django.utils.dateparse import parse_duration
 from modernrpc.core import REQUEST_KEY, rpc_method
 
 from tcms.core import helpers
@@ -14,6 +15,44 @@ from tcms.rpc import utils
 from tcms.rpc.api.forms.testcase import NewForm, UpdateForm
 from tcms.rpc.decorators import permissions_required
 from tcms.testcases.models import Property, TestCase, TestCasePlan
+
+
+DURATION_FILTER_FIELDS = ("setup_duration", "testing_duration", "expected_duration")
+
+
+def _duration_filter_value(value):
+    if isinstance(value, timedelta):
+        return value
+
+    if isinstance(value, (int, float)):
+        return timedelta(seconds=value)
+
+    if isinstance(value, str):
+        try:
+            return timedelta(seconds=float(value))
+        except ValueError:
+            duration = parse_duration(value)
+            if duration is not None:
+                return duration
+
+    return value
+
+
+def _normalize_duration_filters(query):
+    normalized_query = {}
+
+    for key, value in query.items():
+        field_name, _separator, lookup = key.partition("__")
+        if field_name not in DURATION_FILTER_FIELDS or lookup == "isnull":
+            normalized_query[key] = value
+            continue
+
+        if lookup == "in":
+            normalized_query[key] = [_duration_filter_value(item) for item in value]
+        else:
+            normalized_query[key] = _duration_filter_value(value)
+
+    return normalized_query
 
 
 @permissions_required("testcases.add_testcasecomponent")
@@ -268,7 +307,15 @@ def filter(query=None):  # pylint: disable=redefined-builtin
     if query is None:
         query = {}
 
-    test_case_ids = TestCase.objects.filter(**query).values("id")
+    query = _normalize_duration_filters(query)
+    test_case_ids = (
+        TestCase.objects.annotate(
+            expected_duration=Coalesce("setup_duration", timedelta(0))
+            + Coalesce("testing_duration", timedelta(0))
+        )
+        .filter(**query)
+        .values("id")
+    )
     qs = (
         # note: queries from HistoricalTestCase
         TestCase.history.annotate(  # pylint: disable=no-member

--- a/tcms/rpc/tests/test_testcase.py
+++ b/tcms/rpc/tests/test_testcase.py
@@ -247,6 +247,41 @@ class TestCaseFilter(APITestCase):
         self.assertEqual(result[0]["testing_duration"], testing_duration)
         self.assertEqual(result[0]["expected_duration"], expected_duration)
 
+    @parameterized.expand(
+        [
+            ("setup_duration_min", "setup_duration__gte", 120),
+            ("setup_duration_max", "setup_duration__lte", "00:02:00"),
+            ("testing_duration_min", "testing_duration__gte", 300),
+            ("testing_duration_max", "testing_duration__lte", "00:05:00"),
+            ("expected_duration_min", "expected_duration__gte", 420),
+            ("expected_duration_max", "expected_duration__lte", "00:07:00"),
+        ]
+    )
+    def test_filter_by_duration_fields(self, _name, lookup, value):
+        matching_case = TestCaseFactory(
+            setup_duration=timedelta(minutes=2),
+            testing_duration=timedelta(minutes=5),
+        )
+        matching_case.save()
+        if lookup.endswith("__gte"):
+            excluded_setup_duration = timedelta(seconds=1)
+            excluded_testing_duration = timedelta(seconds=1)
+        else:
+            excluded_setup_duration = timedelta(minutes=10)
+            excluded_testing_duration = timedelta(minutes=15)
+
+        excluded_case = TestCaseFactory(
+            setup_duration=excluded_setup_duration,
+            testing_duration=excluded_testing_duration,
+        )
+        excluded_case.save()
+
+        result = self.rpc_client.TestCase.filter({lookup: value})
+        result_ids = [testcase["id"] for testcase in result]
+
+        self.assertIn(matching_case.pk, result_ids)
+        self.assertNotIn(excluded_case.pk, result_ids)
+
 
 class TestUpdate(APITestCase):
     non_existing_username = "FakeUsername"

--- a/tcms/testcases/static/testcases/js/search.js
+++ b/tcms/testcases/static/testcases/js/search.js
@@ -62,6 +62,13 @@ function preProcessData (data, callbackF) {
     })
 }
 
+function updateDurationFilter (selector, filterName, params) {
+    const value = $(selector).val()
+    if (value !== '') {
+        params[filterName] = Number(value)
+    }
+}
+
 export function pageTestcasesSearchReadyHandler () {
     initializeDateTimePicker('#id_before')
     initializeDateTimePicker('#id_after')
@@ -130,6 +137,12 @@ export function pageTestcasesSearchReadyHandler () {
             };
 
             updateParamsToSearchTags('#id_tag', params)
+            updateDurationFilter('#id_setup_duration__gte', 'setup_duration__gte', params)
+            updateDurationFilter('#id_setup_duration__lte', 'setup_duration__lte', params)
+            updateDurationFilter('#id_testing_duration__gte', 'testing_duration__gte', params)
+            updateDurationFilter('#id_testing_duration__lte', 'testing_duration__lte', params)
+            updateDurationFilter('#id_expected_duration__gte', 'expected_duration__gte', params)
+            updateDurationFilter('#id_expected_duration__lte', 'expected_duration__lte', params)
 
             dataTableJsonRPC('TestCase.filter', params, callbackF, preProcessData)
         },

--- a/tcms/testcases/templates/testcases/search.html
+++ b/tcms/testcases/templates/testcases/search.html
@@ -150,6 +150,44 @@
         </div>
 
         <div class="form-group">
+            <label class="col-md-1 col-lg-1" for="id_setup_duration__gte">{% trans "Setup duration" %}</label>
+            <div class="col-md-3 col-lg-3">
+                <div class="input-group">
+                    <span class="input-group-addon">{% trans "Min" %}</span>
+                    <input id="id_setup_duration__gte" type="number" min="0" step="1" class="form-control"
+                        placeholder="{% trans 'Seconds' %}">
+                    <span class="input-group-addon">{% trans "Max" %}</span>
+                    <input id="id_setup_duration__lte" type="number" min="0" step="1" class="form-control"
+                        placeholder="{% trans 'Seconds' %}">
+                </div>
+            </div>
+
+            <label class="col-md-1 col-lg-1" for="id_testing_duration__gte">{% trans "Testing duration" %}</label>
+            <div class="col-md-3 col-lg-3">
+                <div class="input-group">
+                    <span class="input-group-addon">{% trans "Min" %}</span>
+                    <input id="id_testing_duration__gte" type="number" min="0" step="1" class="form-control"
+                        placeholder="{% trans 'Seconds' %}">
+                    <span class="input-group-addon">{% trans "Max" %}</span>
+                    <input id="id_testing_duration__lte" type="number" min="0" step="1" class="form-control"
+                        placeholder="{% trans 'Seconds' %}">
+                </div>
+            </div>
+
+            <label class="col-md-1 col-lg-1" for="id_expected_duration__gte">{% trans "Expected duration" %}</label>
+            <div class="col-md-3 col-lg-3">
+                <div class="input-group">
+                    <span class="input-group-addon">{% trans "Min" %}</span>
+                    <input id="id_expected_duration__gte" type="number" min="0" step="1" class="form-control"
+                        placeholder="{% trans 'Seconds' %}">
+                    <span class="input-group-addon">{% trans "Max" %}</span>
+                    <input id="id_expected_duration__lte" type="number" min="0" step="1" class="form-control"
+                        placeholder="{% trans 'Seconds' %}">
+                </div>
+            </div>
+        </div>
+
+        <div class="form-group">
             <div class="col-md-1 col-lg-1">
                 <button id="btn_search" type="submit" class="btn btn-default btn-lg">{% trans "Search" %}</button>
             </div>

--- a/tcms/testcases/tests/test_views.py
+++ b/tcms/testcases/tests/test_views.py
@@ -531,6 +531,12 @@ class TestSearchCases(BasePlanCase):
     def test_page_renders(self):
         response = self.client.get(self.search_url, {})
         self.assertContains(response, '<option value="">----------</option>', html=True)
+        self.assertContains(response, 'id="id_setup_duration__gte"')
+        self.assertContains(response, 'id="id_setup_duration__lte"')
+        self.assertContains(response, 'id="id_testing_duration__gte"')
+        self.assertContains(response, 'id="id_testing_duration__lte"')
+        self.assertContains(response, 'id="id_expected_duration__gte"')
+        self.assertContains(response, 'id="id_expected_duration__lte"')
 
     def test_get_parameter_should_be_accepted_for_a_product(self):
         response = self.client.get(self.search_url, {"product": self.product.pk})


### PR DESCRIPTION
## Summary
- add setup/testing/expected duration min/max filters to `/cases/search/`
- normalize duration RPC filter values so search UI seconds and API duration strings work with `DurationField` lookups
- annotate `expected_duration` for `TestCase.filter` so it can be filtered the same way it is returned

## Testing
- `LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8 .venv/bin/python manage.py test -v2 --noinput --settings=tcms.settings.test tcms.rpc.tests.test_testcase.TestCaseFilter tcms.testcases.tests.test_views.TestSearchCases`
- `git diff --check`

Closes #1923.