### PR TITLE
Remove deprecated license specifier from setup.py

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,7 @@
+[metadata]
+license = GPLv2
+license_files = LICENSE
+
 [flake8]
 max-line-length = 102
 extend-ignore = E203

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,6 @@ setup(
     maintainer="Kiwi TCMS",
     maintainer_email="info@kiwitcms.org",
     url="https://github.com/kiwitcms/Kiwi/",
-    license="GPLv2",
     keywords="test case",
     install_requires=INSTALL_REQUIRES,
     dependency_links=DEPENDENCY_LINKS,
@@ -63,7 +62,6 @@ setup(
     include_package_data=True,
     classifiers=[
         "Intended Audience :: Developers",
-        "License :: OSI Approved :: GNU General Public License v2 (GPLv2)",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
This PR removes the deprecated `license` argument and classifier from `setup.py` and specifies `license_files` in `setup.cfg` instead, in accordance with https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license.

This prevents the `SetuptoolsDeprecationWarning: License classifiers are deprecated.` warning during builds.