### PR TITLE
Remove unused handle_attachments_post_save and _introspect_request

### DIFF
--- a/tcms/bugs/apps.py
+++ b/tcms/bugs/apps.py
@@ -13,7 +13,6 @@ class AppConfig(DjangoAppConfig):
         from .models import Bug
 
         post_save.connect(signals.handle_emails_post_bug_save, sender=Bug)
-        post_save.connect(signals.handle_attachments_post_save, sender=Bug)
         pre_delete.connect(signals.handle_attachments_pre_delete, sender=Bug)
         pre_delete.connect(signals.handle_comments_pre_delete, sender=Bug)
         post_migrate.connect(

--- a/tcms/signals.py
+++ b/tcms/signals.py
@@ -31,7 +31,6 @@ __all__ = [
     "notify_admins",
     "pre_save_clean",
     "handle_attachments_pre_delete",
-    "handle_attachments_post_save",
     "handle_comments_pre_delete",
     "handle_emails_post_case_save",
     "handle_emails_pre_case_delete",
@@ -263,36 +262,3 @@ def handle_emails_post_bug_save(sender, instance, created=False, **kwargs):
             "comment": comments.last(),
         },
     )
-
-
-def _introspect_request():
-    """
-    Introspect the current thread b/c signals are executed synchronously
-    after .save() and find out the `request` variable.
-    """
-    import inspect
-
-    for frame_record in inspect.stack():
-        if frame_record[3] == "get_response":
-            return frame_record[0].f_locals["request"]
-
-    return None
-
-
-def handle_attachments_post_save(sender, instance, created=False, **kwargs):
-    """
-    SimpleMDE image/file buttons will upload attachments under the currently
-    logged-in user. This signal handler will re-attach these files under the
-    document which is being saved!
-    """
-    from attachments.models import Attachment
-
-    if kwargs.get("raw", False):
-        return
-
-    request = _introspect_request()
-    if not request:
-        return
-
-    for attachment in Attachment.objects.attachments_for_object(request.user):
-        attachment.attach_to(instance)

--- a/tcms/testcases/apps.py
+++ b/tcms/testcases/apps.py
@@ -15,7 +15,6 @@ class AppConfig(DjangoAppConfig):
 
         pre_save.connect(signals.pre_save_clean, TestCase)
         post_save.connect(signals.handle_emails_post_case_save, TestCase)
-        post_save.connect(signals.handle_attachments_post_save, sender=TestCase)
         pre_delete.connect(signals.handle_emails_pre_case_delete, TestCase)
         pre_delete.connect(signals.handle_attachments_pre_delete, sender=TestCase)
         pre_delete.connect(signals.handle_comments_pre_delete, TestCase)

--- a/tcms/testplans/apps.py
+++ b/tcms/testplans/apps.py
@@ -14,5 +14,4 @@ class AppConfig(DjangoAppConfig):
 
         pre_save.connect(signals.pre_save_clean, TestPlan)
         post_save.connect(signals.handle_emails_post_plan_save, TestPlan)
-        post_save.connect(signals.handle_attachments_post_save, sender=TestPlan)
         pre_delete.connect(signals.handle_attachments_pre_delete, sender=TestPlan)

--- a/tcms/testruns/apps.py
+++ b/tcms/testruns/apps.py
@@ -13,10 +13,8 @@ class AppConfig(DjangoAppConfig):
         from .models import TestExecution, TestRun
 
         post_save.connect(signals.handle_emails_post_run_save, sender=TestRun)
-        post_save.connect(signals.handle_attachments_post_save, sender=TestRun)
         pre_save.connect(signals.pre_save_clean, sender=TestRun)
         pre_delete.connect(signals.handle_attachments_pre_delete, TestRun)
 
-        post_save.connect(signals.handle_attachments_post_save, sender=TestExecution)
         pre_delete.connect(signals.handle_attachments_pre_delete, TestExecution)
         pre_delete.connect(signals.handle_comments_pre_delete, TestExecution)


### PR DESCRIPTION
This PR removes  and  from , as well as their registrations and usages across app configs, cleaning up unused signal handling code.