### PR TITLE
Improve Markdown.render() API method's internal caching

### DIFF
--- a/tcms/rpc/api/markdown.py
+++ b/tcms/rpc/api/markdown.py
@@ -1,3 +1,5 @@
+import hashlib
+
 from django.core.cache import cache
 
 from tcms.core.templatetags.extra_filters import markdown2html
@@ -25,10 +27,11 @@ def render(text):
         :return: Rendered HTML text
         :rtype: str
     """
-    result = cache.get(text)
+    cache_key = hashlib.sha256(text.encode()).hexdigest()
+    result = cache.get(cache_key)
     if result:
         return result
 
     result = markdown2html(text)
-    cache.set(text, result)
+    cache.set(cache_key, result)
     return result


### PR DESCRIPTION
route the incoming text via sha256 to produce cache keys:

- don't contain whitespace or control characters
- have fixed length of 64 characters

https://docs.djangoproject.com/en/6.0/topics/cache/#cache-key-warnings