### PR TITLE
Make NewExecutionForm tenant-aware

### DIFF
--- a/tcms/rpc/api/forms/testrun.py
+++ b/tcms/rpc/api/forms/testrun.py
@@ -42,6 +42,18 @@ class NewExecutionForm(forms.ModelForm):
     stop_date = DateTimeField(required=False)
     start_date = DateTimeField(required=False)
 
+    def __init__(self, *args, **kwargs):
+        request = kwargs.pop("request", None)
+        super().__init__(*args, **kwargs)
+        if (
+            request
+            and hasattr(request, "tenant")
+            and request.tenant.schema_name != "public"
+        ):
+            tenant_users = request.tenant.authorized_users.all()
+            self.fields["assignee"].queryset = tenant_users
+            self.fields["tested_by"].queryset = tenant_users
+
 
 class UpdateExecutionForm(  # pylint: disable=remove-empty-class,too-many-ancestors
     UpdateModelFormMixin, NewExecutionForm

--- a/tcms/rpc/api/testexecution.py
+++ b/tcms/rpc/api/testexecution.py
@@ -203,18 +203,19 @@ def update(execution_id, values, **kwargs):
         :raises ValueError: if data validations fail
         :raises PermissionDenied: if missing *testruns.change_testexecution* permission
     """
+    request = kwargs.get(REQUEST_KEY)
     test_execution = TestExecution.objects.get(pk=execution_id)
 
     if values.get("case_text_version") == "latest":
         values["case_text_version"] = test_execution.case.history.latest().history_id
 
     if values.get("status") and not values.get("tested_by"):
-        values["tested_by"] = kwargs.get(REQUEST_KEY).user.id
+        values["tested_by"] = request.user.id
 
     if values.get("status") and not values.get("build"):
         values["build"] = test_execution.run.build.pk
 
-    form = UpdateExecutionForm(values, instance=test_execution)
+    form = UpdateExecutionForm(values, instance=test_execution, request=request)
 
     if form.is_valid():
         test_execution = form.save()
@@ -467,7 +468,8 @@ def create(values, **kwargs):
 
     .. versionadded:: 15.3
     """
-    form = NewExecutionForm(values)
+    request = kwargs.get(REQUEST_KEY)
+    form = NewExecutionForm(values, request=request)
 
     if form.is_valid():
         test_execution = form.save()


### PR DESCRIPTION
In `tcms/rpc/api/forms/testrun.py`:

- Add `__init__` to `NewExecutionForm` that pops `request` from kwargs and restricts `assignee` and `tested_by` querysets to `request.tenant.authorized_users.all()` when the schema is not `public`

In `tcms/rpc/api/testexecution.py`:

- Pass `request` to `NewExecutionForm` in `TestExecution.create()`
- Pass `request` to `UpdateExecutionForm` in `TestExecution.update()`

Follows the same pattern as PR #4432 for TestPlan forms.