### PR TITLE
Remove unused User = get_user_model() assignments

### DIFF
--- a/tcms/rpc/api/component.py
+++ b/tcms/rpc/api/component.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from django.contrib.auth import get_user_model
 from django.forms.models import model_to_dict
 from modernrpc.core import REQUEST_KEY, rpc_method
 
@@ -8,8 +7,6 @@ from tcms.management.forms import ComponentForm
 from tcms.management.models import Component
 from tcms.rpc.api.forms.management import ComponentUpdateForm
 from tcms.rpc.decorators import permissions_required
-
-User = get_user_model()  # pylint: disable=invalid-name
 
 
 @permissions_required("management.view_component")

--- a/tcms/rpc/api/forms/testrun.py
+++ b/tcms/rpc/api/forms/testrun.py
@@ -1,5 +1,4 @@
 from django import forms
-from django.contrib.auth import get_user_model
 
 from tcms.core.forms.fields import UserField
 from tcms.management.models import Build
@@ -10,8 +9,6 @@ from tcms.testruns.models import (
     TestExecutionStatus,
     TestRun,
 )
-
-User = get_user_model()  # pylint: disable=invalid-name
 
 
 class UpdateForm(UpdateModelFormMixin, forms.ModelForm):

--- a/tcms/testruns/forms.py
+++ b/tcms/testruns/forms.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 from django import forms
-from django.contrib.auth import get_user_model
 from django.utils.translation import gettext_lazy as _
 
 from tcms.core.forms.fields import UserField
@@ -8,8 +7,6 @@ from tcms.management.models import Build, Product, Version
 from tcms.rpc.api.forms import DateTimeField
 from tcms.testcases.models import TestCase
 from tcms.testruns.models import Environment, TestRun
-
-User = get_user_model()  # pylint: disable=invalid-name
 
 
 class NewRunForm(forms.ModelForm):

--- a/tcms/testruns/views.py
+++ b/tcms/testruns/views.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from django.contrib.auth import get_user_model
 from django.contrib.auth.decorators import permission_required
 from django.core.exceptions import ObjectDoesNotExist
 from django.http import HttpResponseRedirect
@@ -24,8 +23,6 @@ from tcms.testruns.models import (
     TestExecutionStatus,
     TestRun,
 )
-
-User = get_user_model()  # pylint: disable=invalid-name
 
 
 @method_decorator(permission_required("testruns.add_testrun"), name="dispatch")


### PR DESCRIPTION
Remove unused `User = get_user_model()` assignments and their corresponding `from django.contrib.auth import get_user_model` imports from 4 files where the User model was imported but never referenced:

- `tcms/rpc/api/forms/testrun.py`
- `tcms/rpc/api/component.py`
- `tcms/testruns/forms.py`
- `tcms/testruns/views.py`

All other files that use this pattern (`tcms/core/forms/fields.py`, `tcms/kiwi_auth/admin.py`, `tcms/kiwi_auth/forms.py`, `tcms/kiwi_auth/tests/test_views.py`, `tcms/kiwi_auth/views.py`, `tcms/testruns/views.py`) were checked — `User` is actively used in those and left untouched.