### PR TITLE
similar-string: skip modules named test_*.py

### DIFF
--- a/kiwi_lint/similar_string.py
+++ b/kiwi_lint/similar_string.py
@@ -89,6 +89,10 @@ class SimilarStringChecker(BaseChecker):
 
     @utils.only_required_for_messages("similar-string")
     def visit_call(self, node):
+        # don't inspect test modules, i.e. files named test_*.py
+        module_file = node.root().file
+        if module_file and os.path.basename(module_file).startswith("test_"):
+            return
         if not (
             isinstance(node.func, astroid.Name)
             and node.func.name in ("_", "gettext_lazy")


### PR DESCRIPTION
Don't inspect Python modules whose filename starts with `test_` in the `SimilarStringChecker`.

Test modules frequently contain repeated or near-identical translation strings (fixtures, assertions, etc.) that don't need to be flagged for translators. This adds an early bail-out in `visit_call` based on the enclosing module's filename.