### PR TITLE
similar-string: skip English plural forms of already-seen strings

### DIFF
--- a/kiwi_lint/similar_string.py
+++ b/kiwi_lint/similar_string.py
@@ -41,6 +41,30 @@ class SimilarStringChecker(BaseChecker):
                     )
 
     @staticmethod
+    def is_plural_form(first, second):
+        """
+        Return True if one of the strings is the regular English plural form
+        of the other, e.g. "Product"/"Products" or "status"/"statuses".
+
+        Such pairs are intentionally different and translators expect both
+        the singular and the plural, so they should not be reported as
+        similar strings.
+        """
+        singular, plural = sorted(
+            (first.strip().lower(), second.strip().lower()), key=len
+        )
+        if not singular or singular == plural:
+            return False
+
+        # cat -> cats, box -> boxes
+        if plural in (singular + "s", singular + "es"):
+            return True
+        # category -> categories
+        if singular.endswith("y") and plural == singular[:-1] + "ies":
+            return True
+        return False
+
+    @staticmethod
     def clean_string(text):
         """
         This method removes the operators and other punctuations
@@ -86,6 +110,10 @@ class SimilarStringChecker(BaseChecker):
         similar_string, similarity = self.check_similar_string(translation_string)
 
         if similar_string:
+            # plural forms of an already seen string are expected to differ
+            if self.is_plural_form(translation_string, similar_string):
+                self._dict_of_strings[translation_string] = True
+                return
             if isinstance(node, str):
                 error_message["node"] = astroid.Module(node, file=node)
             else:


### PR DESCRIPTION
The `similar-string` (R5011) check was flagging regular English plural forms of strings it had already seen, e.g.:

- `"Products"` vs `"Product"`
- `"Templates"` vs `"Template"`
- `"Components"` vs `"Component"`
- `"Versions"` vs `"Version"`
- `"Test case statuses"` vs `"Test case status"`

These pairs are intentionally distinct — translators expect both the singular and the plural — so reporting them adds noise without value and was failing the `similar_strings` CI job.

## Change

When a candidate translation string is similar to one already seen, skip it if it is the regular English plural form of that string:

- `-s` (Product → Products)
- `-es` (status → statuses)
- `-y` → `-ies` (category → categories)

Genuine near-duplicates are still reported, e.g. `"Login"`/`"Log in"`, `"Close"`/`"Closed"`, `"Search Test Runs"`/`"Search Test Plans"`.

## Testing

Ran the exact CI target locally (Python 3.12, pylint 3.3.9):

```
PYTHONPATH=.:./tcms/ DJANGO_SETTINGS_MODULE=tcms.settings.test \
    pylint --load-plugins=kiwi_lint -d all -e similar-string tcms/ tcms_settings_dir/
```

All plural/singular pairs are no longer reported; only genuine near-duplicates remain. The modified file passes `flake8`, `black`, `isort`, and `pylint` (10.00/10).