### PR TITLE
Make bug views/API tenant aware

### DIFF
--- a/tcms/bugs/api.py
+++ b/tcms/bugs/api.py
@@ -160,10 +160,11 @@ def create(values, **kwargs):
     if "status" not in values:
         values["status"] = True
 
+    request = kwargs.get(REQUEST_KEY)
     if not values.get("reporter"):
-        values["reporter"] = kwargs.get(REQUEST_KEY).user.pk
+        values["reporter"] = request.user.pk
 
-    form = NewBugFromRPCForm(values)
+    form = NewBugFromRPCForm(values, request=request)
     if form.is_valid():
         bug = form.save()
 

--- a/tcms/bugs/forms.py
+++ b/tcms/bugs/forms.py
@@ -50,6 +50,14 @@ Expected results:
 Additional info:"""),
     )
 
+    def __init__(self, *args, **kwargs):
+        request = kwargs.pop("request", None)
+        super().__init__(*args, **kwargs)
+        if request and hasattr(request, "tenant"):
+            tenant_users = request.tenant.authorized_users.all()
+            self.fields["reporter"].queryset = tenant_users
+            self.fields["assignee"].queryset = tenant_users
+
     def populate(self, product_id=None):
         if product_id:
             self.fields["version"].queryset = Version.objects.filter(
@@ -63,7 +71,7 @@ Additional info:"""),
             self.fields["build"].queryset = Build.objects.all()
 
 
-class NewBugFromRPCForm(forms.ModelForm):
+class NewBugFromRPCForm(NewBugForm):
     created_at = DateTimeFieldWithDefault(required=False)
 
     class Meta:

--- a/tcms/bugs/views.py
+++ b/tcms/bugs/views.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2021 Alexander Todorov <atodorov@MrSenko.com>
+# Copyright (c) 2019-2026 Alexander Todorov <atodorov@MrSenko.com>
 
 # Licensed under the GPL 2.0: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 
@@ -76,6 +76,7 @@ class New(CreateView):
                 "reporter": self.request.user,
             }
         )
+        kwargs["request"] = self.request
         return kwargs
 
     def get_form(self, form_class=None):
@@ -177,6 +178,11 @@ class Edit(UpdateView):
                 result += f"{field.title()}: {_before_update} -> {_after_update}\n"
         if result:
             add_comment([self.object], result, self.request.user)
+
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        kwargs["request"] = self.request
+        return kwargs
 
     def get_initial(self):
         return {

--- a/tcms/core/forms/fields.py
+++ b/tcms/core/forms/fields.py
@@ -14,6 +14,13 @@ class UserField(forms.CharField):
     Will eventually support user selection
     """
 
+    def __init__(self, *, queryset=None, **kwargs):
+        super().__init__(**kwargs)
+        if queryset is None:
+            self.queryset = User.objects.all()
+        else:
+            self.queryset = queryset
+
     def clean(self, value):
         """
         Form-validation:  accept a string/integer.
@@ -25,18 +32,18 @@ class UserField(forms.CharField):
             return None
         if isinstance(value, int):
             try:
-                return User.objects.get(pk=value)
+                return self.queryset.get(pk=value)
             except User.DoesNotExist:
                 raise ValidationError(f'Unknown user_id: "{value}"') from None
         else:
             value = value.strip()
             if value.isdigit():
                 try:
-                    return User.objects.get(pk=value)
+                    return self.queryset.get(pk=value)
                 except User.DoesNotExist:
                     raise ValidationError(f'Unknown user_id: "{value}"') from None
             else:
                 try:
-                    return User.objects.get((Q(email=value) | Q(username=value)))
+                    return self.queryset.get((Q(email=value) | Q(username=value)))
                 except User.DoesNotExist:
                     raise ValidationError(f'Unknown user: "{value}"') from None


### PR DESCRIPTION
## Changes

- **NewBugForm** (tcms/bugs/forms.py): Added  that accepts  kwarg and filters the  queryset (and  if it has a queryset) to , matching the pattern used by 
- **NewBugFromRPCForm** (tcms/bugs/forms.py): Now inherits from  (instead of ) to reuse the tenant filtering logic, with additional  and  fields
- **Bug.create** API (tcms/bugs/api.py): Passes  to the form, mirroring how  does it
- **New** view (tcms/bugs/views.py): Passes  to the form via 
- **Edit** view (tcms/bugs/views.py): Passes  to the form via 