### PR TITLE
TestRunAdmin.add_view: redirect to testruns-new

### DIFF
--- a/tcms/testruns/admin.py
+++ b/tcms/testruns/admin.py
@@ -12,7 +12,7 @@ from tcms.testruns.models import Environment, TestExecutionStatus, TestRun
 
 class TestRunAdmin(ObjectPermissionsAdminMixin, ReadOnlyHistoryAdmin):
     def add_view(self, request, form_url="", extra_context=None):
-        return HttpResponseRedirect(reverse("admin:testruns_testrun_changelist"))
+        return HttpResponseRedirect(reverse("testruns-new"))
 
     def change_view(self, request, object_id, form_url="", extra_context=None):
         return HttpResponseRedirect(reverse("testruns-get", args=[object_id]))

--- a/tcms/testruns/tests/test_admin.py
+++ b/tcms/testruns/tests/test_admin.py
@@ -25,7 +25,7 @@ class TestTestRunAdmin(LoggedInTestCase):
 
     def test_regular_user_can_not_add_testrun(self):
         response = self.client.get(reverse("admin:testruns_testrun_add"))
-        self.assertRedirects(response, reverse("admin:testruns_testrun_changelist"))
+        self.assertRedirects(response, reverse("testruns-new"))
 
     def test_regular_user_can_not_change_testrun(self):
         response = self.client.get(


### PR DESCRIPTION
Instead of redirecting to the admin changelist when adding a new
TestRun from the admin page, redirect to the `testruns-new` view
which provides the proper UI for creating new test runs.