### PR TITLE
Fix invalid multiline {% trans %} on password reset confirm page

### DIFF
--- a/tcms/templates/registration/password_reset_confirm.html
+++ b/tcms/templates/registration/password_reset_confirm.html
@@ -43,8 +43,8 @@
         {% if validlink %}
             {% trans "Please enter your new password twice so we can verify you typed it in correctly" %}.
         {% else %}
-            {% trans "The password reset link was invalid, possibly because it has already been used.
-            Please" %} <a href="{% url "tcms-password_reset" %}">{% trans "request a new password reset" %}</a>.
+            {% url "tcms-password_reset" as reset_url %}
+            {% blocktrans %}The password reset link was invalid, possibly because it has already been used. Please <a href="{{ reset_url }}">request a new password reset</a>.{% endblocktrans %}
         {% endif %}
       </p>
     </div><!--/.col-*-->


### PR DESCRIPTION
## Problem

The `{% trans %}` template tag does not allow multiline string literals. In `tcms/templates/registration/password_reset_confirm.html` the invalid-link message was split across two lines inside a single `{% trans %}`:

```django
{% trans "The password reset link was invalid, possibly because it has already been used.
Please" %} ...
```

Under **Django 6** this tag is no longer processed and is rendered **literally**, so users hitting an invalid/expired reset link saw the raw template source (`{% trans "..." %}`) on the page instead of the translated message.

This was caught by the enterprise `password-reset.robot` sanity test once the stack moved to Django 6 (via `kiwitcms-tenants>=4.5.0`, which bumped Django to `>=6.0.0`).

## Fix

Use `{% blocktrans %}` instead. It supports multi-part translatable content and keeps the sentence and the embedded link together as a single translatable unit (better for translators than the previous two separate `trans` strings).

```django
{% url "tcms-password_reset" as reset_url %}
{% blocktrans %}The password reset link was invalid, possibly because it has already been used. Please <a href="{{ reset_url }}">request a new password reset</a>.{% endblocktrans %}
```