### PR TITLE
Remove handling for next parameter in Confirm view

### DIFF
--- a/tcms/kiwi_auth/views.py
+++ b/tcms/kiwi_auth/views.py
@@ -110,9 +110,7 @@ class Confirm(RedirectView):  # pylint: disable=missing-permission-required
     http_method_names = ["get"]
 
     def get_redirect_url(self, *args, **kwargs):
-        self.url = self.request.GET.get("next", reverse("core-views-index"))
-        if not self.url.startswith("/"):
-            self.url = reverse("core-views-index")
+        self.url = reverse("core-views-index")
 
         activation_key = kwargs["activation_key"]
         try:


### PR DESCRIPTION
Appears to have been added when this was originally converted to a class based view, however it doesn't seem this functionality was ever used for anything of purpose.