### PR TITLE
Remove version field from docker-compose files

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '2'
-
 services:
     db:
         container_name: kiwi_db

--- a/tests/azureboards/docker-compose.yml
+++ b/tests/azureboards/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
     # just because the CI config needs this.
     # not using it in actual tests

--- a/tests/bugzilla/docker-compose.yml
+++ b/tests/bugzilla/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
     # build ourselves b/c bugzilla/docker-bugzilla-dev
     # is too old and doesn't work

--- a/tests/github/docker-compose.yml
+++ b/tests/github/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
     # just because the CI config needs this.
     # not using it in actual tests

--- a/tests/gitlab_ce/docker-compose.yml
+++ b/tests/gitlab_ce/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
     bugtracker_kiwitcms_org:
         container_name: bugtracker_kiwitcms_org

--- a/tests/gitlab_com/docker-compose.yml
+++ b/tests/gitlab_com/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
     # just because the CI config needs this.
     # not using it in actual tests

--- a/tests/gitlab_ee/docker-compose.yml
+++ b/tests/gitlab_ee/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
     bugtracker_kiwitcms_org:
         container_name: bugtracker_kiwitcms_org

--- a/tests/jira/docker-compose.yml
+++ b/tests/jira/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
     # just because the CI config needs this.
     # not using it in actual tests

--- a/tests/kiwitcms/docker-compose.yml
+++ b/tests/kiwitcms/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
     # just because the CI config needs this.
     # not using it in actual tests

--- a/tests/redmine/docker-compose.yml
+++ b/tests/redmine/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
     # build our own modified image to make it easier for testing
     bugtracker_kiwitcms_org:


### PR DESCRIPTION
Docker Compose version field is deprecated and no longer needed.