### PR TITLE
Make TestCase views/RPC methods tenant-aware

### DIFF
--- a/tcms/rpc/api/forms/testcase.py
+++ b/tcms/rpc/api/forms/testcase.py
@@ -23,6 +23,18 @@ class NewForm(forms.ModelForm):
             "plan",
         )
 
+    def __init__(self, *args, **kwargs):
+        request = kwargs.pop("request", None)
+        super().__init__(*args, **kwargs)
+        if (
+            request
+            and hasattr(request, "tenant")
+            and request.tenant.schema_name != "public"
+        ):
+            tenant_users = request.tenant.authorized_users.all()
+            self.fields["author"].queryset = tenant_users
+            self.fields["default_tester"].queryset = tenant_users
+
 
 class UpdateForm(UpdateModelFormMixin, forms.ModelForm):
     class Meta:
@@ -32,6 +44,19 @@ class UpdateForm(UpdateModelFormMixin, forms.ModelForm):
     default_tester = UserField()
     author = UserField()
     reviewer = UserField()
+
+    def __init__(self, *args, **kwargs):
+        request = kwargs.pop("request", None)
+        super().__init__(*args, **kwargs)
+        if (
+            request
+            and hasattr(request, "tenant")
+            and request.tenant.schema_name != "public"
+        ):
+            tenant_users = request.tenant.authorized_users.all()
+            self.fields["author"].queryset = tenant_users
+            self.fields["default_tester"].queryset = tenant_users
+            self.fields["reviewer"].queryset = tenant_users
 
 
 class BugSystemForm(forms.ModelForm):

--- a/tcms/rpc/api/testcase.py
+++ b/tcms/rpc/api/testcase.py
@@ -230,7 +230,7 @@ def create(values, **kwargs):
     if not (values.get("author") or values.get("author_id")):
         values["author"] = request.user.pk
 
-    form = NewForm(values)
+    form = NewForm(values, request=request)
 
     if form.is_valid():
         test_case = form.save()
@@ -365,9 +365,9 @@ def sortkeys(query=None):
 
 @permissions_required("testcases.change_testcase")
 @rpc_method(name="TestCase.update")
-def update(case_id, values):
+def update(case_id, values, **kwargs):
     """
-    .. function:: RPC TestCase.update(case_id, values)
+    .. function:: RPC TestCase.update(case_id, values, **kwargs)
 
         Update the fields of the selected test case.
 
@@ -375,14 +375,17 @@ def update(case_id, values):
         :type case_id: int
         :param values: Field values for :class:`tcms.testcases.models.TestCase`.
         :type values: dict
+        :param \\**kwargs: Dict providing access to the current request, protocol,
+                entry point name and handler instance from the rpc method
         :return: Serialized :class:`tcms.testcases.models.TestCase` object
         :rtype: dict
         :raises ValueError: if form is not valid
         :raises TestCase.DoesNotExist: if object specified by PK doesn't exist
         :raises PermissionDenied: if missing *testcases.change_testcase* permission
     """
+    request = kwargs.get(REQUEST_KEY)
     test_case = TestCase.objects.get(pk=case_id)
-    form = UpdateForm(values, instance=test_case)
+    form = UpdateForm(values, instance=test_case, request=request)
 
     if form.is_valid():
         test_case = form.save()

--- a/tcms/testcases/forms.py
+++ b/tcms/testcases/forms.py
@@ -47,6 +47,18 @@ class TestCaseForm(forms.ModelForm):
         required=False,
     )
 
+    def __init__(self, *args, **kwargs):
+        request = kwargs.pop("request", None)
+        super().__init__(*args, **kwargs)
+        if (
+            request
+            and hasattr(request, "tenant")
+            and request.tenant.schema_name != "public"
+        ):
+            tenant_users = request.tenant.authorized_users.all()
+            self.fields["author"].queryset = tenant_users
+            self.fields["default_tester"].queryset = tenant_users
+
     def populate(self, product_id=None):
         if product_id:
             self.fields["category"].queryset = Category.objects.filter(

--- a/tcms/testcases/views.py
+++ b/tcms/testcases/views.py
@@ -48,6 +48,7 @@ class NewCaseView(CreateView):
 
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()
+        kwargs["request"] = self.request
         kwargs["initial"].update(  # pylint: disable=objects-update-used
             {
                 "author": self.request.user,
@@ -200,6 +201,11 @@ class EditTestCaseView(UpdateView):
         else:
             form.populate(product_id=self.object.category.product_id)
         return form
+
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        kwargs["request"] = self.request
+        return kwargs
 
     def get_initial(self):
         default_tester = None


### PR DESCRIPTION
Add __init__ to NewForm and UpdateForm in rpc/api/forms/testcase.py and TestCaseForm in tcms/testcases/forms.py that accepts a request parameter and filters the author, default_tester, and reviewer UserField querysets to tenant-authorized users when the tenant is not the public schema.

Pass request from NewCaseView, EditTestCaseView and TestCase.create/TestCase.update RPC methods to the forms.

Follows the same pattern as previous tenant-aware form PRs (#4431, #4432, #4436, #4442).