### PR TITLE
Add failing tests for BugSystem with invalid tracker_type values

### DIFF
--- a/tcms/issuetracker/tests/raise.py
+++ b/tcms/issuetracker/tests/raise.py
@@ -1,0 +1,11 @@
+# Copyright (c) 2026 Alexander Todorov <atodorov@MrSenko.com>
+#
+# Licensed under the GPL 2.0: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+
+from tcms.issuetracker.base import IssueTrackerType
+
+
+class Bogus(IssueTrackerType):  # pylint: disable=abstract-method
+    def __init__(self, bug_system, request):
+        super().__init__(bug_system, request)
+        raise RuntimeError("Used during testing")

--- a/tcms/rpc/api/bugtracker.py
+++ b/tcms/rpc/api/bugtracker.py
@@ -4,9 +4,9 @@
 
 from django.forms.models import model_to_dict
 
-from tcms.rpc.api.forms.testcase import BugSystemForm
 from tcms.rpc.decorators import permissions_required
 from tcms.rpc.views import rpc_method
+from tcms.testcases.admin import BugSystemAdminForm
 from tcms.testcases.models import BugSystem
 
 
@@ -60,7 +60,7 @@ def create(values):
         :raises ValueError: if input values don't validate
         :raises PermissionDenied: if missing *testcases.add_bugsystem* permission
     """
-    form = BugSystemForm(values)
+    form = BugSystemAdminForm(values)
 
     if form.is_valid():
         bug_system = form.save()

--- a/tcms/rpc/api/forms/testcase.py
+++ b/tcms/rpc/api/forms/testcase.py
@@ -2,13 +2,7 @@ from django import forms
 
 from tcms.core.forms.fields import UserField
 from tcms.rpc.api.forms import DateTimeFieldWithDefault, UpdateModelFormMixin
-from tcms.testcases.models import (
-    BugSystem,
-    Category,
-    Template,
-    TestCase,
-    TestCaseStatus,
-)
+from tcms.testcases.models import Category, Template, TestCase, TestCaseStatus
 
 
 class NewForm(forms.ModelForm):
@@ -57,12 +51,6 @@ class UpdateForm(UpdateModelFormMixin, forms.ModelForm):
             self.fields["author"].queryset = tenant_users
             self.fields["default_tester"].queryset = tenant_users
             self.fields["reviewer"].queryset = tenant_users
-
-
-class BugSystemForm(forms.ModelForm):
-    class Meta:
-        model = BugSystem
-        fields = "__all__"
 
 
 class CategoryForm(forms.ModelForm):

--- a/tcms/rpc/tests/test_bugtracker.py
+++ b/tcms/rpc/tests/test_bugtracker.py
@@ -50,16 +50,16 @@ class BugTrackerCreate(APIPermissionsTestCase):
         result = self.rpc_client.BugTracker.create(
             {
                 "name": "Local Kiwi TCMS",
-                "tracker_type": "tcms.issuetracker.types.KiwiTCMS",
-                "base_url": "https://example.com",
+                "tracker_type": "tcms.issuetracker.types.GitHub",
+                "base_url": "https://github.com/kiwitcms",
             }
         )
 
         # verify the serialized result
         self.assertIn("id", result)
         self.assertEqual(result["name"], "Local Kiwi TCMS")
-        self.assertEqual(result["tracker_type"], "tcms.issuetracker.types.KiwiTCMS")
-        self.assertEqual(result["base_url"], "https://example.com")
+        self.assertEqual(result["tracker_type"], "tcms.issuetracker.types.GitHub")
+        self.assertEqual(result["base_url"], "https://github.com/kiwitcms")
         self.assertIsNone(result["api_url"])
         self.assertIsNone(result["api_username"])
         self.assertNotIn("api_password", result)

--- a/tcms/rpc/tests/test_bugtracker.py
+++ b/tcms/rpc/tests/test_bugtracker.py
@@ -1,16 +1,19 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=attribute-defined-outside-init, invalid-name, objects-update-used
 #
-# Copyright (c) 2025 Alexander Todorov <atodorov@MrSenko.com>
+# Copyright (c) 2025-2026 Alexander Todorov <atodorov@MrSenko.com>
 #
 # Licensed under the GPL 2.0: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 
+from django.test import override_settings
+from parameterized import parameterized
 
 from tcms.rpc.tests.utils import APIPermissionsTestCase
 from tcms.testcases.models import BugSystem
 from tcms.xmlrpc_wrapper import XmlRPCFault
 
 
+@override_settings(LANGUAGE_CODE="en")
 class BugTrackerCreate(APIPermissionsTestCase):
     permission_label = "testcases.add_bugsystem"
 
@@ -74,6 +77,34 @@ class BugTrackerCreate(APIPermissionsTestCase):
                     "api_password": "this-is-secret",  # nosec:B105:hardcoded_password_string
                 }
             )
+
+    @parameterized.expand(
+        [
+            ("base_class", "tcms.issuetracker.base.IssueTrackerType"),
+            ("raises_in_init", "tcms.issuetracker.tests.raise.Bogus"),
+            ("random_dotted_path", "random.dotted.string"),
+            ("not_a_dotted_path", "random string"),
+        ]
+    )
+    def test_create_with_invalid_tracker_type_will_fail(self, _name, tracker_type):
+        # grant only the permission needed for BugTracker.create
+        self.no_permissions_but(self.permission_label)
+
+        with self.assertRaisesRegex(
+            XmlRPCFault,
+            f".*tracker_type.*Select a valid choice. {tracker_type} is not one of the available choices.*",
+        ):
+            self.rpc_client.BugTracker.create(
+                {
+                    "name": f"Bogus tracker: {_name}",
+                    "tracker_type": tracker_type,
+                    "base_url": "https://bogus.example.com",
+                }
+            )
+
+        self.assertFalse(
+            BugSystem.objects.filter(name=f"Bogus tracker: {_name}").exists()
+        )
 
 
 class TestBugTrackerFilter(APIPermissionsTestCase):

--- a/tcms/testcases/admin.py
+++ b/tcms/testcases/admin.py
@@ -109,7 +109,7 @@ class IssueTrackerTypeField(forms.ChoiceField):
     widget = IssueTrackerTypeSelectWidget
 
     def valid_value(self, value):
-        return True
+        return value in settings.EXTERNAL_BUG_TRACKERS
 
 
 class BugSystemAdminForm(forms.ModelForm):

--- a/tcms/testcases/tests/test_admin.py
+++ b/tcms/testcases/tests/test_admin.py
@@ -1,6 +1,8 @@
 from http import HTTPStatus
 
+from django.test import override_settings
 from django.urls import reverse
+from parameterized import parameterized
 
 from tcms.testcases.models import BugSystem
 from tcms.tests import LoggedInTestCase
@@ -28,6 +30,7 @@ class TestTestCaseAdmin(LoggedInTestCase):
         )
 
 
+@override_settings(LANGUAGE_CODE="en")
 class TestBugSystemAdmin(LoggedInTestCase):
     @classmethod
     def setUpTestData(cls):
@@ -58,3 +61,61 @@ class TestBugSystemAdmin(LoggedInTestCase):
         self.assertEqual("https://bugzilla.example.org", self.bug_system.base_url)
         # will always overwrite this field
         self.assertEqual("", self.bug_system.api_password)
+
+    @parameterized.expand(
+        [
+            ("base_class", "tcms.issuetracker.base.IssueTrackerType"),
+            ("raises_in_init", "tcms.issuetracker.tests.raise.Bogus"),
+            ("random_dotted_path", "random.dotted.string"),
+            ("not_a_dotted_path", "random string"),
+        ]
+    )
+    def test_add_view_with_invalid_tracker_type_will_fail(self, _name, tracker_type):
+        response = self.client.post(
+            reverse("admin:testcases_bugsystem_add"),
+            {
+                "name": f"Bogus tracker: {_name}",
+                "tracker_type": tracker_type,
+                "base_url": "https://bogus.example.com",
+            },
+            follow=True,
+        )
+
+        self.assertContains(response, "Please correct the error below.")
+        self.assertContains(
+            response,
+            f"Select a valid choice. {tracker_type} is not one of the available choices.",
+        )
+        self.assertFalse(
+            BugSystem.objects.filter(name=f"Bogus tracker: {_name}").exists()
+        )
+
+    @parameterized.expand(
+        [
+            ("base_class", "tcms.issuetracker.base.IssueTrackerType"),
+            ("raises_in_init", "tcms.issuetracker.tests.raise.Bogus"),
+            ("random_dotted_path", "random.dotted.string"),
+            ("not_a_dotted_path", "random string"),
+        ]
+    )
+    def test_change_view_with_invalid_tracker_type_will_fail(self, _name, tracker_type):
+        response = self.client.post(
+            reverse("admin:testcases_bugsystem_change", args=[self.bug_system.pk]),
+            {
+                "name": self.bug_system.name,
+                "tracker_type": tracker_type,
+                "base_url": self.bug_system.base_url,
+            },
+            follow=True,
+        )
+
+        self.assertContains(response, "Please correct the error below.")
+        self.assertContains(
+            response,
+            f"Select a valid choice. {tracker_type} is not one of the available choices.",
+        )
+
+        self.bug_system.refresh_from_db()
+        self.assertEqual(
+            "tcms.issuetracker.types.Bugzilla", self.bug_system.tracker_type
+        )


### PR DESCRIPTION
## Summary

Adds parametrized tests exercising invalid `tracker_type` field values against:

1. **Admin add view** (`admin:testcases_bugsystem_add`) — POST a new BugSystem record, expect an error and no object in the DB
2. **Admin change view** (`admin:testcases_bugsystem_change`) — POST an edit to an existing BugSystem record, expect an error and unchanged `tracker_type` in the DB
3. **`BugTracker.create()` RPC API method** — expect an `XmlRPCFault` mentioning `tracker_type` and no object in the DB

Parametrized values:

- `tcms.issuetracker.base.IssueTrackerType` — the base class, should not be accepted as a valid integration
- `tcms.issuetracker.tests.raise.Bogus` — a helper class (new file `tcms/issuetracker/tests/raise.py`) which raises `RuntimeError` in its `__init__`
- `random string` — not a dotted Python path at all

## ⚠️ All of these tests are EXPECTED TO FAIL at first!

`IssueTrackerTypeField.valid_value()` in `tcms/testcases/admin.py` always returns `True` and no other validation is performed on the `tracker_type` field, so invalid values are currently accepted and saved to the database. These tests define the desired behavior; the validation fix will follow in a separate commit/PR.