### PR TITLE
test: add view and admin tests for Environment property page

### DIFF
--- a/tcms/testruns/tests/test_admin.py
+++ b/tcms/testruns/tests/test_admin.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=invalid-name
+from django.test import override_settings
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 from parameterized import parameterized
 
-from tcms.testruns.models import TestExecutionStatus, TestRun
+from tcms.testruns.models import Environment, TestExecutionStatus, TestRun
 from tcms.tests import LoggedInTestCase
 from tcms.tests.factories import TestRunFactory, UserFactory
 from tcms.utils.permissions import initiate_user_with_default_setups
@@ -133,3 +134,18 @@ class TestTestExecutionStatusAdmin(LoggedInTestCase):
             _("1 negative, 1 neutral & 1 positive status required!"),
             html=True,
         )
+
+
+@override_settings(LANGUAGE_CODE="en")
+class TestEnvironmentAdmin(LoggedInTestCase):
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        initiate_user_with_default_setups(cls.tester)
+        Environment.objects.create(name="Test Environment")
+
+    def test_admin_page_loads(self):
+        response = self.client.get("/admin/testruns/environment/")
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Select environment to change")
+        self.assertContains(response, "Edit parameters")


### PR DESCRIPTION
Adds a test case that loads the admin page /admin/testruns/environment/ and verifies the environment changelist renders, including the 'Edit parameters' link. The test pins LANGUAGE_CODE to English so the assertions are stable regardless of the host locale.