### PR TITLE
Make TestPlan views/API tenant aware for author field

### DIFF
--- a/tcms/bugs/forms.py
+++ b/tcms/bugs/forms.py
@@ -53,7 +53,11 @@ Additional info:"""),
     def __init__(self, *args, **kwargs):
         request = kwargs.pop("request", None)
         super().__init__(*args, **kwargs)
-        if request and hasattr(request, "tenant"):
+        if (
+            request
+            and hasattr(request, "tenant")
+            and request.tenant.schema_name != "public"
+        ):
             tenant_users = request.tenant.authorized_users.all()
             self.fields["reporter"].queryset = tenant_users
             self.fields["assignee"].queryset = tenant_users

--- a/tcms/management/forms.py
+++ b/tcms/management/forms.py
@@ -33,7 +33,11 @@ class ComponentForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         request = kwargs.pop("request", None)
         super().__init__(*args, **kwargs)
-        if request and hasattr(request, "tenant"):
+        if (
+            request
+            and hasattr(request, "tenant")
+            and request.tenant.schema_name != "public"
+        ):
             self.fields["initial_owner"].queryset = (
                 request.tenant.authorized_users.all()
             )

--- a/tcms/rpc/api/testplan.py
+++ b/tcms/rpc/api/testplan.py
@@ -49,7 +49,7 @@ def create(values, **kwargs):
     if not values.get("is_active"):
         values["is_active"] = True
 
-    form = NewPlanAPIForm(values)
+    form = NewPlanAPIForm(values, request=request)
     form.populate(product_id=values["product"])
 
     if form.is_valid():
@@ -157,7 +157,7 @@ def remove_tag(plan_id, tag_name):
 
 @permissions_required("testplans.change_testplan")
 @rpc_method(name="TestPlan.update")
-def update(plan_id, values):
+def update(plan_id, values, **kwargs):
     """
     .. function:: RPC TestPlan.update(plan_id, values)
 
@@ -167,14 +167,17 @@ def update(plan_id, values):
         :type plan_id: int
         :param values: Field values for :class:`tcms.testplans.models.TestPlan`
         :type values: dict
+        :param \\**kwargs: Dict providing access to the current request, protocol,
+                entry point name and handler instance from the rpc method
         :return: Serialized :class:`tcms.testplans.models.TestPlan` object
         :rtype: dict
         :raises TestPlan.DoesNotExist: if object specified by PK doesn't exist
         :raises PermissionDenied: if missing *testplans.change_testplan* permission
         :raises ValueError: if validations fail
     """
+    request = kwargs.get(REQUEST_KEY)
     test_plan = TestPlan.objects.get(pk=plan_id)
-    form = EditPlanForm(values, instance=test_plan)
+    form = EditPlanForm(values, instance=test_plan, request=request)
     if form.is_valid():
         test_plan = form.save()
         result = model_to_dict(test_plan, exclude=["tag"])

--- a/tcms/testplans/forms.py
+++ b/tcms/testplans/forms.py
@@ -15,6 +15,16 @@ class NewPlanForm(forms.ModelForm):
 
     text = forms.CharField(widget=SimpleMDE(), required=False)
 
+    def __init__(self, *args, **kwargs):
+        request = kwargs.pop("request", None)
+        super().__init__(*args, **kwargs)
+        if (
+            request
+            and hasattr(request, "tenant")
+            and request.tenant.schema_name != "public"
+        ):
+            self.fields["author"].queryset = request.tenant.authorized_users.all()
+
     def populate(self, product_id):
         if product_id:
             self.fields["product_version"].queryset = Version.objects.filter(

--- a/tcms/testplans/views.py
+++ b/tcms/testplans/views.py
@@ -38,6 +38,7 @@ class NewTestPlanView(CreateView):
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()
         kwargs["initial"]["author"] = self.request.user
+        kwargs["request"] = self.request
         return kwargs
 
     def get_context_data(self, **kwargs):
@@ -78,6 +79,11 @@ class Edit(UpdateView):
         else:
             form.populate(product_id=self.object.product_id)
         return form
+
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        kwargs["request"] = self.request
+        return kwargs
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)


### PR DESCRIPTION
### Commit 1: Add public schema check to tenant-aware forms

Skip tenant filtering when schema_name is 'public' to avoid restricting queries in the public schema context.

Updates existing conditions in tcms/bugs/forms.py and tcms/management/forms.py.

### Commit 2: Make TestPlan views/API tenant aware for author field

Add __init__ to NewPlanForm that accepts a request parameter and filters the author field queryset to tenant-authorized users when the tenant is not the public schema.

Pass request from:
- NewTestPlanView.get_form_kwargs() (plans-new)
- Edit.get_form_kwargs() (plan-edit)
- TestPlan.create RPC method
- TestPlan.update RPC method

Follows the same pattern as PR #4431 for Bug forms.