### PR TITLE
Move management forms to tcms.management.forms

### DIFF
--- a/tcms/management/forms.py
+++ b/tcms/management/forms.py
@@ -2,7 +2,51 @@
 
 from django import forms
 
-from tcms.management.models import Version
+from tcms.management.models import (
+    Build,
+    Classification,
+    Component,
+    Priority,
+    Product,
+    Tag,
+    Version,
+)
+
+
+class BuildForm(forms.ModelForm):
+    class Meta:
+        model = Build
+        fields = "__all__"
+
+
+class ClassificationForm(forms.ModelForm):
+    class Meta:
+        model = Classification
+        fields = "__all__"
+
+
+class ComponentForm(forms.ModelForm):
+    class Meta:
+        model = Component
+        fields = "__all__"
+
+
+class PriorityForm(forms.ModelForm):
+    class Meta:
+        model = Priority
+        fields = "__all__"
+
+
+class ProductForm(forms.ModelForm):
+    class Meta:
+        model = Product
+        fields = "__all__"
+
+
+class TagForm(forms.ModelForm):
+    class Meta:
+        model = Tag
+        fields = "__all__"
 
 
 class VersionForm(forms.ModelForm):

--- a/tcms/rpc/api/build.py
+++ b/tcms/rpc/api/build.py
@@ -3,8 +3,9 @@
 from django.forms.models import model_to_dict
 from modernrpc.core import rpc_method
 
+from tcms.management.forms import BuildForm
 from tcms.management.models import Build
-from tcms.rpc.api.forms.management import BuildForm, BuildUpdateForm
+from tcms.rpc.api.forms.management import BuildUpdateForm
 from tcms.rpc.decorators import permissions_required
 
 

--- a/tcms/rpc/api/classification.py
+++ b/tcms/rpc/api/classification.py
@@ -5,8 +5,8 @@
 from django.forms.models import model_to_dict
 from modernrpc.core import rpc_method
 
+from tcms.management.forms import ClassificationForm
 from tcms.management.models import Classification
-from tcms.rpc.api.forms.management import ClassificationForm
 from tcms.rpc.decorators import permissions_required
 
 

--- a/tcms/rpc/api/component.py
+++ b/tcms/rpc/api/component.py
@@ -4,8 +4,9 @@ from django.contrib.auth import get_user_model
 from django.forms.models import model_to_dict
 from modernrpc.core import REQUEST_KEY, rpc_method
 
+from tcms.management.forms import ComponentForm
 from tcms.management.models import Component
-from tcms.rpc.api.forms.management import ComponentForm, ComponentUpdateForm
+from tcms.rpc.api.forms.management import ComponentUpdateForm
 from tcms.rpc.decorators import permissions_required
 
 User = get_user_model()  # pylint: disable=invalid-name

--- a/tcms/rpc/api/forms/management.py
+++ b/tcms/rpc/api/forms/management.py
@@ -1,20 +1,5 @@
-from django import forms
-
-from tcms.management.models import (
-    Build,
-    Classification,
-    Component,
-    Priority,
-    Product,
-    Tag,
-)
+from tcms.management.forms import BuildForm, ComponentForm
 from tcms.rpc.api.forms import UpdateModelFormMixin
-
-
-class BuildForm(forms.ModelForm):
-    class Meta:
-        model = Build
-        fields = "__all__"
 
 
 class BuildUpdateForm(  # pylint: disable=remove-empty-class,too-many-ancestors
@@ -23,37 +8,7 @@ class BuildUpdateForm(  # pylint: disable=remove-empty-class,too-many-ancestors
     pass
 
 
-class ComponentForm(forms.ModelForm):
-    class Meta:
-        model = Component
-        fields = "__all__"
-
-
 class ComponentUpdateForm(
     UpdateModelFormMixin, ComponentForm
 ):  # pylint: disable=remove-empty-class,too-many-ancestors
     pass
-
-
-class ProductForm(forms.ModelForm):
-    class Meta:
-        model = Product
-        fields = "__all__"
-
-
-class ClassificationForm(forms.ModelForm):
-    class Meta:
-        model = Classification
-        fields = "__all__"
-
-
-class PriorityForm(forms.ModelForm):
-    class Meta:
-        model = Priority
-        fields = "__all__"
-
-
-class TagForm(forms.ModelForm):
-    class Meta:
-        model = Tag
-        fields = "__all__"

--- a/tcms/rpc/api/priority.py
+++ b/tcms/rpc/api/priority.py
@@ -3,8 +3,8 @@
 from django.forms.models import model_to_dict
 from modernrpc.core import rpc_method
 
+from tcms.management.forms import PriorityForm
 from tcms.management.models import Priority
-from tcms.rpc.api.forms.management import PriorityForm
 from tcms.rpc.decorators import permissions_required
 
 

--- a/tcms/rpc/api/product.py
+++ b/tcms/rpc/api/product.py
@@ -3,8 +3,8 @@
 from django.forms.models import model_to_dict
 from modernrpc.core import rpc_method
 
+from tcms.management.forms import ProductForm
 from tcms.management.models import Product
-from tcms.rpc.api.forms.management import ProductForm
 from tcms.rpc.decorators import permissions_required
 
 

--- a/tcms/rpc/api/tag.py
+++ b/tcms/rpc/api/tag.py
@@ -3,8 +3,8 @@ from django.conf import settings
 from django.forms.models import model_to_dict
 from modernrpc.core import rpc_method
 
+from tcms.management.forms import TagForm
 from tcms.management.models import Tag
-from tcms.rpc.api.forms.management import TagForm
 from tcms.rpc.decorators import permissions_required
 
 


### PR DESCRIPTION
Move BuildForm, ComponentForm, ProductForm, ClassificationForm, PriorityForm, and TagForm from tcms/rpc/api/forms/management.py to tcms/management/forms.py. Update all imports and keep backwards compatibility.