### PR TITLE
Display TestExecution attachments in Test Run execution rows

### DIFF
--- a/tcms/testruns/static/testruns/js/get.js
+++ b/tcms/testruns/static/testruns/js/get.js
@@ -544,23 +544,26 @@ function getExpandArea (testExecution) {
         bindDeleteLinkButton()
     })
 
-    jsonRPC('TestExecution.list_attachments', [testExecution.id], attachments => {
-        const ul = container.find('.test-case-attachments')
+    jsonRPC('TestCase.list_attachments', [testExecution.case], testCaseAttachments => {
+        jsonRPC('TestExecution.list_attachments', [testExecution.id], testExecutionAttachments => {
+            const attachments = testCaseAttachments.concat(testExecutionAttachments)
+            const ul = container.find('.test-case-attachments')
 
-        if (!attachments.length) {
-            ul.find('.hidden').removeClass('hidden')
-            return
-        }
+            if (!attachments.length) {
+                ul.find('.hidden').removeClass('hidden')
+                return
+            }
 
-        const liTemplate = $('#attachments-list-item')[0].content
+            const liTemplate = $('#attachments-list-item')[0].content
 
-        attachments.forEach(attachment => {
-            const li = liTemplate.cloneNode(true)
-            const attachmentLink = $(li).find('a')[0]
+            attachments.forEach(attachment => {
+                const li = liTemplate.cloneNode(true)
+                const attachmentLink = $(li).find('a')[0]
 
-            attachmentLink.href = attachment.url
-            attachmentLink.innerText = attachment.url.split('/').slice(-1)[0]
-            ul.append(li)
+                attachmentLink.href = attachment.url
+                attachmentLink.innerText = attachment.url.split('/').slice(-1)[0]
+                ul.append(li)
+            })
         })
     })
 

--- a/tcms/testruns/static/testruns/js/get.js
+++ b/tcms/testruns/static/testruns/js/get.js
@@ -544,7 +544,7 @@ function getExpandArea (testExecution) {
         bindDeleteLinkButton()
     })
 
-    jsonRPC('TestCase.list_attachments', [testExecution.case], attachments => {
+    jsonRPC('TestExecution.list_attachments', [testExecution.id], attachments => {
         const ul = container.find('.test-case-attachments')
 
         if (!attachments.length) {


### PR DESCRIPTION
  ### Problem

  The expanded Test Execution row on a Test Run requests attachments from
  the associated Test Case:

  ```javascript
  TestCase.list_attachments(testExecution.case)

  Consequently, files uploaded with TestExecution.add_attachment() are
  stored correctly, but the execution row displays "No attachments".

  ### Change

  Request attachments from the concrete Test Execution:

  TestExecution.list_attachments(testExecution.id)

  ### Steps to reproduce

  1. Create a Test Run containing a Test Execution.
  2. Upload a file using TestExecution.add_attachment().
  3. Confirm that TestExecution.list_attachments() returns the file.
  4. Expand the execution on the Test Run page.

  ### Results

  Before this change, the page queries Test Case attachments and does not
  display the execution attachment.

  After this change, the attachment belonging to the selected Test
  Execution is displayed.

  Tested with Kiwi TCMS 16.4.