### PR TITLE
Load pylint_django in similar_strings command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ pylint:
 
 .PHONY: similar_strings
 similar_strings:
-	PYTHONPATH=.:./tcms/ DJANGO_SETTINGS_MODULE=$(DJANGO_SETTINGS_MODULE) pylint --load-plugins=kiwi_lint --load-plugins=pylint.extensions.no_self_use -d all -e similar-string tcms/ tcms_settings_dir/
+	PYTHONPATH=.:./tcms/ DJANGO_SETTINGS_MODULE=$(DJANGO_SETTINGS_MODULE) pylint --load-plugins=kiwi_lint --load-plugins=pylint_django --load-plugins=pylint.extensions.no_self_use -d all -e similar-string tcms/ tcms_settings_dir/
 
 .PHONY: bandit
 bandit:


### PR DESCRIPTION
## Summary

The `similar_strings` Makefile target only loaded `kiwi_lint`, so pylint did not recognize the `pylint_django` message `modelform-uses-exclude` used in inline `# pylint: disable=modelform-uses-exclude` comments across the form modules. This produced `W0012 (unknown-option-value)` errors and failed the `similar_strings` CI job:

```
tcms/testplans/forms.py:14:0: W0012: Unknown option value for 'disable', expected a valid pylint message and got 'modelform-uses-exclude' (unknown-option-value)
```

This adds `--load-plugins=pylint_django` to the `similar_strings` command, matching the main `pylint` target which already loads it. With the plugin loaded, `modelform-uses-exclude` is a recognized message again.

## Tested

- `make similar_strings` no longer emits any `W0012 unknown-option-value` (or `useless-option-value`) errors. Verified locally with Python 3.12 + pylint 3.3.9.