### PR TITLE
Add JSON-RPC test with named parameters for User.filter

### DIFF
--- a/tcms/rpc/tests/test_user.py
+++ b/tcms/rpc/tests/test_user.py
@@ -366,6 +366,32 @@ class TestUserFilterJsonRpc(APIPermissionsTestCase):
         self.assertEqual(user["id"], self.user2.pk)
         self.assertEqual(user["username"], self.user2.username)
 
+        # same as above but with named parameters, see
+        # https://www.jsonrpc.org/specification#parameter_structures
+        response = self.client.post(
+            "/json-rpc/",
+            {
+                "id": "jsonrpc",
+                "jsonrpc": "2.0",
+                "method": "User.filter",
+                "params": {
+                    "query": {
+                        "email": "user2@example.com",
+                    }
+                },
+            },
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        result = response.json()
+        self.assertIn("result", result)
+        users = result["result"]
+        self.assertEqual(len(users), 1)
+        user = users[0]
+        self.assertEqual(user["id"], self.user2.pk)
+        self.assertEqual(user["username"], self.user2.username)
+
         # filtering by this field should fail
         response = self.client.post(
             "/json-rpc/",


### PR DESCRIPTION
Extend `TestUserFilterJsonRpc.verify_api_with_permission` with an additional `User.filter` call that uses **named parameters** (`params` as a JSON object keyed by argument name, i.e. `{"query": {...}}`) instead of positional parameters, as described in the JSON-RPC 2.0 specification: https://www.jsonrpc.org/specification#parameter_structures

The assertions mirror the positional-parameter call right above it: the request succeeds and returns exactly the expected user record.