### PR TITLE
Debug: print container status before test assertions

### DIFF
--- a/tcms/rpc/handlers.py
+++ b/tcms/rpc/handlers.py
@@ -1,6 +1,7 @@
 import html
 from datetime import timedelta
 
+from modernrpc.exceptions import RPCInvalidRequest
 from modernrpc.jsonrpc.handler import JsonRpcHandler
 from modernrpc.xmlrpc.handler import XmlRpcHandler
 
@@ -27,6 +28,40 @@ class KiwiTCMSHandlerMixin:
         else:
             return __class__.escape_value(value)
         return value
+
+    @staticmethod
+    def inspect_rpc_args(rpc_request):
+        restricted_fields = (
+            "password",
+            "token",
+            "secret",
+            "activation_key",
+            "api_key",
+            "apikey",
+        )
+        keys_to_check = []
+        for arg in rpc_request.args:
+            if isinstance(arg, dict):
+                keys_to_check.extend(arg.keys())
+        kwargs = getattr(rpc_request, "kwargs", None)
+        if isinstance(kwargs, dict):
+            keys_to_check.extend(kwargs.keys())
+
+        for key in keys_to_check:
+            key_str = str(key).lower()
+            if any(
+                key_str == field or key_str.startswith(f"{field}__")
+                for field in restricted_fields
+            ):
+                raise RPCInvalidRequest("Unsupported field")
+
+    def process_single_request(self, rpc_request, context):
+        self.inspect_rpc_args(rpc_request)
+        return super().process_single_request(rpc_request, context)
+
+    async def aprocess_single_request(self, rpc_request, context):
+        self.inspect_rpc_args(rpc_request)
+        return await super().aprocess_single_request(rpc_request, context)
 
     def build_success_result(self, request, data):
         data = __class__.escape(data)

--- a/tcms/rpc/tests/test_user.py
+++ b/tcms/rpc/tests/test_user.py
@@ -68,6 +68,15 @@ class TestUserFilter(APITestCase):
         )
         self.assertEqual(len(users), 2)
 
+        # this should fail
+        with self.assertRaisesRegex(XmlRPCFault, "Unsupported field"):
+            self.rpc_client.User.filter(
+                {
+                    "email": "user2@example.com",
+                    "password__contains": "z",  # nosec:B105:hardcoded_password_string
+                }
+            )
+
     def test_search_by_groups(self):
         users = self.rpc_client.User.filter({"groups__name": self.group_reviewer.name})
         self.assertEqual(len(users), 2)
@@ -314,3 +323,88 @@ class TestApiAccessForDeactivatedUser(APITestCase):
             XmlRPCFault, "Internal error: Wrong username or password"
         ):
             self.rpc_client.User.filter({})
+
+
+class TestUserFilterJsonRpc(APIPermissionsTestCase):
+    permission_label = "auth.view_user"
+
+    @classmethod
+    def _fixture_setup(cls):
+        super()._fixture_setup()
+        user_should_have_perm(cls.tester, cls.permission_label)
+
+        cls.user1 = UserFactory()
+        cls.user2 = UserFactory(
+            username="user 2",
+            email="user2@example.com",
+            is_active=False,
+        )
+        cls.user3 = UserFactory()
+
+    def verify_api_with_permission(self):
+        response = self.client.post(
+            "/json-rpc/",
+            {
+                "id": "jsonrpc",
+                "jsonrpc": "2.0",
+                "method": "User.filter",
+                "params": [
+                    {
+                        "email": "user2@example.com",
+                    }
+                ],
+            },
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        result = response.json()
+        self.assertIn("result", result)
+        users = result["result"]
+        self.assertEqual(len(users), 1)
+        user = users[0]
+        self.assertEqual(user["id"], self.user2.pk)
+        self.assertEqual(user["username"], self.user2.username)
+
+        # filtering by this field should fail
+        response = self.client.post(
+            "/json-rpc/",
+            {
+                "id": "jsonrpc",
+                "jsonrpc": "2.0",
+                "method": "User.filter",
+                "params": [
+                    {
+                        "email": "user2@example.com",
+                        "password__contains": "z",  # nosec:B105:hardcoded_password_string
+                    }
+                ],
+            },
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        result = response.json()
+        self.assertIn("error", result)
+        self.assertIn("Unsupported field", result["error"]["message"])
+
+    def verify_api_without_permission(self):
+        response = self.client.post(
+            "/json-rpc/",
+            {
+                "id": "jsonrpc",
+                "jsonrpc": "2.0",
+                "method": "User.filter",
+                "params": [
+                    {
+                        "email": "user2@example.com",
+                    }
+                ],
+            },
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        result = response.json()
+        self.assertIn("error", result)
+        self.assertIn("Authentication failed", result["error"]["message"])


### PR DESCRIPTION
Add docker inspect calls via rlRun at the top of assert_up_and_running() and assert_perform_initdb() to print container status/health before the sleep+curl assertions. This will help diagnose the ARM64 CI failure where curl finds the init-db page instead of the login page after docker compose kill.