### PR TITLE
Make TestRun views/RPC methods tenant-aware

### DIFF
--- a/tcms/rpc/api/forms/testrun.py
+++ b/tcms/rpc/api/forms/testrun.py
@@ -26,6 +26,18 @@ class UpdateForm(UpdateModelFormMixin, forms.ModelForm):
     planned_start = DateTimeField()
     planned_stop = DateTimeField()
 
+    def __init__(self, *args, **kwargs):
+        request = kwargs.pop("request", None)
+        super().__init__(*args, **kwargs)
+        if (
+            request
+            and hasattr(request, "tenant")
+            and request.tenant.schema_name != "public"
+        ):
+            tenant_users = request.tenant.authorized_users.all()
+            self.fields["manager"].queryset = tenant_users
+            self.fields["default_tester"].queryset = tenant_users
+
     def populate(self, version_id):
         self.fields["build"].queryset = Build.objects.filter(
             version_id=version_id, is_active=True

--- a/tcms/rpc/api/testrun.py
+++ b/tcms/rpc/api/testrun.py
@@ -199,10 +199,11 @@ def create(values, **kwargs):
             }
             >>> TestRun.create(values)
     """
+    request = kwargs.get(REQUEST_KEY)
     if not values.get("default_tester"):
-        values["default_tester"] = kwargs.get(REQUEST_KEY).user.pk
+        values["default_tester"] = request.user.pk
 
-    form = NewRunForm(values)
+    form = NewRunForm(values, request=request)
     form.populate(values.get("plan"))
 
     if form.is_valid():
@@ -273,8 +274,9 @@ def update(run_id, values):
         :raises PermissionDenied: if missing *testruns.change_testrun* permission
         :raises ValueError: if data validations fail
     """
+    request = kwargs.get(REQUEST_KEY)
     test_run = TestRun.objects.get(pk=run_id)
-    form = UpdateForm(values, instance=test_run)
+    form = UpdateForm(values, instance=test_run, request=request)
 
     # In the rare case where this TR is reassigned to another TP
     # don't validate if TR.build has a FK relationship with TP.product_version.

--- a/tcms/testruns/forms.py
+++ b/tcms/testruns/forms.py
@@ -24,6 +24,18 @@ class NewRunForm(forms.ModelForm):
     planned_start = DateTimeField(required=False)
     planned_stop = DateTimeField(required=False)
 
+    def __init__(self, *args, **kwargs):
+        request = kwargs.pop("request", None)
+        super().__init__(*args, **kwargs)
+        if (
+            request
+            and hasattr(request, "tenant")
+            and request.tenant.schema_name != "public"
+        ):
+            tenant_users = request.tenant.authorized_users.all()
+            self.fields["manager"].queryset = tenant_users
+            self.fields["default_tester"].queryset = tenant_users
+
     case = forms.ModelMultipleChoiceField(
         queryset=TestCase.objects.none(),
         required=False,

--- a/tcms/testruns/views.py
+++ b/tcms/testruns/views.py
@@ -55,7 +55,7 @@ class NewTestRunView(View):
                 "plan": plan_id,
             }
 
-        form = NewRunForm(initial=form_initial)
+        form = NewRunForm(initial=form_initial, request=request)
         form.populate(plan_id)
 
         context_data = {
@@ -68,7 +68,7 @@ class NewTestRunView(View):
         return render(request, self.template_name, context_data)
 
     def post(self, request):
-        form = NewRunForm(data=request.POST)
+        form = NewRunForm(data=request.POST, request=request)
         form.populate(request.POST.get("plan"))
 
         if form.is_valid():
@@ -241,6 +241,11 @@ class EditTestRunView(UpdateView):
         form.populate(self.object.plan_id)
 
         return form
+
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        kwargs["request"] = self.request
+        return kwargs
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)


### PR DESCRIPTION
Add `__init__` to `NewRunForm` and RPC `UpdateForm` that accepts a `request` parameter and filters the `manager` and `default_tester` UserField querysets to tenant-authorized users when the tenant is not the public schema.

Pass `request` from `NewTestRunView` (get/post), `EditTestRunView` and `TestRun.create`/`TestRun.update` RPC methods to the forms.

Follows the same pattern as PRs #4431 (Bug forms) and #4432 (TestPlan forms).