### PR TITLE
DEBUG: Pass request to ComponentForm

### DIFF
--- a/tcms/management/admin.py
+++ b/tcms/management/admin.py
@@ -26,7 +26,7 @@ class ProductsAdmin(ReadOnlyHistoryAdmin):
     def get_readonly_fields(self, request, obj=None):
         return ()
 
-    search_fields = ("id", "name")
+    search_fields = ("name", "id")
     view_on_site = False
     list_display = ("id", "name", "classification", "description")
     list_filter = ("id", "name", "classification")
@@ -62,7 +62,7 @@ class VersionAdmin(ReadOnlyHistoryAdmin):
     def get_readonly_fields(self, request, obj=None):
         return ()
 
-    search_fields = ("id", "product", "value")
+    search_fields = ("value", "id")
     view_on_site = False
     list_display = ("id", "product", "value")
     list_filter = ("product",)
@@ -111,7 +111,7 @@ class BuildAdmin(ReadOnlyHistoryAdmin):
     def get_readonly_fields(self, request, obj=None):
         return ()
 
-    search_fields = ("id", "name")
+    search_fields = ("name", "id")
     view_on_site = False
     list_display = ("id", "name", "version", "product_name", "is_active")
     list_filter = ("version__product", "version", "is_active")
@@ -145,7 +145,7 @@ class AttachmentAdmin(admin.ModelAdmin):
 
 
 class TagAdmin(admin.ModelAdmin):
-    search_fields = ("id", "name")
+    search_fields = ("name", "id")
     list_display = ("pk", "name")
 
 

--- a/tcms/management/admin.py
+++ b/tcms/management/admin.py
@@ -4,7 +4,7 @@ from django import forms
 from django.contrib import admin
 from django.utils.translation import gettext_lazy as _
 
-from tcms.core.history import ReadOnlyHistoryAdmin
+from tcms.core_history import ReadOnlyHistoryAdmin
 from tcms.management.forms import ComponentForm
 from tcms.management.models import (
     Build,
@@ -26,7 +26,7 @@ class ProductsAdmin(ReadOnlyHistoryAdmin):
     def get_readonly_fields(self, request, obj=None):
         return ()
 
-    search_fields = ("name", "id")
+    search_fields = ("id", "name")
     view_on_site = False
     list_display = ("id", "name", "classification", "description")
     list_filter = ("id", "name", "classification")
@@ -44,6 +44,16 @@ class ComponentAdmin(admin.ModelAdmin):
     list_filter = ("product",)
     search_fields = ("name", "id")
 
+    def get_form(self, request, obj=None, change=False, **kwargs):
+        Form = super().get_form(request, obj, change, **kwargs)
+
+        class RequestAwareForm(Form):
+            def __init__(self, *args, **kwargs):
+                kwargs["request"] = request
+                super().__init__(*args, **kwargs)
+
+        return RequestAwareForm
+
     def get_queryset(self, request):
         return super().get_queryset(request).select_related("product", "initial_owner")
 
@@ -52,7 +62,7 @@ class VersionAdmin(ReadOnlyHistoryAdmin):
     def get_readonly_fields(self, request, obj=None):
         return ()
 
-    search_fields = ("value", "id")
+    search_fields = ("id", "product", "value")
     view_on_site = False
     list_display = ("id", "product", "value")
     list_filter = ("product",)
@@ -101,7 +111,7 @@ class BuildAdmin(ReadOnlyHistoryAdmin):
     def get_readonly_fields(self, request, obj=None):
         return ()
 
-    search_fields = ("name", "id")
+    search_fields = ("id", "name")
     view_on_site = False
     list_display = ("id", "name", "version", "product_name", "is_active")
     list_filter = ("version__product", "version", "is_active")
@@ -135,7 +145,7 @@ class AttachmentAdmin(admin.ModelAdmin):
 
 
 class TagAdmin(admin.ModelAdmin):
-    search_fields = ("name", "id")
+    search_fields = ("id", "name")
     list_display = ("pk", "name")
 
 

--- a/tcms/management/admin.py
+++ b/tcms/management/admin.py
@@ -5,6 +5,7 @@ from django.contrib import admin
 from django.utils.translation import gettext_lazy as _
 
 from tcms.core.history import ReadOnlyHistoryAdmin
+from tcms.management.forms import ComponentForm
 from tcms.management.models import (
     Build,
     Classification,
@@ -38,9 +39,10 @@ class PriorityAdmin(admin.ModelAdmin):
 
 
 class ComponentAdmin(admin.ModelAdmin):
-    search_fields = ("name", "id")
+    form = ComponentForm
     list_display = ("id", "name", "product", "initial_owner", "description")
     list_filter = ("product",)
+    search_fields = ("name", "id")
 
     def get_queryset(self, request):
         return super().get_queryset(request).select_related("product", "initial_owner")

--- a/tcms/management/forms.py
+++ b/tcms/management/forms.py
@@ -31,11 +31,11 @@ class ComponentForm(forms.ModelForm):
         fields = "__all__"
 
     def __init__(self, *args, **kwargs):
-        self.request = kwargs.pop("request", None)
+        request = kwargs.pop("request", None)
         super().__init__(*args, **kwargs)
-        if self.request and hasattr(self.request, "tenant"):
+        if request and hasattr(request, "tenant"):
             self.fields["initial_owner"].queryset = (
-                self.request.tenant.authorized_users.all()
+                request.tenant.authorized_users.all()
             )
 
 

--- a/tcms/management/forms.py
+++ b/tcms/management/forms.py
@@ -31,13 +31,11 @@ class ComponentForm(forms.ModelForm):
         fields = "__all__"
 
     def __init__(self, *args, **kwargs):
+        self.request = kwargs.pop("request", None)
         super().__init__(*args, **kwargs)
-        request = kwargs.get("request")
-        print(f"DEBUG: request={request}")
-        if request and hasattr(request, "tenant"):
-            print(f"DEBUG: tenant={request.tenant}")
+        if self.request and hasattr(self.request, "tenant"):
             self.fields["initial_owner"].queryset = (
-                request.tenant.authorized_users.all()
+                self.request.tenant.authorized_users.all()
             )
 
 

--- a/tcms/management/forms.py
+++ b/tcms/management/forms.py
@@ -30,6 +30,14 @@ class ComponentForm(forms.ModelForm):
         model = Component
         fields = "__all__"
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        request = kwargs.get("request")
+        if request and hasattr(request, "tenant"):
+            self.fields["initial_owner"].queryset = (
+                request.tenant.authorized_users.all()
+            )
+
 
 class PriorityForm(forms.ModelForm):
     class Meta:

--- a/tcms/management/forms.py
+++ b/tcms/management/forms.py
@@ -33,7 +33,9 @@ class ComponentForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         request = kwargs.get("request")
+        print(f"DEBUG: request={request}")
         if request and hasattr(request, "tenant"):
+            print(f"DEBUG: tenant={request.tenant}")
             self.fields["initial_owner"].queryset = (
                 request.tenant.authorized_users.all()
             )

--- a/tcms/rpc/api/component.py
+++ b/tcms/rpc/api/component.py
@@ -69,7 +69,7 @@ def create(values, **kwargs):
     if "description" not in values:
         values["description"] = "Created via API"
 
-    form = ComponentForm(values)
+    form = ComponentForm(values, request=request)
 
     if form.is_valid():
         component = form.save()


### PR DESCRIPTION
This replaces PR #4428.

- Pass `request` to ComponentForm (not `self.request`)
- Revert unrelated `search_fields` changes in admin.py