### PR TITLE
Load no_self_use extension in remaining pylint commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ check: flake8 test
 
 .PHONY: pylint
 pylint:
-	pylint -d missing-docstring *.py kiwi_lint/
+	pylint --load-plugins=pylint.extensions.no_self_use -d missing-docstring *.py kiwi_lint/
 
 	PYTHONPATH=.:./tcms/ DJANGO_SETTINGS_MODULE=$(DJANGO_SETTINGS_MODULE) \
 	    pylint                                                            \
@@ -67,7 +67,7 @@ pylint:
 
 .PHONY: similar_strings
 similar_strings:
-	PYTHONPATH=.:./tcms/ DJANGO_SETTINGS_MODULE=$(DJANGO_SETTINGS_MODULE) pylint --load-plugins=kiwi_lint -d all -e similar-string tcms/ tcms_settings_dir/
+	PYTHONPATH=.:./tcms/ DJANGO_SETTINGS_MODULE=$(DJANGO_SETTINGS_MODULE) pylint --load-plugins=kiwi_lint --load-plugins=pylint.extensions.no_self_use -d all -e similar-string tcms/ tcms_settings_dir/
 
 .PHONY: bandit
 bandit:


### PR DESCRIPTION
## Summary

`no-self-use` was moved to an optional extension in pylint 2.14 (see [removed checkers](https://pylint.readthedocs.io/en/latest/whatsnew/2/2.14/summary.html#removed-checkers)). Two Makefile pylint targets lint code that still carries `# pylint: disable=no-self-use` comments but did not load the extension, so pylint raised `R0022 (useless-option-value)` and failed the `similar_strings` CI job.

This adds `--load-plugins=pylint.extensions.no_self_use` to the two commands that were missing it:
- `pylint` target: the root `*.py kiwi_lint/` invocation
- `similar_strings` target

The migrations and main `tcms/` invocations already load the extension, so they are unchanged.

## Tested

- `make similar_strings` no longer emits `R0022 useless-option-value`; the only remaining findings are pre-existing `similar-string` (R5011) messages.
- `pylint --load-plugins=pylint.extensions.no_self_use -d missing-docstring *.py kiwi_lint/` runs clean (no new no-self-use findings).