### PR TITLE
Make TestRun views/RPC methods tenant-aware

### DIFF
--- a/tcms/rpc/api/forms/testrun.py
+++ b/tcms/rpc/api/forms/testrun.py
@@ -26,6 +26,18 @@ class UpdateForm(UpdateModelFormMixin, forms.ModelForm):
     planned_start = DateTimeField()
     planned_stop = DateTimeField()
 
+    def __init__(self, *args, **kwargs):
+        request = kwargs.pop("request", None)
+        super().__init__(*args, **kwargs)
+        if (
+            request
+            and hasattr(request, "tenant")
+            and request.tenant.schema_name != "public"
+        ):
+            tenant_users = request.tenant.authorized_users.all()
+            self.fields["manager"].queryset = tenant_users
+            self.fields["default_tester"].queryset = tenant_users
+
     def populate(self, version_id):
         self.fields["build"].queryset = Build.objects.filter(
             version_id=version_id, is_active=True

--- a/tcms/rpc/api/testrun.py
+++ b/tcms/rpc/api/testrun.py
@@ -199,10 +199,11 @@ def create(values, **kwargs):
             }
             >>> TestRun.create(values)
     """
+    request = kwargs.get(REQUEST_KEY)
     if not values.get("default_tester"):
-        values["default_tester"] = kwargs.get(REQUEST_KEY).user.pk
+        values["default_tester"] = request.user.pk
 
-    form = NewRunForm(values)
+    form = NewRunForm(values, request=request)
     form.populate(values.get("plan"))
 
     if form.is_valid():
@@ -258,7 +259,7 @@ def filter(query=None):  # pylint: disable=redefined-builtin
 
 @permissions_required("testruns.change_testrun")
 @rpc_method(name="TestRun.update")
-def update(run_id, values):
+def update(run_id, values, **kwargs):
     """
     .. function:: RPC TestRun.update(run_id, values)
 
@@ -268,13 +269,16 @@ def update(run_id, values):
         :type run_id: int
         :param values: Field values for :class:`tcms.testruns.models.TestRun`
         :type values: dict
+        :param \\**kwargs: Dict providing access to the current request, protocol,
+                entry point name and handler instance from the rpc method
         :return: Serialized :class:`tcms.testruns.models.TestRun` object
         :rtype: dict
         :raises PermissionDenied: if missing *testruns.change_testrun* permission
         :raises ValueError: if data validations fail
     """
+    request = kwargs.get(REQUEST_KEY)
     test_run = TestRun.objects.get(pk=run_id)
-    form = UpdateForm(values, instance=test_run)
+    form = UpdateForm(values, instance=test_run, request=request)
 
     # In the rare case where this TR is reassigned to another TP
     # don't validate if TR.build has a FK relationship with TP.product_version.

--- a/tcms/testruns/forms.py
+++ b/tcms/testruns/forms.py
@@ -24,6 +24,18 @@ class NewRunForm(forms.ModelForm):
     planned_start = DateTimeField(required=False)
     planned_stop = DateTimeField(required=False)
 
+    def __init__(self, *args, **kwargs):
+        request = kwargs.pop("request", None)
+        super().__init__(*args, **kwargs)
+        if (
+            request
+            and hasattr(request, "tenant")
+            and request.tenant.schema_name != "public"
+        ):
+            tenant_users = request.tenant.authorized_users.all()
+            self.fields["manager"].queryset = tenant_users
+            self.fields["default_tester"].queryset = tenant_users
+
     case = forms.ModelMultipleChoiceField(
         queryset=TestCase.objects.none(),
         required=False,

--- a/tcms/testruns/views.py
+++ b/tcms/testruns/views.py
@@ -55,7 +55,7 @@ class NewTestRunView(View):
                 "plan": plan_id,
             }
 
-        form = NewRunForm(initial=form_initial)
+        form = NewRunForm(initial=form_initial, request=request)
         form.populate(plan_id)
 
         context_data = {
@@ -68,7 +68,7 @@ class NewTestRunView(View):
         return render(request, self.template_name, context_data)
 
     def post(self, request):
-        form = NewRunForm(data=request.POST)
+        form = NewRunForm(data=request.POST, request=request)
         form.populate(request.POST.get("plan"))
 
         if form.is_valid():
@@ -241,6 +241,11 @@ class EditTestRunView(UpdateView):
         form.populate(self.object.plan_id)
 
         return form
+
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        kwargs["request"] = self.request
+        return kwargs
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)


### PR DESCRIPTION
Make NewRunForm and RPC UpdateForm tenant-aware by filtering manager/default_tester UserFields to tenant-authorized users when not on the public schema.

Pass request variable to form in TestRun.create/update RPC methods and new/edit views.

Follows the same pattern as previous tenant-aware form PRs (Bug forms, TestPlan forms, ComponentForm, TestExecution forms).